### PR TITLE
feat(core): add configurable CHUNK_LIMIT environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ EMBEDDING_MODEL=text-embedding-3-small
 # You can customize it according to the throughput of your embedding model. Generally, larger batch size means less indexing time.
 EMBEDDING_BATCH_SIZE=100
 
+# Maximum number of chunks to index before stopping (default: 450000)
+# Set a lower value to limit indexing for very large codebases. Minimum value is 1000.
+# CHUNK_LIMIT=450000
+
 # =============================================================================
 # OpenAI Configuration
 # =============================================================================

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -702,8 +702,9 @@ export class Context {
     ): Promise<{ processedFiles: number; totalChunks: number; status: 'completed' | 'limit_reached' }> {
         const isHybrid = this.getIsHybrid();
         const EMBEDDING_BATCH_SIZE = Math.max(1, parseInt(envManager.get('EMBEDDING_BATCH_SIZE') || '100', 10));
-        const CHUNK_LIMIT = 450000;
+        const CHUNK_LIMIT = Math.max(1000, parseInt(envManager.get('CHUNK_LIMIT') || '450000', 10));
         console.log(`[Context] 🔧 Using EMBEDDING_BATCH_SIZE: ${EMBEDDING_BATCH_SIZE}`);
+        console.log(`[Context] 🔧 Using CHUNK_LIMIT: ${CHUNK_LIMIT}`);
 
         let chunkBuffer: Array<{ chunk: CodeChunk; codebasePath: string }> = [];
         let processedFiles = 0;


### PR DESCRIPTION
## Summary
- Add CHUNK_LIMIT environment variable support for configurable chunk processing limits
- Default value remains 450000 to maintain backward compatibility
- Set minimum value of 1000 to prevent issues with very small limits
- Add configuration documentation to .env.example
- Add console logging to show configured CHUNK_LIMIT value at runtime

## Motivation
Currently, the CHUNK_LIMIT is hardcoded to 450000 in the processFileList method. This makes it impossible for users to customize the chunk limit for their specific use cases without modifying the source code. Large codebases may need lower limits, while smaller codebases or users with more processing power may want higher limits.

## Changes Made
1. **Modified packages/core/src/context.ts:**
   - Changed hardcoded CHUNK_LIMIT from 450000 to use envManager.get('CHUNK_LIMIT') || '450000'
   - Added Math.max(1000, ...) to enforce minimum value
   - Added console logging for the configured CHUNK_LIMIT value

2. **Updated .env.example:**
   - Added CHUNK_LIMIT configuration with documentation
   - Included usage notes and default value information

## Test Plan
- [x] Built the project successfully with pnpm build
- [x] Verified backward compatibility (default value 450000 maintained)
- [x] Confirmed minimum value enforcement (1000)
- [x] Added proper documentation in .env.example

## Breaking Changes
None - this is a backward compatible enhancement.

## Additional Notes
The change follows the same pattern used for EMBEDDING_BATCH_SIZE configuration in the same function, maintaining consistency with existing environment variable handling.