### PR TITLE
feat(core): add ZILLIZ_PROJECT_NAME environment variable for configurable project name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,9 @@ MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint
 # https://github.com/zilliztech/claude-context/blob/master/assets/signup_and_get_apikey.png
 MILVUS_TOKEN=your-zilliz-cloud-api-key
 
+# Zilliz Cloud project name to use when auto-resolving address from token (optional, defaults to 'Default Project')
+# ZILLIZ_PROJECT_NAME=Default Project
+
 
 # =============================================================================
 # Code Splitter Configuration

--- a/README.md
+++ b/README.md
@@ -75,6 +75,29 @@ See the [Claude Code MCP documentation](https://docs.anthropic.com/en/docs/claud
 ### Other MCP Client Configurations
 
 <details>
+<summary><strong>OpenAI Codex CLI</strong></summary>
+
+Codex CLI uses TOML configuration files:
+
+1. Create or edit the `~/.codex/config.toml` file.
+
+2. Add the following configuration:
+
+```toml
+# IMPORTANT: the top-level key is `mcp_servers` rather than `mcpServers`.
+[mcp_servers.claude-context]
+command = "npx"
+args = ["@zilliz/claude-context-mcp@latest"]
+env = { "OPENAI_API_KEY" = "your-openai-api-key", "MILVUS_TOKEN" = "your-zilliz-cloud-api-key" }
+# Optional: override the default 10s startup timeout
+startup_timeout_ms = 20000
+```
+
+3. Save the file and restart Codex CLI to apply the changes.
+
+</details>
+
+<details>
 <summary><strong>Gemini CLI</strong></summary>
 
 Gemini CLI requires manual configuration through a JSON file:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Use the command line interface to add the Claude Context MCP server:
 ```bash
 claude mcp add claude-context \
   -e OPENAI_API_KEY=sk-your-openai-api-key \
+  -e MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint \
   -e MILVUS_TOKEN=your-zilliz-cloud-api-key \
   -- npx @zilliz/claude-context-mcp@latest
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/zilliz_universe.svg?style=social&label=Follow%20%40Zilliz)](https://twitter.com/zilliz_universe)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-AI%20Docs-purple.svg?logo=gitbook&logoColor=white)](https://deepwiki.com/zilliztech/claude-context)
 <a href="https://discord.gg/mKc3R95yE5"><img height="20" src="https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white" alt="discord" /></a>
+<a href="https://trendshift.io/repositories/15064"><img src="https://trendshift.io/api/badge/repositories/15064" alt="zilliztech/claude-context | Trendshift" width="250" height="55" /></a>
 </div>
 
 **Claude Context** is an MCP plugin that adds semantic code search to Claude Code and other AI coding agents, giving them deep context from your entire codebase.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![](assets/claude-context.png)
 
+> 🆕 **Looking for persistent memory for Claude Code?** Check out [memsearch Claude Code plugin](https://github.com/zilliztech/memsearch/tree/main/ccplugin) — a markdown-first memory system that gives your AI agent long-term memory across sessions.
+
 ### Your entire codebase as Claude's context
 
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](assets/claude-context.png)
 
-> 🆕 **Looking for persistent memory for Claude Code?** Check out [memsearch Claude Code plugin](https://github.com/zilliztech/memsearch/tree/main/ccplugin) — a markdown-first memory system that gives your AI agent long-term memory across sessions.
+> 🆕 **Looking for persistent memory for Claude Code?** Check out [memsearch Claude Code plugin](https://github.com/zilliztech/memsearch/tree/main/plugins/claude-code) — a markdown-first memory system that gives your AI agent long-term memory across sessions.
 
 ### Your entire codebase as Claude's context
 
@@ -152,11 +152,9 @@ Create or edit the `~/.qwen/settings.json` file and add the following configurat
 <details>
 <summary><strong>Cursor</strong></summary>
 
-<a href="https://cursor.com/install-mcp?name=claude-context&config=JTdCJTIyY29tbWFuZCUyMiUzQSUyMm5weCUyMC15JTIwJTQwemlsbGl6JTJGY29kZS1jb250ZXh0LW1jcCU0MGxhdGVzdCUyMiUyQyUyMmVudiUyMiUzQSU3QiUyMk9QRU5BSV9BUElfS0VZJTIyJTNBJTIyeW91ci1vcGVuYWktYXBpLWtleSUyMiUyQyUyMk1JTFZVU19BRERSRVNTJTIyJTNBJTIybG9jYWxob3N0JTNBMTk1MzAlMjIlN0QlN0Q%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add claude-context MCP server to Cursor" height="32" /></a>
-
 Go to: `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`
 
-Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) for more info.
+Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more info.
 
 ```json
 {
@@ -545,7 +543,7 @@ Claude Context is a monorepo containing three main packages:
 
 ### Supported Technologies
 
-- **Embedding Providers**: [OpenAI](https://openai.com), [VoyageAI](https://voyageai.com), [Ollama](https://ollama.ai), [Gemini](https://gemini.google.com)
+- **Embedding Providers**: [OpenAI](https://openai.com), [VoyageAI](https://voyageai.com), [Ollama](https://ollama.com), [Gemini](https://gemini.google.com)
 - **Vector Databases**: [Milvus](https://milvus.io) or [Zilliz Cloud](https://zilliz.com/cloud)(fully managed vector database as a service)
 - **Code Splitters**: AST-based splitter (with automatic fallback), LangChain character-based splitter
 - **Languages**: TypeScript, JavaScript, Python, Java, C++, C#, Go, Rust, PHP, Ruby, Swift, Kotlin, Scala, Markdown

--- a/docs/dive-deep/asynchronous-indexing-workflow.md
+++ b/docs/dive-deep/asynchronous-indexing-workflow.md
@@ -35,6 +35,39 @@ The flow diagram above shows the complete indexing workflow, illustrating how th
 - **`indexfailed`** - ❌ Error occurred, can retry
 - **`not_found`** - ❌ Not indexed yet
 
+## How Progress Is Calculated
+
+`get_indexing_status` reports a **coarse, phase-based percentage**, not an exact fraction of files completed.
+
+- **0%** - Preparing the target collection and validating indexing prerequisites
+- **~5%** - Scanning the codebase and building the file list
+- **10% → 100%** - Processing files, chunking code, generating embeddings, and writing batches to the vector database
+- **100%** - Indexing finished successfully
+
+This means it is normal for indexing to jump to around `10%` quickly on a large codebase. It reflects a transition from setup phases into file processing, not that exactly one tenth of all files are already indexed.
+
+Progress is also persisted periodically to the local MCP snapshot file at `~/.context/mcp-codebase-snapshot.json`, so very fast phases may appear as jumps rather than smooth increments.
+
+## When File and Chunk Counts Appear
+
+`get_indexing_status` shows file and chunk totals after a run has completed and the final statistics have been written to the local snapshot.
+
+During active indexing, the MCP server tracks progress percentage, but it does **not** stream live file/chunk totals through `get_indexing_status`.
+
+If you see an indexed entry with `0 files, 0 chunks`, that usually means the local snapshot metadata is stale or was created by an older / incomplete bookkeeping path. It is not a live count fetched from the vector database at status-check time.
+
+To refresh those stored totals, clear and re-index the **same absolute path**.
+
+## How Codebases Are Identified
+
+Claude Context tracks codebases by their resolved **absolute path**.
+
+- The MCP tools resolve relative paths to absolute paths before indexing, searching, clearing, or checking status.
+- Collection identity is derived from the normalized absolute path.
+- If you index the same repository through different absolute paths (for example, a symlink, a different clone, or a mounted path), Claude Context treats them as separate codebases.
+
+For the most predictable behavior, always use the same absolute path for `index_codebase`, `search_code`, `clear_index`, and `get_indexing_status`.
+
 
 ## Key Benefits
 

--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -47,6 +47,7 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 |----------|-------------|---------|
 | `MILVUS_TOKEN` | Milvus authentication token. Get [Zilliz Personal API Key](https://github.com/zilliztech/claude-context/blob/master/assets/signup_and_get_apikey.png) | Recommended |
 | `MILVUS_ADDRESS` | Milvus server address. Optional when using Zilliz Personal API Key | Auto-resolved from token |
+| `ZILLIZ_PROJECT_NAME` | Zilliz Cloud project name to use when auto-resolving address from token | `Default Project` |
 
 ### Ollama (Optional)
 | Variable | Description | Default |

--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -47,6 +47,7 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 |----------|-------------|---------|
 | `MILVUS_TOKEN` | Milvus authentication token. Get [Zilliz Personal API Key](https://github.com/zilliztech/claude-context/blob/master/assets/signup_and_get_apikey.png) | Recommended |
 | `MILVUS_ADDRESS` | Milvus server address. Optional when using Zilliz Personal API Key | Auto-resolved from token |
+| `MILVUS_COLLECTION_LIMIT_CHECK_TIMEOUT_MS` | Timeout for gRPC pre-check in `checkCollectionLimit()` before indexing begins | `15000` |
 
 ### Ollama (Optional)
 | Variable | Description | Default |

--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -77,6 +77,7 @@ cat > ~/.context/.env << 'EOF'
 EMBEDDING_PROVIDER=OpenAI
 OPENAI_API_KEY=sk-your-openai-api-key
 EMBEDDING_MODEL=text-embedding-3-small
+MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint
 MILVUS_TOKEN=your-zilliz-cloud-api-key
 EOF
 ```
@@ -87,7 +88,11 @@ See the [Example File](../../.env.example) for more details.
 
 **Claude Code:**
 ```bash
-claude mcp add claude-context -- npx @zilliz/claude-context-mcp@latest
+claude mcp add claude-context \
+  -e OPENAI_API_KEY=sk-your-openai-api-key \
+  -e MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint \
+  -e MILVUS_TOKEN=your-zilliz-cloud-api-key \
+  -- npx @zilliz/claude-context-mcp@latest
 ```
 
 **Cursor/Windsurf/Others:**

--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -64,6 +64,9 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 | `SPLITTER_TYPE` | Code splitter type: `ast`, `langchain` | `ast` |
 | `CUSTOM_EXTENSIONS` | Additional file extensions to include (comma-separated, e.g., `.vue,.svelte,.astro`) | None |
 | `CUSTOM_IGNORE_PATTERNS` | Additional ignore patterns (comma-separated, e.g., `temp/**,*.backup,private/**`) | None |
+| `CODE_CHUNKS_COLLECTION_NAME_OVERRIDE` | Optional custom prefix for collection names. Produces `code_chunks_<suffix>_<pathHash>` or `hybrid_code_chunks_<suffix>_<pathHash>` after sanitization. The path hash stays appended so collections remain unique per codebase even when the override is set | None |
+
+When `CODE_CHUNKS_COLLECTION_NAME_OVERRIDE` is set, Claude Context writes to an override-named collection instead of the default `code_chunks_<pathHash>`. The per-codebase `<pathHash>` suffix is preserved to keep multiple codebases distinct under the same override. If you later unset the variable, Claude Context returns to the plain hash-based naming for that path.
 
 ## 🚀 Quick Setup
 

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -23,7 +23,7 @@ Before setting up Claude Context, ensure you have the following requirements met
 - **Quota**: Check current quotas and limits
 
 #### Option 4: Ollama (Local)
-- **Installation**: Download from [ollama.ai](https://ollama.ai/)
+- **Installation**: Download from [ollama.com](https://ollama.com/)
 - **Models**: Pull embedding models like `nomic-embed-text`
 - **Hardware**: Sufficient RAM for model loading (varies by model)
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -45,6 +45,29 @@ Replace the API keys with your actual keys.
 ## Alternative Quick Setups
 
 <details>
+<summary><strong>OpenAI Codex CLI</strong></summary>
+
+Codex CLI uses TOML configuration files:
+
+1. Create or edit the `~/.codex/config.toml` file.
+
+2. Add the following configuration:
+
+```toml
+# IMPORTANT: the top-level key is `mcp_servers` rather than `mcpServers`.
+[mcp_servers.claude-context]
+command = "npx"
+args = ["@zilliz/claude-context-mcp@latest"]
+env = { "OPENAI_API_KEY" = "your-openai-api-key", "MILVUS_TOKEN" = "your-zilliz-cloud-api-key" }
+# Optional: override the default 10s startup timeout
+startup_timeout_ms = 20000
+```
+
+3. Save the file and restart Codex CLI to apply the changes.
+
+</details>
+
+<details>
 <summary><strong>Gemini CLI</strong></summary>
 
 Gemini CLI requires manual configuration through a JSON file:

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -122,7 +122,7 @@ Create or edit the `~/.qwen/settings.json` file and add the following configurat
 
 Go to: `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`
 
-Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) for more info.
+Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more info.
 
 **OpenAI Configuration (Default):**
 ```json

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -19,6 +19,7 @@ Run this single command to add Claude Context to Claude Code:
 ```bash
 claude mcp add claude-context \
   -e OPENAI_API_KEY=sk-your-openai-api-key \
+  -e MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint \
   -e MILVUS_TOKEN=your-zilliz-cloud-api-key \
   -- npx @zilliz/claude-context-mcp@latest
 ```

--- a/docs/troubleshooting/faq.md
+++ b/docs/troubleshooting/faq.md
@@ -43,7 +43,37 @@ You can seamlessly use queries like `index this codebase` or `search the main fu
 - **Background Code Synchronization**: Continuously monitors for changes and automatically re-indexes modified parts
 - **Context-Aware Operations**: All indexing and search operations are scoped to the current project context
 
+**Important path detail:** Claude Context keys each indexed codebase by its absolute path. If you index the same repository through different paths (for example, a symlinked path, a second clone, or a mounted path), those are treated as separate indexed codebases.
+
 This makes it effortless to work across multiple projects while maintaining isolated, up-to-date indexes for each codebase.
+
+## Q: Why does `get_indexing_status` jump quickly to 10% or feel coarse?
+
+**A:** The percentage is a **phase-based progress indicator**, not a live fraction of indexed files.
+
+In practice, Claude Context moves through broad stages:
+
+- collection preparation
+- file scanning
+- file processing, chunking, embedding, and insertion
+
+The status output can therefore jump quickly to around `10%` once setup is complete, even for very large repositories. That is expected behavior.
+
+For the full background workflow, see [Asynchronous Indexing Workflow](../dive-deep/asynchronous-indexing-workflow.md).
+
+## Q: Why does `get_indexing_status` show `0 files, 0 chunks` for a completed codebase?
+
+**A:** `get_indexing_status` reads the MCP snapshot metadata, not a live aggregate directly from the vector database.
+
+If a completed entry shows `0 files, 0 chunks`, the most common explanation is that the local snapshot metadata is stale or was created before final statistics were refreshed.
+
+What to do:
+
+1. Make sure you are checking the **same absolute path** that you originally indexed.
+2. If the entry still shows zero counts, run `clear_index` for that path.
+3. Re-run `index_codebase` for that exact absolute path.
+
+This refreshes the stored file/chunk totals used by `get_indexing_status`.
 
 ## Q: How does Claude Context compare to other coding tools like Serena, Context7, or DeepWiki?
 

--- a/docs/troubleshooting/troubleshooting-guide.md
+++ b/docs/troubleshooting/troubleshooting-guide.md
@@ -33,7 +33,7 @@ If Step 1 doesn't reveal the issue, collect detailed debug information:
 - If you use Cursor-like GUI IDEs, find the MCP logs in the Output panel, e.g. Cursor:
   1. Open the Output panel in Cursor (⌘⇧U)
   2. Select "MCP Logs" from the dropdown
-  3. See [Cursor MCP FAQ](https://docs.cursor.com/en/context/mcp#faq) for details
+  3. See [Cursor MCP FAQ](https://cursor.com/docs/context/mcp) for details
 
 **Check your MCP Client Setting:**
 If logs don't solve the problem, note:
@@ -57,7 +57,7 @@ If you locate the problem at [Step 1](#step-1-check-indexing-status-first) or [S
   /mcp refresh
   ```
   For more details, see [this PR](https://github.com/google-gemini/gemini-cli/pull/4566).
-- **Cursor and other GUI IDEs**: Look for a toggle icon or restart button to restart the MCP connection. e.g. [Cursor MCP FAQ](https://docs.cursor.com/en/context/mcp#faq)
+- **Cursor and other GUI IDEs**: Look for a toggle icon or restart button to restart the MCP connection. e.g. [Cursor MCP FAQ](https://cursor.com/docs/context/mcp)
 
 After reconnecting, test if your issue is resolved and the system works normally.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "claude-context",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "A powerful code indexing tool with multi-platform support",
     "private": true,
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "claude-context",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "A powerful code indexing tool with multi-platform support",
     "private": true,
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "claude-context",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "A powerful code indexing tool with multi-platform support",
     "private": true,
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "claude-context",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "A powerful code indexing tool with multi-platform support",
     "private": true,
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "claude-context",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "A powerful code indexing tool with multi-platform support",
     "private": true,
     "scripts": {

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-chrome-extension",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Claude Context Chrome extension for web-based code indexing",
     "private": true,
     "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-core",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Core indexing engine for Claude Context",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-core",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Core indexing engine for Claude Context",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-core",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Core indexing engine for Claude Context",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-core",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "Core indexing engine for Claude Context",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-core",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "Core indexing engine for Claude Context",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -648,9 +648,9 @@ export class Context {
         const dirName = path.basename(codebasePath);
 
         if (isHybrid === true) {
-            await this.vectorDatabase.createHybridCollection(collectionName, dimension, `Hybrid Index for ${dirName}`);
+            await this.vectorDatabase.createHybridCollection(collectionName, dimension, `codebasePath:${codebasePath}`);
         } else {
-            await this.vectorDatabase.createCollection(collectionName, dimension, `Index for ${dirName}`);
+            await this.vectorDatabase.createCollection(collectionName, dimension, `codebasePath:${codebasePath}`);
         }
 
         console.log(`[Context] ✅ Collection ${collectionName} created successfully (dimension: ${dimension})`);

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -94,14 +94,19 @@ export interface ContextConfig {
     ignorePatterns?: string[];
     customExtensions?: string[]; // New: custom extensions from MCP
     customIgnorePatterns?: string[]; // New: custom ignore patterns from MCP
+    collectionNameOverride?: string; // Optional: custom collection name suffix
 }
 
 export class Context {
+    private static readonly MAX_COLLECTION_NAME_LENGTH = 255;
+
     private embedding: Embedding;
     private vectorDatabase: VectorDatabase;
     private codeSplitter: Splitter;
     private supportedExtensions: string[];
     private ignorePatterns: string[];
+    private collectionNameOverride?: string;
+    private warnedOverrideSanitization = new Set<string>();
     private synchronizers = new Map<string, FileSynchronizer>();
 
     constructor(config: ContextConfig = {}) {
@@ -144,6 +149,7 @@ export class Context {
         ];
         // Remove duplicates
         this.ignorePatterns = [...new Set(allIgnorePatterns)];
+        this.collectionNameOverride = config.collectionNameOverride;
 
         console.log(`[Context] 🔧 Initialized with ${this.supportedExtensions.length} supported extensions and ${this.ignorePatterns.length} ignore patterns`);
         if (envCustomExtensions.length > 0) {
@@ -233,10 +239,58 @@ export class Context {
      */
     public getCollectionName(codebasePath: string): string {
         const isHybrid = this.getIsHybrid();
-        const normalizedPath = path.resolve(codebasePath);
-        const hash = crypto.createHash('md5').update(normalizedPath).digest('hex');
         const prefix = isHybrid === true ? 'hybrid_code_chunks' : 'code_chunks';
-        return `${prefix}_${hash.substring(0, 8)}`;
+        const normalizedPath = path.resolve(codebasePath);
+        const pathHash = crypto.createHash('md5').update(normalizedPath).digest('hex').substring(0, 8);
+
+        // Overrides always keep the per-codebase `_<pathHash>` suffix so that multiple
+        // codebases indexed by the same MCP server can't collapse into one collection.
+        const configOverride = this.getValidOverrideValue(this.collectionNameOverride);
+        if (configOverride) {
+            const suffix = this.sanitizeCollectionNameSuffix(configOverride, prefix, pathHash, 'Context config');
+            return `${prefix}_${suffix}`;
+        }
+
+        const envOverride = this.getValidOverrideValue(envManager.get('CODE_CHUNKS_COLLECTION_NAME_OVERRIDE'));
+        if (envOverride) {
+            const suffix = this.sanitizeCollectionNameSuffix(envOverride, prefix, pathHash, 'CODE_CHUNKS_COLLECTION_NAME_OVERRIDE');
+            return `${prefix}_${suffix}`;
+        }
+
+        return `${prefix}_${pathHash}`;
+    }
+
+    private getValidOverrideValue(value?: string): string | undefined {
+        if (!value) {
+            return undefined;
+        }
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+    }
+
+    private sanitizeCollectionNameSuffix(value: string, prefix: string, pathHash: string, source: string): string {
+        const hashSuffix = `_${pathHash}`;
+        // Leave room for both the prefix and the trailing `_<pathHash>` disambiguator.
+        const maxReadableLength = Context.MAX_COLLECTION_NAME_LENGTH - `${prefix}_`.length - hashSuffix.length;
+        const normalized = value.trim();
+        let sanitized = normalized.replace(/[^A-Za-z0-9_]/g, '_');
+        sanitized = sanitized.slice(0, Math.max(0, maxReadableLength));
+
+        if (sanitized.length === 0) {
+            sanitized = 'custom';
+        }
+
+        const full = `${sanitized}${hashSuffix}`;
+
+        if (sanitized !== normalized) {
+            const warningKey = `${source}:${normalized}:${sanitized}`;
+            if (!this.warnedOverrideSanitization.has(warningKey)) {
+                console.warn(`[Context] ⚠️ Sanitized collection name override from "${normalized}" to "${sanitized}" (${source}); final suffix "${full}"`);
+                this.warnedOverrideSanitization.add(warningKey);
+            }
+        }
+
+        return full;
     }
 
     /**

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -324,7 +324,7 @@ export class Context {
             await this.loadIgnorePatterns(codebasePath);
 
             // To be safe, let's initialize if it's not there.
-            const newSynchronizer = new FileSynchronizer(codebasePath, this.ignorePatterns);
+            const newSynchronizer = new FileSynchronizer(codebasePath, this.ignorePatterns, this.supportedExtensions);
             await newSynchronizer.initialize();
             this.synchronizers.set(collectionName, newSynchronizer);
         }

--- a/packages/core/src/embedding/voyageai-embedding.ts
+++ b/packages/core/src/embedding/voyageai-embedding.ts
@@ -29,9 +29,10 @@ export class VoyageAIEmbedding extends Embedding {
         const modelInfo = supportedModels[model];
 
         if (modelInfo) {
-            // If dimension is a string (indicating variable dimension), use default value 1024
             if (typeof modelInfo.dimension === 'string') {
-                this.dimension = 1024; // Default dimension
+                // Parse default dimension from string like "1024 (default), 256, 512, 2048"
+                const match = modelInfo.dimension.match(/^(\d+)/);
+                this.dimension = match ? parseInt(match[1], 10) : 1024;
             } else {
                 this.dimension = modelInfo.dimension;
             }

--- a/packages/core/src/embedding/voyageai-embedding.ts
+++ b/packages/core/src/embedding/voyageai-embedding.ts
@@ -45,23 +45,6 @@ export class VoyageAIEmbedding extends Embedding {
         }
     }
 
-    private updateDimensionForModel(model: string): void {
-        const supportedModels = VoyageAIEmbedding.getSupportedModels();
-        const modelInfo = supportedModels[model];
-
-        if (modelInfo) {
-            // If dimension is a string (indicating variable dimension), use default value 1024
-            if (typeof modelInfo.dimension === 'string') {
-                this.dimension = 1024; // Default dimension
-            } else {
-                this.dimension = modelInfo.dimension;
-            }
-        } else {
-            // Use default dimension for unknown models
-            this.dimension = 1024;
-        }
-    }
-
     async detectDimension(): Promise<number> {
         // VoyageAI doesn't need dynamic detection, return configured dimension
         return this.dimension;
@@ -149,7 +132,28 @@ export class VoyageAIEmbedding extends Embedding {
      */
     static getSupportedModels(): Record<string, { dimension: number | string; contextLength: number; description: string }> {
         return {
-            // Latest recommended models
+            // Voyage 4 series (January 2026)
+            'voyage-4-large': {
+                dimension: '1024 (default), 256, 512, 2048',
+                contextLength: 32000,
+                description: 'Best general-purpose and multilingual retrieval quality (latest)'
+            },
+            'voyage-4': {
+                dimension: '1024 (default), 256, 512, 2048',
+                contextLength: 32000,
+                description: 'Optimized for general-purpose and multilingual retrieval quality'
+            },
+            'voyage-4-lite': {
+                dimension: '1024 (default), 256, 512, 2048',
+                contextLength: 32000,
+                description: 'Optimized for latency and cost'
+            },
+            'voyage-4-nano': {
+                dimension: '512 (default), 128, 256',
+                contextLength: 32000,
+                description: 'Open-weight model, smallest and fastest'
+            },
+            // Voyage 3 series
             'voyage-3-large': {
                 dimension: '1024 (default), 256, 512, 2048',
                 contextLength: 32000,

--- a/packages/core/src/embedding/voyageai-embedding.ts
+++ b/packages/core/src/embedding/voyageai-embedding.ts
@@ -149,7 +149,7 @@ export class VoyageAIEmbedding extends Embedding {
                 description: 'Optimized for latency and cost'
             },
             'voyage-4-nano': {
-                dimension: '512 (default), 128, 256',
+                dimension: '1024 (default), 256, 512, 2048',
                 contextLength: 32000,
                 description: 'Open-weight model, smallest and fastest'
             },

--- a/packages/core/src/sync/merkle.ts
+++ b/packages/core/src/sync/merkle.ts
@@ -78,22 +78,13 @@ export class MerkleDAG {
         return dag;
     }
 
-    public static compare(dag1: MerkleDAG, dag2: MerkleDAG): { added: string[], removed: string[], modified: string[] } {
-        const nodes1 = new Map(Array.from(dag1.getAllNodes()).map(n => [n.id, n]));
-        const nodes2 = new Map(Array.from(dag2.getAllNodes()).map(n => [n.id, n]));
+    public static compare(dag1: MerkleDAG, dag2: MerkleDAG): { added: string[], removed: string[] } {
+        const nodes1 = new Set(Array.from(dag1.getAllNodes()).map(n => n.id));
+        const nodes2 = new Set(Array.from(dag2.getAllNodes()).map(n => n.id));
 
-        const added = Array.from(nodes2.keys()).filter(k => !nodes1.has(k));
-        const removed = Array.from(nodes1.keys()).filter(k => !nodes2.has(k));
-        
-        // For modified, we'll check if the data has changed for nodes that exist in both
-        const modified: string[] = [];
-        for (const [id, node1] of Array.from(nodes1.entries())) {
-            const node2 = nodes2.get(id);
-            if (node2 && node1.data !== node2.data) {
-                modified.push(id);
-            }
-        }
+        const added = Array.from(nodes2).filter(k => !nodes1.has(k));
+        const removed = Array.from(nodes1).filter(k => !nodes2.has(k));
 
-        return { added, removed, modified };
+        return { added, removed };
     }
 } 

--- a/packages/core/src/sync/synchronizer.ts
+++ b/packages/core/src/sync/synchronizer.ts
@@ -236,8 +236,8 @@ export class FileSynchronizer {
         // Compare the DAGs
         const changes = MerkleDAG.compare(this.merkleDAG, newMerkleDAG);
 
-        // If there are any changes in the DAG, we should also do a file-level comparison
-        if (changes.added.length > 0 || changes.removed.length > 0 || changes.modified.length > 0) {
+        // If there are any changes in the DAG, do a file-level comparison
+        if (changes.added.length > 0 || changes.removed.length > 0) {
             console.log('[Synchronizer] Merkle DAG has changed. Comparing file states...');
             const fileChanges = this.compareStates(this.fileHashes, newFileHashes);
 

--- a/packages/core/src/sync/synchronizer.ts
+++ b/packages/core/src/sync/synchronizer.ts
@@ -10,13 +10,15 @@ export class FileSynchronizer {
     private rootDir: string;
     private snapshotPath: string;
     private ignorePatterns: string[];
+    private supportedExtensions: string[];
 
-    constructor(rootDir: string, ignorePatterns: string[] = []) {
+    constructor(rootDir: string, ignorePatterns: string[] = [], supportedExtensions: string[] = []) {
         this.rootDir = rootDir;
         this.snapshotPath = this.getSnapshotPath(rootDir);
         this.fileHashes = new Map();
         this.merkleDAG = new MerkleDAG();
         this.ignorePatterns = ignorePatterns;
+        this.supportedExtensions = supportedExtensions;
     }
 
     private getSnapshotPath(codebasePath: string): string {
@@ -81,6 +83,10 @@ export class FileSynchronizer {
             } else if (stat.isFile()) {
                 // Verify it's really a file and not ignored
                 if (!this.shouldIgnore(relativePath, false)) {
+                    const ext = path.extname(entry.name);
+                    if (this.supportedExtensions.length > 0 && !this.supportedExtensions.includes(ext)) {
+                        continue;
+                    }
                     try {
                         const hash = await this.hashFile(fullPath);
                         fileHashes.set(relativePath, hash);

--- a/packages/core/src/vectordb/milvus-restful-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-restful-vectordb.ts
@@ -191,11 +191,10 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
         try {
             const restfulConfig = this.config as MilvusRestfulConfig;
             // Build collection schema based on the original milvus-vectordb.ts implementation
-            // Note: REST API doesn't support description parameter in collection creation
-            // Unlike gRPC version, the description parameter is ignored in REST API
-            const collectionSchema = {
+            const collectionSchema: any = {
                 collectionName,
                 dbName: restfulConfig.database,
+                description: description || `Claude Context collection: ${collectionName}`,
                 schema: {
                     enableDynamicField: false,
                     fields: [
@@ -492,14 +491,22 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
 
         try {
             const restfulConfig = this.config as MilvusRestfulConfig;
-            const queryRequest = {
+            const queryRequest: Record<string, any> = {
                 collectionName,
                 dbName: restfulConfig.database,
-                filter,
                 outputFields,
-                limit: limit || 16384, // Use provided limit or default
                 offset: 0
             };
+            // Only include filter if it's a non-empty, non-whitespace string
+            if (filter && filter.trim() !== '') {
+                queryRequest.filter = filter;
+            }
+            // Add limit if provided, or default when no filter is specified
+            if (limit !== undefined) {
+                queryRequest.limit = limit;
+            } else if (!filter || filter.trim() === '') {
+                queryRequest.limit = 16384;
+            }
 
             const response = await this.makeRequest('/entities/query', 'POST', queryRequest);
 
@@ -519,9 +526,10 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
         try {
             const restfulConfig = this.config as MilvusRestfulConfig;
 
-            const collectionSchema = {
+            const collectionSchema: any = {
                 collectionName,
                 dbName: restfulConfig.database,
+                description: description || `Hybrid code context collection: ${collectionName}`,
                 schema: {
                     enableDynamicField: false,
                     functions: [
@@ -783,6 +791,23 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
 
         } catch (error) {
             console.error(`[MilvusRestfulDB] ❌ Failed to perform hybrid search on collection '${collectionName}':`, error);
+            throw error;
+        }
+    }
+
+    async getCollectionDescription(collectionName: string): Promise<string> {
+        await this.ensureInitialized();
+
+        try {
+            const restfulConfig = this.config as MilvusRestfulConfig;
+            const response = await this.makeRequest('/collections/describe', 'POST', {
+                collectionName,
+                dbName: restfulConfig.database
+            });
+
+            return response.data?.description || '';
+        } catch (error) {
+            console.error(`[MilvusRestfulDB] ❌ Failed to get description for collection '${collectionName}':`, error);
             throw error;
         }
     }

--- a/packages/core/src/vectordb/milvus-restful-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-restful-vectordb.ts
@@ -823,4 +823,48 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
         console.warn('[MilvusRestfulDB] ⚠️  checkCollectionLimit not implemented for REST API - returning true');
         return true;
     }
+
+    /**
+     * Get the number of entities (rows) in a collection.
+     * Returns -1 on any failure (collection missing, RPC error, malformed response).
+     * -1 means "unknown" — callers must NOT treat it as "empty".
+     *
+     * Uses count(*) via /entities/query rather than /collections/get_stats: stats
+     * are computed from sealed segments and lag recent inserts (returning 0 for
+     * a freshly-indexed but unflushed collection), while count(*) reads the real
+     * current state. A stale 0 would fool recovery into thinking the collection
+     * is truly empty and cause Issue #295-style false-negative "not indexed"
+     * errors even when data exists.
+     */
+    async getCollectionRowCount(collectionName: string): Promise<number> {
+        await this.ensureInitialized();
+        try {
+            const restfulConfig = this.config as MilvusRestfulConfig;
+
+            const hasResponse = await this.makeRequest('/collections/has', 'POST', {
+                collectionName,
+                dbName: restfulConfig.database
+            });
+            if (!hasResponse.data?.has) return -1;
+
+            // count(*) requires the collection to be loaded.
+            await this.ensureLoaded(collectionName);
+
+            const response = await this.makeRequest('/entities/query', 'POST', {
+                collectionName,
+                dbName: restfulConfig.database,
+                outputFields: ['count(*)'],
+            });
+
+            const row = response?.data?.[0];
+            if (!row) return -1;
+            const raw = row['count(*)'] ?? row['count'];
+            if (raw === undefined || raw === null) return -1;
+            const n = typeof raw === 'number' ? raw : parseInt(String(raw), 10);
+            return Number.isFinite(n) && n >= 0 ? n : -1;
+        } catch (error) {
+            console.error(`[MilvusRestfulDB] ❌ Error in count(*) query for '${collectionName}':`, error);
+            return -1;
+        }
+    }
 }

--- a/packages/core/src/vectordb/milvus-restful-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-restful-vectordb.ts
@@ -774,20 +774,29 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
             console.log(`[MilvusRestfulDB] ✅ Found ${results.length} results from hybrid search`);
 
             // Transform response to HybridSearchResult format
-            return results.map((result: any) => ({
-                document: {
-                    id: result.id,
-                    content: result.content,
-                    vector: [], // Vector not returned in search results
-                    sparse_vector: [], // Vector not returned in search results
-                    relativePath: result.relativePath,
-                    startLine: result.startLine,
-                    endLine: result.endLine,
-                    fileExtension: result.fileExtension,
-                    metadata: JSON.parse(result.metadata || '{}'),
-                },
-                score: result.score || result.distance || 0,
-            }));
+            return results.map((result: any) => {
+                let metadata = {};
+                try {
+                    metadata = JSON.parse(result.metadata || '{}');
+                } catch (error) {
+                    console.warn(`[MilvusRestfulDB] Failed to parse metadata for item ${result.id}:`, error);
+                }
+
+                return {
+                    document: {
+                        id: result.id,
+                        content: result.content,
+                        vector: [], // Vector not returned in search results
+                        sparse_vector: [], // Vector not returned in search results
+                        relativePath: result.relativePath,
+                        startLine: result.startLine,
+                        endLine: result.endLine,
+                        fileExtension: result.fileExtension,
+                        metadata,
+                    },
+                    score: result.score || result.distance || 0,
+                };
+            });
 
         } catch (error) {
             console.error(`[MilvusRestfulDB] ❌ Failed to perform hybrid search on collection '${collectionName}':`, error);

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -707,20 +707,29 @@ export class MilvusVectorDatabase implements VectorDatabase {
             console.log(`[MilvusDB] ✅ Found ${searchResult.results.length} results from hybrid search`);
 
             // Transform results to HybridSearchResult format
-            return searchResult.results.map((result: any) => ({
-                document: {
-                    id: result.id,
-                    content: result.content,
-                    vector: [],
-                    sparse_vector: [],
-                    relativePath: result.relativePath,
-                    startLine: result.startLine,
-                    endLine: result.endLine,
-                    fileExtension: result.fileExtension,
-                    metadata: JSON.parse(result.metadata || '{}'),
-                },
-                score: result.score,
-            }));
+            return searchResult.results.map((result: any) => {
+                let metadata = {};
+                try {
+                    metadata = JSON.parse(result.metadata || '{}');
+                } catch (error) {
+                    console.warn(`[MilvusDB] Failed to parse metadata for item ${result.id}:`, error);
+                }
+
+                return {
+                    document: {
+                        id: result.id,
+                        content: result.content,
+                        vector: [],
+                        sparse_vector: [],
+                        relativePath: result.relativePath,
+                        startLine: result.startLine,
+                        endLine: result.endLine,
+                        fileExtension: result.fileExtension,
+                        metadata,
+                    },
+                    score: result.score,
+                };
+            });
 
         } catch (error) {
             console.error(`[MilvusDB] ❌ Failed to perform hybrid search on collection '${collectionName}':`, error);

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -742,6 +742,8 @@ export class MilvusVectorDatabase implements VectorDatabase {
             throw new Error('MilvusClient is not initialized. Call ensureInitialized() first.');
         }
 
+        const parsedTimeoutMs = Number(process.env.MILVUS_COLLECTION_LIMIT_CHECK_TIMEOUT_MS);
+        const timeoutMs = Number.isFinite(parsedTimeoutMs) && parsedTimeoutMs > 0 ? parsedTimeoutMs : 15000;
         const collectionName = `dummy_collection_${Date.now()}`;
         const createCollectionParams = {
             collection_name: collectionName,
@@ -761,8 +763,39 @@ export class MilvusVectorDatabase implements VectorDatabase {
             ]
         };
 
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+        let timedOut = false;
         try {
-            await this.client.createCollection(createCollectionParams);
+            const createPromise = this.client.createCollection(createCollectionParams);
+            // Best-effort late cleanup ONLY if the timeout fires first. Gated by `timedOut`
+            // so we do not race the normal-path drop below on fast successes.
+            void createPromise
+                .then(async () => {
+                    if (!timedOut) return;
+                    try {
+                        if (!this.client) return;
+                        if (await this.client.hasCollection({ collection_name: collectionName })) {
+                            await this.client.dropCollection({
+                                collection_name: collectionName,
+                            });
+                        }
+                    } catch {
+                        // Best effort only: orphan cleanup is not user-visible.
+                    }
+                })
+                .catch(() => {
+                    // createCollection failed; nothing to clean up.
+                });
+
+            await Promise.race([
+                createPromise,
+                new Promise<never>((_, reject) => {
+                    timeoutHandle = setTimeout(() => {
+                        timedOut = true;
+                        reject(new Error(`checkCollectionLimit timeout after ${timeoutMs}ms`));
+                    }, timeoutMs);
+                }),
+            ]);
             // Immediately drop the collection after successful creation
             if (await this.client.hasCollection({ collection_name: collectionName })) {
                 await this.client.dropCollection({
@@ -777,8 +810,19 @@ export class MilvusVectorDatabase implements VectorDatabase {
                 // Return false for collection limit exceeded
                 return false;
             }
+            if (/deadline_exceeded|deadline exceeded|timeout/i.test(errorMessage)) {
+                console.warn(
+                    `[MilvusDB] checkCollectionLimit timed out after ${timeoutMs}ms; proceeding without limit pre-check. ` +
+                    'Set MILVUS_COLLECTION_LIMIT_CHECK_TIMEOUT_MS to increase timeout.'
+                );
+                return true;
+            }
             // Re-throw other errors as-is
             throw error;
+        } finally {
+            if (timeoutHandle) {
+                clearTimeout(timeoutHandle);
+            }
         }
     }
 

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -781,4 +781,49 @@ export class MilvusVectorDatabase implements VectorDatabase {
             throw error;
         }
     }
+
+    /**
+     * Get the number of entities (rows) in a collection.
+     * Returns -1 on any failure (collection missing, RPC error, malformed response).
+     * -1 means "unknown" — callers must NOT treat it as "empty".
+     *
+     * Uses count(*) via query() rather than getCollectionStatistics(): stats are
+     * computed from sealed segments and lag recent inserts (returning 0 for a
+     * freshly-indexed but unflushed collection), while count(*) reads the real
+     * current state. A stale 0 would fool recovery into thinking the collection
+     * is truly empty and cause Issue #295-style false-negative "not indexed"
+     * errors even when data exists.
+     */
+    async getCollectionRowCount(collectionName: string): Promise<number> {
+        await this.ensureInitialized();
+        if (!this.client) return -1;
+        try {
+            const hasCol = await this.client.hasCollection({ collection_name: collectionName });
+            if (!hasCol.value) return -1;
+
+            // count(*) requires the collection to be loaded.
+            await this.ensureLoaded(collectionName);
+
+            const result = await this.client.query({
+                collection_name: collectionName,
+                output_fields: ['count(*)'],
+                expr: '',
+            });
+            if (result.status.error_code !== 'Success') {
+                console.warn(`[MilvusDB] count(*) query failed for '${collectionName}': ${result.status.reason}`);
+                return -1;
+            }
+
+            // Shape observed: { data: [{ "count(*)": "<number-as-string>" }] }
+            const row = result.data?.[0] as Record<string, any> | undefined;
+            if (!row) return -1;
+            const raw = row['count(*)'] ?? row['count'];
+            if (raw === undefined || raw === null) return -1;
+            const n = typeof raw === 'number' ? raw : parseInt(String(raw), 10);
+            return Number.isFinite(n) && n >= 0 ? n : -1;
+        } catch (error) {
+            console.error(`[MilvusDB] Error in count(*) query for '${collectionName}':`, error);
+            return -1;
+        }
+    }
 }

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -394,19 +394,28 @@ export class MilvusVectorDatabase implements VectorDatabase {
             return [];
         }
 
-        return searchResult.results.map((result: any) => ({
-            document: {
-                id: result.id,
-                vector: queryVector,
-                content: result.content,
-                relativePath: result.relativePath,
-                startLine: result.startLine,
-                endLine: result.endLine,
-                fileExtension: result.fileExtension,
-                metadata: JSON.parse(result.metadata || '{}'),
-            },
-            score: result.score,
-        }));
+        return searchResult.results.map((result: any) => {
+            let metadata = {};
+            try {
+                metadata = JSON.parse(result.metadata || '{}');
+            } catch (error) {
+                console.warn(`[MilvusDB] Failed to parse metadata for item ${result.id}:`, error);
+            }
+
+            return {
+                document: {
+                    id: result.id,
+                    vector: queryVector,
+                    content: result.content,
+                    relativePath: result.relativePath,
+                    startLine: result.startLine,
+                    endLine: result.endLine,
+                    fileExtension: result.fileExtension,
+                    metadata,
+                },
+                score: result.score,
+            };
+        });
     }
 
     async delete(collectionName: string, ids: string[]): Promise<void> {

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -434,16 +434,21 @@ export class MilvusVectorDatabase implements VectorDatabase {
         try {
             const queryParams: any = {
                 collection_name: collectionName,
-                filter: filter,
                 output_fields: outputFields,
             };
 
-            // Add limit if provided, or default for empty filter expressions
+            // Only include filter if it's a non-empty, non-whitespace string
+            // An empty string filter is falsy in JS and causes Milvus SDK to return empty results
+            if (filter && filter.trim() !== '') {
+                queryParams.filter = filter;
+            }
+
+            // Add limit if provided, or default when no filter is specified
             if (limit !== undefined) {
                 queryParams.limit = limit;
-            } else if (filter === '' || filter.trim() === '') {
-                // Milvus requires limit when using empty expressions
-                queryParams.limit = 16384; // Default limit for empty filters
+            } else if (!filter || filter.trim() === '') {
+                // Milvus requires limit when no filter expression is provided
+                queryParams.limit = 16384; // Default limit for unfiltered queries
             }
 
             const result = await this.client.query(queryParams);
@@ -712,6 +717,20 @@ export class MilvusVectorDatabase implements VectorDatabase {
             console.error(`[MilvusDB] ❌ Failed to perform hybrid search on collection '${collectionName}':`, error);
             throw error;
         }
+    }
+
+    async getCollectionDescription(collectionName: string): Promise<string> {
+        await this.ensureInitialized();
+
+        if (!this.client) {
+            throw new Error('MilvusClient is not initialized after ensureInitialized().');
+        }
+
+        const result = await this.client.describeCollection({
+            collection_name: collectionName,
+        });
+
+        return (result as any).schema?.description || '';
     }
 
     /**

--- a/packages/core/src/vectordb/types.ts
+++ b/packages/core/src/vectordb/types.ts
@@ -138,6 +138,13 @@ export interface VectorDatabase {
      * Returns true if collection can be created, false if limit exceeded
      */
     checkCollectionLimit(): Promise<boolean>;
+
+    /**
+     * Get the number of entities (rows) in a collection.
+     * Returns -1 if the count cannot be determined (query failed, collection missing, etc).
+     * Callers should treat -1 as "unknown" and NOT as "empty".
+     */
+    getCollectionRowCount(collectionName: string): Promise<number>;
 }
 
 /**

--- a/packages/core/src/vectordb/types.ts
+++ b/packages/core/src/vectordb/types.ts
@@ -127,6 +127,13 @@ export interface VectorDatabase {
     query(collectionName: string, filter: string, outputFields: string[], limit?: number): Promise<Record<string, any>[]>;
 
     /**
+     * Get collection description
+     * @param collectionName Collection name
+     * @returns Collection description string
+     */
+    getCollectionDescription(collectionName: string): Promise<string>;
+
+    /**
      * Check collection limit
      * Returns true if collection can be created, false if limit exceeded
      */

--- a/packages/mcp/CONTRIBUTING.md
+++ b/packages/mcp/CONTRIBUTING.md
@@ -101,7 +101,7 @@ You can use the following configuration to configure the MCP server with a devel
 
 ### Claude Code Development Mode Configuration
 ```bash
-claude mcp add claude-context -e OPENAI_API_KEY=sk-your-openai-api-key -e MILVUS_TOKEN=your-zilliz-cloud-api-key -- node PATH_TO_CLAUDECONTEXT/packages/mcp/dist/index.js
+claude mcp add claude-context -e OPENAI_API_KEY=sk-your-openai-api-key -e MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint -e MILVUS_TOKEN=your-zilliz-cloud-api-key -- node PATH_TO_CLAUDECONTEXT/packages/mcp/dist/index.js
 ```
 And then you can start Claude Code with `claude --debug` to see the MCP server logs.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -201,6 +201,29 @@ See the [Claude Code MCP documentation](https://docs.anthropic.com/en/docs/claud
 </details>
 
 <details>
+<summary><strong>OpenAI Codex CLI</strong></summary>
+
+Codex CLI uses TOML configuration files:
+
+1. Create or edit the `~/.codex/config.toml` file.
+
+2. Add the following configuration:
+
+```toml
+# IMPORTANT: the top-level key is `mcp_servers` rather than `mcpServers`.
+[mcp_servers.claude-context]
+command = "npx"
+args = ["@zilliz/claude-context-mcp@latest"]
+env = { "OPENAI_API_KEY" = "your-openai-api-key", "MILVUS_TOKEN" = "your-zilliz-cloud-api-key" }
+# Optional: override the default 10s startup timeout
+startup_timeout_ms = 20000
+```
+
+3. Save the file and restart Codex CLI to apply the changes.
+
+</details>
+
+<details>
 <summary><strong>Gemini CLI</strong></summary>
 
 Gemini CLI requires manual configuration through a JSON file:

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -159,6 +159,10 @@ Copy your Personal Key to replace `your-zilliz-cloud-api-key` in the configurati
 
 ```bash
 MILVUS_TOKEN=your-zilliz-cloud-api-key
+
+# Optional: Specify Zilliz Cloud project name (defaults to 'Default Project')
+# Use this if you want to use a different project when auto-resolving address from token
+# ZILLIZ_PROJECT_NAME=My Custom Project
 ```
 
 #### Embedding Batch Size

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -159,6 +159,9 @@ Copy your Personal Key to replace `your-zilliz-cloud-api-key` in the configurati
 
 ```bash
 MILVUS_TOKEN=your-zilliz-cloud-api-key
+
+# Optional: increase timeout for Milvus collection-limit pre-check on slow clusters (default: 15000)
+MILVUS_COLLECTION_LIMIT_CHECK_TIMEOUT_MS=30000
 ```
 
 #### Embedding Batch Size

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -134,7 +134,7 @@ OLLAMA_HOST=http://127.0.0.1:11434
 
 **Setup Instructions:**
 
-1. Install Ollama from [ollama.ai](https://ollama.ai/)
+1. Install Ollama from [ollama.com](https://ollama.com/)
 2. Pull the embedding model:
 
    ```bash
@@ -278,7 +278,7 @@ Create or edit the `~/.qwen/settings.json` file and add the following configurat
 
 Go to: `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`
 
-Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) for more info.
+Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more info.
 
 **OpenAI Configuration (Default):**
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -668,6 +668,16 @@ Get the current indexing status of a codebase. Shows progress percentage for act
 
 - `path` (required): Absolute path to the codebase directory to check status for
 
+**What the status output means:**
+
+- Progress is **phase-based**, not a direct file-count ratio. The MCP server reports coarse milestones for collection preparation, file scanning, and file processing / embedding work.
+- Because indexing runs in the background and progress is persisted periodically, percentages can jump quickly on large repositories or appear unchanged for a while during long embedding batches.
+- File and chunk statistics are written when an indexing run finishes successfully. During active indexing, `get_indexing_status` intentionally reports progress rather than live file/chunk totals.
+- Codebases are keyed by their **absolute path**. Indexing `/repo`, a symlinked path to the same repo, and a second clone will create separate tracked entries.
+- If a completed entry shows `0 files, 0 chunks`, that usually means the local snapshot metadata is stale rather than the vector database being queried live. Re-indexing, or clearing and re-indexing that exact absolute path, refreshes the stored stats.
+
+For a deeper explanation, see the [asynchronous indexing workflow guide](../../docs/dive-deep/asynchronous-indexing-workflow.md) and the [troubleshooting FAQ](../../docs/troubleshooting/faq.md).
+
 ## Contributing
 
 This package is part of the Claude Context monorepo. Please see:

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -186,6 +186,17 @@ CUSTOM_IGNORE_PATTERNS=temp/**,*.backup,private/**,uploads/**
 
 These settings work in combination with tool parameters - patterns from both sources will be merged together.
 
+#### Custom Collection Name (Optional)
+
+Use this when you want a human-readable prefix on collection names in Milvus/Zilliz instead of the bare hash:
+
+```bash
+# Creates code_chunks_my_project_<pathHash> or hybrid_code_chunks_my_project_<pathHash>
+CODE_CHUNKS_COLLECTION_NAME_OVERRIDE=my_project
+```
+
+The per-codebase `<pathHash>` suffix is preserved even when the override is set, so the same MCP server can still index multiple repos without collapsing them onto one collection. The override value is sanitized to letters, numbers, and underscores, and truncated to keep the full name within Milvus's 255-char limit. If you unset the variable later, Claude Context switches back to the plain `code_chunks_<pathHash>` naming.
+
 ## Usage with MCP Clients
 
 <details>

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -206,7 +206,7 @@ Use the command line interface to add the Claude Context MCP server:
 
 ```bash
 # Add the Claude Context MCP server
-claude mcp add claude-context -e OPENAI_API_KEY=your-openai-api-key -e MILVUS_TOKEN=your-zilliz-cloud-api-key -- npx @zilliz/claude-context-mcp@latest
+claude mcp add claude-context -e OPENAI_API_KEY=your-openai-api-key -e MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint -e MILVUS_TOKEN=your-zilliz-cloud-api-key -- npx @zilliz/claude-context-mcp@latest
 
 ```
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-mcp",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "Model Context Protocol integration for Claude Context",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-mcp",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Model Context Protocol integration for Claude Context",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-mcp",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Model Context Protocol integration for Claude Context",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-mcp",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Model Context Protocol integration for Claude Context",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-mcp",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "Model Context Protocol integration for Claude Context",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -18,6 +18,7 @@ export interface ContextMcpConfig {
     // Vector database configuration
     milvusAddress?: string; // Optional, can be auto-resolved from token
     milvusToken?: string;
+    zillizProjectName?: string; // Optional, defaults to 'Default Project'
 }
 
 // Legacy format (v1) - for backward compatibility
@@ -130,7 +131,8 @@ export function createMcpConfig(): ContextMcpConfig {
         ollamaHost: envManager.get('OLLAMA_HOST'),
         // Vector database configuration - address can be auto-resolved from token
         milvusAddress: envManager.get('MILVUS_ADDRESS'), // Optional, can be resolved from token
-        milvusToken: envManager.get('MILVUS_TOKEN')
+        milvusToken: envManager.get('MILVUS_TOKEN'),
+        zillizProjectName: envManager.get('ZILLIZ_PROJECT_NAME') // Optional, defaults to 'Default Project'
     };
 
     return config;

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -18,6 +18,7 @@ export interface ContextMcpConfig {
     // Vector database configuration
     milvusAddress?: string; // Optional, can be auto-resolved from token
     milvusToken?: string;
+    collectionNameOverride?: string;
 }
 
 // Legacy format (v1) - for backward compatibility
@@ -111,6 +112,7 @@ export function createMcpConfig(): ContextMcpConfig {
     console.log(`[DEBUG]   GEMINI_API_KEY: ${envManager.get('GEMINI_API_KEY') ? 'SET (length: ' + envManager.get('GEMINI_API_KEY')!.length + ')' : 'NOT SET'}`);
     console.log(`[DEBUG]   OPENAI_API_KEY: ${envManager.get('OPENAI_API_KEY') ? 'SET (length: ' + envManager.get('OPENAI_API_KEY')!.length + ')' : 'NOT SET'}`);
     console.log(`[DEBUG]   MILVUS_ADDRESS: ${envManager.get('MILVUS_ADDRESS') || 'NOT SET'}`);
+    console.log(`[DEBUG]   CODE_CHUNKS_COLLECTION_NAME_OVERRIDE: ${envManager.get('CODE_CHUNKS_COLLECTION_NAME_OVERRIDE') || 'NOT SET'}`);
     console.log(`[DEBUG]   NODE_ENV: ${envManager.get('NODE_ENV') || 'NOT SET'}`);
 
     const config: ContextMcpConfig = {
@@ -130,7 +132,8 @@ export function createMcpConfig(): ContextMcpConfig {
         ollamaHost: envManager.get('OLLAMA_HOST'),
         // Vector database configuration - address can be auto-resolved from token
         milvusAddress: envManager.get('MILVUS_ADDRESS'), // Optional, can be resolved from token
-        milvusToken: envManager.get('MILVUS_TOKEN')
+        milvusToken: envManager.get('MILVUS_TOKEN'),
+        collectionNameOverride: envManager.get('CODE_CHUNKS_COLLECTION_NAME_OVERRIDE')
     };
 
     return config;
@@ -144,6 +147,9 @@ export function logConfigurationSummary(config: ContextMcpConfig): void {
     console.log(`[MCP]   Embedding Provider: ${config.embeddingProvider}`);
     console.log(`[MCP]   Embedding Model: ${config.embeddingModel}`);
     console.log(`[MCP]   Milvus Address: ${config.milvusAddress || (config.milvusToken ? '[Auto-resolve from token]' : '[Not configured]')}`);
+    if (config.collectionNameOverride) {
+        console.log(`[MCP]   Collection Name Override: ✅ Configured`);
+    }
 
     // Log provider-specific configuration without exposing sensitive data
     switch (config.embeddingProvider) {
@@ -202,6 +208,12 @@ Environment Variables:
   Vector Database Configuration:
   MILVUS_ADDRESS          Milvus address (optional, can be auto-resolved from token)
   MILVUS_TOKEN            Milvus token (optional, used for authentication and address resolution)
+  CODE_CHUNKS_COLLECTION_NAME_OVERRIDE
+                          Optional readable prefix for collection names.
+                          Uses code_chunks_<override>_<pathHash> (or hybrid_...)
+                          after sanitization (letters/digits/underscore, 255 chars max).
+                          The per-codebase pathHash is preserved so multiple
+                          codebases stay distinct under the same override.
 
 Examples:
   # Start MCP server with OpenAI (default) and explicit Milvus address
@@ -221,5 +233,8 @@ Examples:
   
   # Start MCP server with Ollama and specific model (using EMBEDDING_MODEL)
   EMBEDDING_PROVIDER=Ollama EMBEDDING_MODEL=nomic-embed-text MILVUS_TOKEN=your-token npx @zilliz/claude-context-mcp@latest
+
+  # Start MCP server with a human-readable collection name override
+  OPENAI_API_KEY=sk-xxx MILVUS_TOKEN=your-token CODE_CHUNKS_COLLECTION_NAME_OVERRIDE=my_project npx @zilliz/claude-context-mcp@latest
         `);
-} 
+}

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -4,7 +4,7 @@ export interface ContextMcpConfig {
     name: string;
     version: string;
     // Embedding provider configuration
-    embeddingProvider: 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama';
+    embeddingProvider: 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama' | 'OpenRouter';
     embeddingModel: string;
     // Provider-specific API keys
     openaiApiKey?: string;
@@ -12,6 +12,8 @@ export interface ContextMcpConfig {
     voyageaiApiKey?: string;
     geminiApiKey?: string;
     geminiBaseUrl?: string;
+    // OpenRouter configuration
+    openrouterApiKey?: string;
     // Ollama configuration
     ollamaModel?: string;
     ollamaHost?: string;
@@ -77,6 +79,8 @@ export function getDefaultModelForProvider(provider: string): string {
             return 'voyage-code-3';
         case 'Gemini':
             return 'gemini-embedding-001';
+        case 'OpenRouter':
+            return 'openai/text-embedding-3-small';
         case 'Ollama':
             return 'nomic-embed-text';
         default:
@@ -95,6 +99,7 @@ export function getEmbeddingModelForProvider(provider: string): string {
         case 'OpenAI':
         case 'VoyageAI':
         case 'Gemini':
+        case 'OpenRouter':
         default:
             // For all other providers, use EMBEDDING_MODEL or default
             const selectedModel = envManager.get('EMBEDDING_MODEL') || getDefaultModelForProvider(provider);
@@ -119,7 +124,7 @@ export function createMcpConfig(): ContextMcpConfig {
         name: envManager.get('MCP_SERVER_NAME') || "Context MCP Server",
         version: envManager.get('MCP_SERVER_VERSION') || "1.0.0",
         // Embedding provider configuration
-        embeddingProvider: (envManager.get('EMBEDDING_PROVIDER') as 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama') || 'OpenAI',
+        embeddingProvider: (envManager.get('EMBEDDING_PROVIDER') as 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama' | 'OpenRouter') || 'OpenAI',
         embeddingModel: getEmbeddingModelForProvider(envManager.get('EMBEDDING_PROVIDER') || 'OpenAI'),
         // Provider-specific API keys
         openaiApiKey: envManager.get('OPENAI_API_KEY'),
@@ -127,6 +132,8 @@ export function createMcpConfig(): ContextMcpConfig {
         voyageaiApiKey: envManager.get('VOYAGEAI_API_KEY'),
         geminiApiKey: envManager.get('GEMINI_API_KEY'),
         geminiBaseUrl: envManager.get('GEMINI_BASE_URL'),
+        // OpenRouter configuration
+        openrouterApiKey: envManager.get('OPENROUTER_API_KEY'),
         // Ollama configuration
         ollamaModel: envManager.get('OLLAMA_MODEL'),
         ollamaHost: envManager.get('OLLAMA_HOST'),
@@ -168,6 +175,9 @@ export function logConfigurationSummary(config: ContextMcpConfig): void {
                 console.log(`[MCP]   Gemini Base URL: ${config.geminiBaseUrl}`);
             }
             break;
+        case 'OpenRouter':
+            console.log(`[MCP]   OpenRouter API Key: ${config.openrouterApiKey ? '✅ Configured' : '❌ Missing'}`);
+            break;
         case 'Ollama':
             console.log(`[MCP]   Ollama Host: ${config.ollamaHost || 'http://127.0.0.1:11434'}`);
             console.log(`[MCP]   Ollama Model: ${config.embeddingModel}`);
@@ -191,7 +201,7 @@ Environment Variables:
   MCP_SERVER_VERSION      Server version
   
   Embedding Provider Configuration:
-  EMBEDDING_PROVIDER      Embedding provider: OpenAI, VoyageAI, Gemini, Ollama (default: OpenAI)
+  EMBEDDING_PROVIDER      Embedding provider: OpenAI, VoyageAI, Gemini, Ollama, OpenRouter (default: OpenAI)
   EMBEDDING_MODEL         Embedding model name (works for all providers)
   
   Provider-specific API Keys:
@@ -200,7 +210,8 @@ Environment Variables:
   VOYAGEAI_API_KEY        VoyageAI API key (required for VoyageAI provider)
   GEMINI_API_KEY          Google AI API key (required for Gemini provider)
   GEMINI_BASE_URL         Gemini API base URL (optional, for custom endpoints)
-  
+  OPENROUTER_API_KEY      OpenRouter API key (required for OpenRouter provider)
+
   Ollama Configuration:
   OLLAMA_HOST             Ollama server host (default: http://127.0.0.1:11434)
   OLLAMA_MODEL            Ollama model name (alternative to EMBEDDING_MODEL for Ollama)

--- a/packages/mcp/src/embedding.ts
+++ b/packages/mcp/src/embedding.ts
@@ -2,7 +2,7 @@ import { OpenAIEmbedding, VoyageAIEmbedding, GeminiEmbedding, OllamaEmbedding } 
 import { ContextMcpConfig } from "./config.js";
 
 // Helper function to create embedding instance based on provider
-export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding {
+export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding  {
     console.log(`[EMBEDDING] Creating ${config.embeddingProvider} embedding instance...`);
 
     switch (config.embeddingProvider) {
@@ -47,6 +47,21 @@ export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbeddi
             console.log(`[EMBEDDING] ✅ Gemini embedding instance created successfully`);
             return geminiEmbedding;
 
+        case 'OpenRouter':
+            if (!config.openrouterApiKey) {
+                console.error(`[EMBEDDING] ❌ OpenRouter API key is required but not provided`);
+                throw new Error('OPENROUTER_API_KEY is required for OpenRouter embedding provider');
+            }
+            console.log(`[EMBEDDING] 🔧 Configuring OpenRouter with model: ${config.embeddingModel}`);
+            // Reuse OpenAIEmbedding with OpenRouter's OpenAI-compatible endpoint
+            const openrouterEmbedding = new OpenAIEmbedding({
+                apiKey: config.openrouterApiKey,
+                model: config.embeddingModel,
+                baseURL: 'https://openrouter.ai/api/v1',
+            });
+            console.log(`[EMBEDDING] ✅ OpenRouter embedding instance created successfully`);
+            return openrouterEmbedding;
+
         case 'Ollama':
             const ollamaHost = config.ollamaHost || 'http://127.0.0.1:11434';
             console.log(`[EMBEDDING] 🔧 Configuring Ollama with model: ${config.embeddingModel}, host: ${ollamaHost}`);
@@ -77,6 +92,9 @@ export function logEmbeddingProviderInfo(config: ContextMcpConfig, embedding: Op
             break;
         case 'Gemini':
             console.log(`[EMBEDDING] Gemini configuration - API Key: ${config.geminiApiKey ? '✅ Provided' : '❌ Missing'}, Base URL: ${config.geminiBaseUrl || 'Default'}`);
+            break;
+        case 'OpenRouter':
+            console.log(`[EMBEDDING] OpenRouter configuration - API Key: ${config.openrouterApiKey ? '✅ Provided' : '❌ Missing'}`);
             break;
         case 'Ollama':
             console.log(`[EMBEDDING] Ollama configuration - Host: ${config.ollamaHost || 'http://127.0.0.1:11434'}, Model: ${config.embeddingModel}`);

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -528,6 +528,18 @@ export class ToolHandlers {
             console.log(`[SEARCH] ✅ Search completed! Found ${searchResults.length} results using ${embeddingProvider.getProvider()} embeddings`);
 
             if (searchResults.length === 0) {
+                // Check if collection was lost (indexed locally but missing in Milvus)
+                if (isIndexed && !isIndexing) {
+                    const collectionName = this.context.getCollectionName(absolutePath);
+                    const hasCollection = await this.context.getVectorDatabase().hasCollection(collectionName);
+                    if (!hasCollection) {
+                        return {
+                            content: [{ type: "text", text: `Error: Index data for '${absolutePath}' has been lost (collection not found in Milvus). Please re-index using index_codebase with force=true.` }],
+                            isError: true
+                        };
+                    }
+                }
+
                 let noResultsMessage = `No results found for query: "${query}" in codebase '${absolutePath}'`;
                 if (isIndexing) {
                     noResultsMessage += `\n\nNote: This codebase is still being indexed. Try searching again after indexing completes, or the query may not match any indexed content.`;

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -85,7 +85,7 @@ export class ToolHandlers {
                         try {
                             const results = await vectorDb.query(
                                 collectionName,
-                                '', // Empty filter to get all results
+                                undefined as any, // Don't pass empty filter
                                 ['metadata'], // Only fetch metadata field
                                 1 // Only need one result to extract codebasePath
                             );
@@ -140,14 +140,24 @@ export class ToolHandlers {
             // Remove local codebases that don't exist in cloud
             for (const localCodebase of localCodebases) {
                 if (!cloudCodebases.has(localCodebase)) {
-                    this.snapshotManager.removeIndexedCodebase(localCodebase);
+                    this.snapshotManager.removeCodebaseCompletely(localCodebase);
                     hasChanges = true;
                     console.log(`[SYNC-CLOUD] ➖ Removed local codebase (not in cloud): ${localCodebase}`);
                 }
             }
 
-            // Note: We don't add cloud codebases that are missing locally (as per user requirement)
-            console.log(`[SYNC-CLOUD] ℹ️  Skipping addition of cloud codebases not present locally (per sync policy)`);
+            // Add cloud codebases that are missing from local snapshot (recovery)
+            for (const cloudCodebase of cloudCodebases) {
+                if (!localCodebases.has(cloudCodebase)) {
+                    this.snapshotManager.setCodebaseIndexed(cloudCodebase, {
+                        indexedFiles: 0,
+                        totalChunks: 0,
+                        status: 'completed' as const
+                    });
+                    hasChanges = true;
+                    console.log(`[SYNC-CLOUD] ➕ Recovered codebase from cloud: ${cloudCodebase}`);
+                }
+            }
 
             if (hasChanges) {
                 this.snapshotManager.saveCodebaseSnapshot();
@@ -228,8 +238,18 @@ export class ToolHandlers {
             }
 
             //Check if the snapshot and cloud index are in sync
-            if (this.snapshotManager.getIndexedCodebases().includes(absolutePath) !== await this.context.hasIndex(absolutePath)) {
-                console.warn(`[INDEX-VALIDATION] ❌ Snapshot and cloud index mismatch: ${absolutePath}`);
+            const snapshotHasIndex = this.snapshotManager.getIndexedCodebases().includes(absolutePath);
+            const vectorDbHasIndex = await this.context.hasIndex(absolutePath);
+            if (snapshotHasIndex !== vectorDbHasIndex) {
+                if (vectorDbHasIndex && !snapshotHasIndex) {
+                    console.warn(`[INDEX-VALIDATION] Recovering missing snapshot for '${absolutePath}'`);
+                    this.snapshotManager.setCodebaseIndexed(absolutePath, { indexedFiles: 0, totalChunks: 0, status: 'completed' as const });
+                    this.snapshotManager.saveCodebaseSnapshot();
+                } else if (!vectorDbHasIndex && snapshotHasIndex) {
+                    console.warn(`[INDEX-VALIDATION] Clearing stale snapshot for '${absolutePath}'`);
+                    this.snapshotManager.removeCodebaseCompletely(absolutePath);
+                    this.snapshotManager.saveCodebaseSnapshot();
+                }
             }
 
             // Check if already indexed (unless force is true)
@@ -478,13 +498,22 @@ export class ToolHandlers {
             const isIndexing = this.snapshotManager.getIndexingCodebases().includes(absolutePath);
 
             if (!isIndexed && !isIndexing) {
-                return {
-                    content: [{
-                        type: "text",
-                        text: `Error: Codebase '${absolutePath}' is not indexed. Please index it first using the index_codebase tool.`
-                    }],
-                    isError: true
-                };
+                // Fallback: check VectorDB directly in case snapshot is out of sync
+                const hasVectorIndex = await this.context.hasIndex(absolutePath);
+                if (hasVectorIndex) {
+                    console.warn(`[SEARCH] Snapshot missing but VectorDB has index for '${absolutePath}', recovering snapshot`);
+                    this.snapshotManager.setCodebaseIndexed(absolutePath, { indexedFiles: 0, totalChunks: 0, status: 'completed' as const });
+                    this.snapshotManager.saveCodebaseSnapshot();
+                    // Continue with search (don't return error)
+                } else {
+                    return {
+                        content: [{
+                            type: "text",
+                            text: `Error: Codebase '${absolutePath}' is not indexed. Please index it first using the index_codebase tool.`
+                        }],
+                        isError: true
+                    };
+                }
             }
 
             // Show indexing status if codebase is being indexed

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -19,6 +19,131 @@ export class ToolHandlers {
     }
 
     /**
+     * Query Milvus for the real row count of a codebase's collection.
+     * Returns null if the count cannot be determined — callers must NOT write a
+     * snapshot entry in that case. Writing { indexedFiles: 0, totalChunks: 0,
+     * status: 'completed' } for an unknown-state collection poisons the client:
+     * the client treats 0/0 as "not indexed" and triggers force reindex, which
+     * deletes real data and rewrites 0/0 — an infinite loop. See Issue #295.
+     */
+    private async queryCollectionStats(codebasePath: string): Promise<{ indexedFiles: number; totalChunks: number } | null> {
+        try {
+            const collectionName = this.context.getCollectionName(codebasePath);
+            const rowCount = await this.context.getVectorDatabase().getCollectionRowCount(collectionName);
+            if (rowCount < 0) {
+                console.warn(`[SNAPSHOT-RECOVERY] Row count unknown for '${codebasePath}', skipping recovery write`);
+                return null;
+            }
+            if (rowCount === 0) {
+                console.warn(`[SNAPSHOT-RECOVERY] Collection '${collectionName}' truly empty — NOT writing recovered entry (would poison client)`);
+                return null;
+            }
+            // rowCount is chunk count, not file count. Without a metadata query
+            // we don't have the real file count; the snapshot will be corrected
+            // on the next full index. Using rowCount for both is imprecise but
+            // keeps the state non-zero so the client doesn't misread it as empty.
+            return { indexedFiles: rowCount, totalChunks: rowCount };
+        } catch (error) {
+            console.warn(`[SNAPSHOT-RECOVERY] Failed to query stats for '${codebasePath}':`, error);
+            return null;
+        }
+    }
+
+    /**
+     * One-shot startup validation: find any legacy 0/0+completed entries on disk
+     * (left over from old MCP versions, v1 snapshot migrations, or pre-fix recovery
+     * paths) and either heal them with the real Milvus row count or remove them
+     * if the underlying collection is empty/missing. See Issue #295.
+     *
+     * Safe to call multiple times but intended to run once per server start after
+     * loadCodebaseSnapshot(). Errors are caught and logged; never throws.
+     */
+    public async validateLegacyZeroEntries(): Promise<void> {
+        try {
+            const indexedCodebases = this.snapshotManager.getIndexedCodebases();
+            let healed = 0, removed = 0, skipped = 0, checked = 0;
+
+            for (const codebasePath of indexedCodebases) {
+                const info = this.snapshotManager.getCodebaseInfo(codebasePath);
+                if (!info || info.status !== 'indexed') continue;
+                // Only validate suspiciously-zero entries
+                if (info.indexedFiles !== 0 || info.totalChunks !== 0) continue;
+
+                checked++;
+                const collectionName = this.context.getCollectionName(codebasePath);
+                const vdb = this.context.getVectorDatabase();
+
+                // First probe: does the collection even exist? A "no" here is
+                // authoritative (permanent orphan), while a throw is most likely
+                // transient (Milvus unreachable) — keep those two cases distinct
+                // so we don't destroy real state on a network blip.
+                let collectionExists: boolean;
+                try {
+                    collectionExists = await vdb.hasCollection(collectionName);
+                } catch (err) {
+                    console.warn(`[SNAPSHOT-VALIDATE] hasCollection failed for '${codebasePath}' (likely transient), skipping:`, err);
+                    skipped++;
+                    continue;
+                }
+
+                if (!collectionExists) {
+                    // Permanent orphan — no matching Milvus collection, so the
+                    // 0/0+completed snapshot entry is a pure phantom. Remove it.
+                    this.snapshotManager.removeCodebaseCompletely(codebasePath);
+                    removed++;
+                    console.warn(`[SNAPSHOT-VALIDATE] Removed orphan 0/0 entry '${codebasePath}' — no matching Milvus collection`);
+                    continue;
+                }
+
+                // Collection exists — get an accurate row count.
+                let rowCount: number;
+                try {
+                    rowCount = await vdb.getCollectionRowCount(collectionName);
+                } catch (err) {
+                    console.warn(`[SNAPSHOT-VALIDATE] getCollectionRowCount failed for '${codebasePath}', skipping:`, err);
+                    skipped++;
+                    continue;
+                }
+
+                if (rowCount > 0) {
+                    // Heal: rewrite with real row count. rowCount is chunk count;
+                    // without a cheap file-count query we reuse it for both fields.
+                    // Imprecise but keeps the state non-zero and will be corrected
+                    // on the next full index.
+                    this.snapshotManager.setCodebaseIndexed(codebasePath, {
+                        indexedFiles: rowCount,
+                        totalChunks: rowCount,
+                        status: 'completed' as const,
+                    });
+                    healed++;
+                    console.log(`[SNAPSHOT-VALIDATE] Healed legacy 0/0 entry '${codebasePath}' → rows=${rowCount}`);
+                } else if (rowCount === 0) {
+                    // Collection exists but truly empty — the 0/0+completed entry
+                    // is a phantom. Remove so the user must explicitly reindex.
+                    this.snapshotManager.removeCodebaseCompletely(codebasePath);
+                    removed++;
+                    console.warn(`[SNAPSHOT-VALIDATE] Removed phantom 0/0 entry '${codebasePath}' — collection exists but empty`);
+                } else {
+                    // rowCount === -1 despite the collection existing: the count
+                    // query failed after the existence probe succeeded. Treat as
+                    // transient and leave the entry alone.
+                    skipped++;
+                    console.warn(`[SNAPSHOT-VALIDATE] Row count unavailable for existing collection '${codebasePath}', skipping`);
+                }
+            }
+
+            if (healed > 0 || removed > 0) {
+                this.snapshotManager.saveCodebaseSnapshot();
+            }
+            if (checked > 0) {
+                console.log(`[SNAPSHOT-VALIDATE] Done — checked=${checked} healed=${healed} removed=${removed} skipped=${skipped}`);
+            }
+        } catch (error) {
+            console.warn(`[SNAPSHOT-VALIDATE] Unexpected error during legacy 0/0 validation (non-fatal):`, error);
+        }
+    }
+
+    /**
      * Sync indexed codebases from Zilliz Cloud collections
      * This method fetches all collections from the vector database,
      * extracts codebasePath from collection description (preferred) or falls back
@@ -146,16 +271,22 @@ export class ToolHandlers {
                 }
             }
 
-            // Add cloud codebases that are missing from local snapshot (recovery)
+            // Add cloud codebases that are missing from local snapshot (recovery).
+            // Query Milvus for the real row count — if unknown/empty, skip the write
+            // so we don't persist a poisoning 0/0+completed entry (Issue #295).
             for (const cloudCodebase of cloudCodebases) {
                 if (!localCodebases.has(cloudCodebase)) {
-                    this.snapshotManager.setCodebaseIndexed(cloudCodebase, {
-                        indexedFiles: 0,
-                        totalChunks: 0,
-                        status: 'completed' as const
-                    });
-                    hasChanges = true;
-                    console.log(`[SYNC-CLOUD] ➕ Recovered codebase from cloud: ${cloudCodebase}`);
+                    const stats = await this.queryCollectionStats(cloudCodebase);
+                    if (stats) {
+                        this.snapshotManager.setCodebaseIndexed(cloudCodebase, {
+                            ...stats,
+                            status: 'completed' as const
+                        });
+                        hasChanges = true;
+                        console.log(`[SYNC-CLOUD] ➕ Recovered codebase from cloud: ${cloudCodebase} (rows=${stats.totalChunks})`);
+                    } else {
+                        console.log(`[SYNC-CLOUD] ⏭️  Skipped recovery for ${cloudCodebase} (row count unknown or zero)`);
+                    }
                 }
             }
 
@@ -242,9 +373,17 @@ export class ToolHandlers {
             const vectorDbHasIndex = await this.context.hasIndex(absolutePath);
             if (snapshotHasIndex !== vectorDbHasIndex) {
                 if (vectorDbHasIndex && !snapshotHasIndex) {
-                    console.warn(`[INDEX-VALIDATION] Recovering missing snapshot for '${absolutePath}'`);
-                    this.snapshotManager.setCodebaseIndexed(absolutePath, { indexedFiles: 0, totalChunks: 0, status: 'completed' as const });
-                    this.snapshotManager.saveCodebaseSnapshot();
+                    // Query Milvus for real row count. If unknown/empty, log and move on
+                    // without writing 0/0+completed (which would trigger the force-reindex
+                    // loop in Issue #295). The user is about to (re)index anyway.
+                    const stats = await this.queryCollectionStats(absolutePath);
+                    if (stats) {
+                        console.warn(`[INDEX-VALIDATION] Recovering missing snapshot for '${absolutePath}' (rows=${stats.totalChunks})`);
+                        this.snapshotManager.setCodebaseIndexed(absolutePath, { ...stats, status: 'completed' as const });
+                        this.snapshotManager.saveCodebaseSnapshot();
+                    } else {
+                        console.warn(`[INDEX-VALIDATION] VectorDB reports index for '${absolutePath}' but row count unknown/zero — not writing snapshot entry`);
+                    }
                 } else if (!vectorDbHasIndex && snapshotHasIndex) {
                     console.warn(`[INDEX-VALIDATION] Clearing stale snapshot for '${absolutePath}'`);
                     this.snapshotManager.removeCodebaseCompletely(absolutePath);
@@ -498,13 +637,27 @@ export class ToolHandlers {
             const isIndexing = this.snapshotManager.getIndexingCodebases().includes(absolutePath);
 
             if (!isIndexed && !isIndexing) {
-                // Fallback: check VectorDB directly in case snapshot is out of sync
+                // Fallback: check VectorDB directly in case snapshot is out of sync.
+                // Only recover the snapshot when we can confirm a real row count —
+                // writing 0/0+completed for an unverifiable collection poisons the
+                // client into a force-reindex loop (Issue #295).
                 const hasVectorIndex = await this.context.hasIndex(absolutePath);
                 if (hasVectorIndex) {
-                    console.warn(`[SEARCH] Snapshot missing but VectorDB has index for '${absolutePath}', recovering snapshot`);
-                    this.snapshotManager.setCodebaseIndexed(absolutePath, { indexedFiles: 0, totalChunks: 0, status: 'completed' as const });
-                    this.snapshotManager.saveCodebaseSnapshot();
-                    // Continue with search (don't return error)
+                    const stats = await this.queryCollectionStats(absolutePath);
+                    if (stats) {
+                        console.warn(`[SEARCH] Snapshot missing but VectorDB has index for '${absolutePath}', recovering snapshot (rows=${stats.totalChunks})`);
+                        this.snapshotManager.setCodebaseIndexed(absolutePath, { ...stats, status: 'completed' as const });
+                        this.snapshotManager.saveCodebaseSnapshot();
+                        // Continue with search (don't return error)
+                    } else {
+                        return {
+                            content: [{
+                                type: "text",
+                                text: `Error: Codebase '${absolutePath}' is not indexed. Please index it first using the index_codebase tool.`
+                            }],
+                            isError: true
+                        };
+                    }
                 } else {
                     return {
                         content: [{

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -531,7 +531,7 @@ export class ToolHandlers {
             const { FileSynchronizer } = await import("@zilliz/claude-context-core");
             const ignorePatterns = this.context.getIgnorePatterns() || [];
             console.log(`[BACKGROUND-INDEX] Using ignore patterns: ${ignorePatterns.join(', ')}`);
-            const synchronizer = new FileSynchronizer(absolutePath, ignorePatterns);
+            const synchronizer = new FileSynchronizer(absolutePath, ignorePatterns, this.context.getSupportedExtensions());
             await synchronizer.initialize();
 
             // Store synchronizer in the context (let context manage collection names)

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -212,13 +212,19 @@ export class ToolHandlers {
 
             // Check if already indexing
             if (this.snapshotManager.getIndexingCodebases().includes(absolutePath)) {
-                return {
-                    content: [{
-                        type: "text",
-                        text: `Codebase '${absolutePath}' is already being indexed in the background. Please wait for completion.`
-                    }],
-                    isError: true
-                };
+                if (forceReindex) {
+                    console.log(`[FORCE-REINDEX] Clearing stale indexing state for '${absolutePath}'`);
+                    this.snapshotManager.removeCodebaseCompletely(absolutePath);
+                    this.snapshotManager.saveCodebaseSnapshot();
+                } else {
+                    return {
+                        content: [{
+                            type: "text",
+                            text: `Codebase '${absolutePath}' is already being indexed in the background. Please wait for completion.`
+                        }],
+                        isError: true
+                    };
+                }
             }
 
             //Check if the snapshot and cloud index are in sync
@@ -239,10 +245,8 @@ export class ToolHandlers {
 
             // If force reindex and codebase is already indexed, remove it
             if (forceReindex) {
-                if (this.snapshotManager.getIndexedCodebases().includes(absolutePath)) {
-                    console.log(`[FORCE-REINDEX] 🔄 Removing '${absolutePath}' from indexed list for re-indexing`);
-                    this.snapshotManager.removeIndexedCodebase(absolutePath);
-                }
+                this.snapshotManager.removeCodebaseCompletely(absolutePath);
+                this.snapshotManager.saveCodebaseSnapshot();
                 if (await this.context.hasIndex(absolutePath)) {
                     console.log(`[FORCE-REINDEX] 🔄 Clearing index for '${absolutePath}'`);
                     await this.context.clearIndex(absolutePath);

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -21,9 +21,10 @@ export class ToolHandlers {
     /**
      * Sync indexed codebases from Zilliz Cloud collections
      * This method fetches all collections from the vector database,
-     * gets the first document from each collection to extract codebasePath from metadata,
+     * extracts codebasePath from collection description (preferred) or falls back
+     * to querying document metadata for old collections,
      * and updates the snapshot with discovered codebases.
-     * 
+     *
      * Logic: Compare mcp-codebase-snapshot.json with zilliz cloud collections
      * - If local snapshot has extra directories (not in cloud), remove them
      * - If local snapshot is missing directories (exist in cloud), ignore them
@@ -41,22 +42,13 @@ export class ToolHandlers {
             console.log(`[SYNC-CLOUD] 📋 Found ${collections.length} collections in Zilliz Cloud`);
 
             if (collections.length === 0) {
-                console.log(`[SYNC-CLOUD] ✅ No collections found in cloud`);
-                // If no collections in cloud, remove all local codebases
-                const localCodebases = this.snapshotManager.getIndexedCodebases();
-                if (localCodebases.length > 0) {
-                    console.log(`[SYNC-CLOUD] 🧹 Removing ${localCodebases.length} local codebases as cloud has no collections`);
-                    for (const codebasePath of localCodebases) {
-                        this.snapshotManager.removeIndexedCodebase(codebasePath);
-                        console.log(`[SYNC-CLOUD] ➖ Removed local codebase: ${codebasePath}`);
-                    }
-                    this.snapshotManager.saveCodebaseSnapshot();
-                    console.log(`[SYNC-CLOUD] 💾 Updated snapshot to match empty cloud state`);
-                }
+                console.log(`[SYNC-CLOUD] ✅ No collections found in cloud. Skipping deletion of local codebases to avoid data loss from transient errors.`);
                 return;
             }
 
             const cloudCodebases = new Set<string>();
+            let codeCollectionsChecked = 0;
+            let successfulExtractions = 0;
 
             // Check each collection for codebase path
             for (const collectionName of collections) {
@@ -67,39 +59,61 @@ export class ToolHandlers {
                         continue;
                     }
 
+                    codeCollectionsChecked++;
                     console.log(`[SYNC-CLOUD] 🔍 Checking collection: ${collectionName}`);
 
-                    // Query the first document to get metadata
-                    const results = await vectorDb.query(
-                        collectionName,
-                        '', // Empty filter to get all results
-                        ['metadata'], // Only fetch metadata field
-                        1 // Only need one result to extract codebasePath
-                    );
-
-                    if (results && results.length > 0) {
-                        const firstResult = results[0];
-                        const metadataStr = firstResult.metadata;
-
-                        if (metadataStr) {
-                            try {
-                                const metadata = JSON.parse(metadataStr);
-                                const codebasePath = metadata.codebasePath;
-
-                                if (codebasePath && typeof codebasePath === 'string') {
-                                    console.log(`[SYNC-CLOUD] 📍 Found codebase path: ${codebasePath} in collection: ${collectionName}`);
-                                    cloudCodebases.add(codebasePath);
-                                } else {
-                                    console.warn(`[SYNC-CLOUD] ⚠️  No codebasePath found in metadata for collection: ${collectionName}`);
-                                }
-                            } catch (parseError) {
-                                console.warn(`[SYNC-CLOUD] ⚠️  Failed to parse metadata JSON for collection ${collectionName}:`, parseError);
+                    // Try to extract codebasePath from collection description first (new format)
+                    let extracted = false;
+                    try {
+                        const description = await vectorDb.getCollectionDescription(collectionName);
+                        if (description && description.startsWith('codebasePath:')) {
+                            const codebasePath = description.substring('codebasePath:'.length);
+                            if (codebasePath.length > 0) {
+                                console.log(`[SYNC-CLOUD] 📍 Found codebase path from description: ${codebasePath} in collection: ${collectionName}`);
+                                cloudCodebases.add(codebasePath);
+                                successfulExtractions++;
+                                extracted = true;
                             }
-                        } else {
-                            console.warn(`[SYNC-CLOUD] ⚠️  No metadata found in collection: ${collectionName}`);
                         }
-                    } else {
-                        console.log(`[SYNC-CLOUD] ℹ️  Collection ${collectionName} is empty`);
+                    } catch (descError: any) {
+                        console.warn(`[SYNC-CLOUD] ⚠️  Failed to get description for collection ${collectionName}:`, descError.message || descError);
+                    }
+
+                    // Fallback: query document metadata for old collections without new description format
+                    if (!extracted) {
+                        console.log(`[SYNC-CLOUD] 🔄 Falling back to query-based extraction for collection: ${collectionName}`);
+                        try {
+                            const results = await vectorDb.query(
+                                collectionName,
+                                '', // Empty filter to get all results
+                                ['metadata'], // Only fetch metadata field
+                                1 // Only need one result to extract codebasePath
+                            );
+
+                            if (results && results.length > 0) {
+                                const firstResult = results[0];
+                                const metadataStr = firstResult.metadata;
+
+                                if (metadataStr) {
+                                    const metadata = JSON.parse(metadataStr);
+                                    const codebasePath = metadata.codebasePath;
+
+                                    if (codebasePath && typeof codebasePath === 'string') {
+                                        console.log(`[SYNC-CLOUD] 📍 Found codebase path from query: ${codebasePath} in collection: ${collectionName}`);
+                                        cloudCodebases.add(codebasePath);
+                                        successfulExtractions++;
+                                    } else {
+                                        console.warn(`[SYNC-CLOUD] ⚠️  No codebasePath found in metadata for collection: ${collectionName}`);
+                                    }
+                                } else {
+                                    console.warn(`[SYNC-CLOUD] ⚠️  No metadata found in collection: ${collectionName}`);
+                                }
+                            } else {
+                                console.log(`[SYNC-CLOUD] ℹ️  Collection ${collectionName} is empty`);
+                            }
+                        } catch (queryError: any) {
+                            console.warn(`[SYNC-CLOUD] ⚠️  Fallback query failed for collection ${collectionName}:`, queryError.message || queryError);
+                        }
                     }
                 } catch (collectionError: any) {
                     console.warn(`[SYNC-CLOUD] ⚠️  Error checking collection ${collectionName}:`, collectionError.message || collectionError);
@@ -107,7 +121,15 @@ export class ToolHandlers {
                 }
             }
 
-            console.log(`[SYNC-CLOUD] 📊 Found ${cloudCodebases.size} valid codebases in cloud`);
+            console.log(`[SYNC-CLOUD] 📊 Found ${cloudCodebases.size} valid codebases in cloud (checked ${codeCollectionsChecked} code collections, ${successfulExtractions} successfully extracted)`);
+
+            // Safety guard: if we checked code collections but none returned results,
+            // treat this as an extraction failure rather than "cloud is empty".
+            // This prevents deleting all local codebases due to transient errors.
+            if (codeCollectionsChecked > 0 && successfulExtractions === 0) {
+                console.warn(`[SYNC-CLOUD] ⚠️  All ${codeCollectionsChecked} code collection extractions failed. Skipping sync to avoid accidental deletion of local codebases.`);
+                return;
+            }
 
             // Get current local codebases
             const localCodebases = new Set(this.snapshotManager.getIndexedCodebases());

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -249,6 +249,11 @@ This tool is versatile and can be used before completing various tasks to retrie
         console.log('[SYNC-DEBUG] MCP server start() method called');
         console.log('Starting Context MCP server...');
 
+        // One-shot startup healing for legacy 0/0+completed snapshot entries
+        // left over from pre-fix MCP versions. Runs before the transport accepts
+        // requests so clients never observe the poisoning state. See Issue #295.
+        await this.toolHandlers.validateLegacyZeroEntries();
+
         const transport = new StdioServerTransport();
         console.log('[SYNC-DEBUG] StdioServerTransport created, attempting server connection...');
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -68,7 +68,8 @@ class ContextMcpServer {
         // Initialize Claude Context
         this.context = new Context({
             embedding,
-            vectorDatabase
+            vectorDatabase,
+            collectionNameOverride: config.collectionNameOverride
         });
 
         // Initialize managers

--- a/packages/mcp/src/snapshot.ts
+++ b/packages/mcp/src/snapshot.ts
@@ -115,11 +115,14 @@ export class SnapshotManager {
                 }
                 console.log(`[SNAPSHOT-DEBUG] Validated indexed codebase: ${codebasePath} (${info.indexedFiles || 'unknown'} files, ${info.totalChunks || 'unknown'} chunks)`);
             } else if (info.status === 'indexing') {
-                if ('indexingPercentage' in info) {
-                    validIndexingCodebases.set(codebasePath, info.indexingPercentage);
-                }
-                console.warn(`[SNAPSHOT-DEBUG] Found interrupted indexing codebase: ${codebasePath} (${info.indexingPercentage || 0}%). Treating as not indexed.`);
-                // Don't add to indexed - treat interrupted indexing as not indexed
+                console.warn(`[SNAPSHOT] Found interrupted indexing for '${codebasePath}', resetting to failed`);
+                const failedInfo: CodebaseInfoIndexFailed = {
+                    status: 'indexfailed',
+                    errorMessage: 'Indexing was interrupted (MCP server restarted)',
+                    lastAttemptedPercentage: info.indexingPercentage,
+                    lastUpdated: new Date().toISOString()
+                };
+                validCodebaseInfoMap.set(codebasePath, failedInfo);
             } else if (info.status === 'indexfailed') {
                 console.warn(`[SNAPSHOT-DEBUG] Found failed indexing codebase: ${codebasePath}. Error: ${info.errorMessage}`);
                 // Failed indexing codebases are not added to indexed or indexing lists
@@ -466,8 +469,60 @@ export class SnapshotManager {
         }
     }
 
+    private acquireLock(maxRetries = 5, retryInterval = 100): boolean {
+        const lockPath = this.snapshotFilePath + '.lock';
+        for (let i = 0; i < maxRetries; i++) {
+            try {
+                fs.mkdirSync(lockPath);
+                return true;
+            } catch {
+                // Check for stale lock (> 10 seconds old)
+                try {
+                    const stat = fs.statSync(lockPath);
+                    if (Date.now() - stat.mtimeMs > 10000) {
+                        fs.rmdirSync(lockPath);
+                        continue; // retry after removing stale lock
+                    }
+                } catch { /* lock was removed by another process */ }
+                // Busy wait and retry
+                const waitUntil = Date.now() + retryInterval;
+                while (Date.now() < waitUntil) { /* busy wait */ }
+            }
+        }
+        return false;
+    }
+
+    private releaseLock(): void {
+        try {
+            fs.rmdirSync(this.snapshotFilePath + '.lock');
+        } catch { /* already released */ }
+    }
+
+    private mergeExternalEntry(codebasePath: string, info: CodebaseInfo): void {
+        if (this.codebaseInfoMap.has(codebasePath)) return; // we already know about it
+        this.codebaseInfoMap.set(codebasePath, info);
+        if (info.status === 'indexed') {
+            if (!this.indexedCodebases.includes(codebasePath)) {
+                this.indexedCodebases.push(codebasePath);
+            }
+            if (info.indexedFiles !== undefined) {
+                this.codebaseFileCount.set(codebasePath, info.indexedFiles);
+            }
+        } else if (info.status === 'indexing') {
+            if (!this.indexingCodebases.has(codebasePath)) {
+                this.indexingCodebases.set(codebasePath, info.indexingPercentage || 0);
+            }
+        }
+        // indexfailed entries only need codebaseInfoMap, no extra list
+    }
+
     public saveCodebaseSnapshot(): void {
         console.log('[SNAPSHOT-DEBUG] Saving codebase snapshot to:', this.snapshotFilePath);
+
+        const locked = this.acquireLock();
+        if (!locked) {
+            console.warn('[SNAPSHOT-DEBUG] Failed to acquire lock, saving without lock');
+        }
 
         try {
             // Ensure directory exists
@@ -475,6 +530,21 @@ export class SnapshotManager {
             if (!fs.existsSync(snapshotDir)) {
                 fs.mkdirSync(snapshotDir, { recursive: true });
                 console.log('[SNAPSHOT-DEBUG] Created snapshot directory:', snapshotDir);
+            }
+
+            // Read-merge: merge entries from disk that we don't have in memory
+            try {
+                if (fs.existsSync(this.snapshotFilePath)) {
+                    const diskData = fs.readFileSync(this.snapshotFilePath, 'utf8');
+                    const diskSnapshot = JSON.parse(diskData);
+                    if (this.isV2Format(diskSnapshot)) {
+                        for (const [diskPath, diskInfo] of Object.entries(diskSnapshot.codebases)) {
+                            this.mergeExternalEntry(diskPath, diskInfo as CodebaseInfo);
+                        }
+                    }
+                }
+            } catch (mergeError) {
+                console.warn('[SNAPSHOT-DEBUG] Error reading disk snapshot for merge, continuing with in-memory state:', mergeError);
             }
 
             // Build v2 format snapshot using the complete info map
@@ -501,6 +571,10 @@ export class SnapshotManager {
 
         } catch (error: any) {
             console.error('[SNAPSHOT-DEBUG] Error saving snapshot:', error);
+        } finally {
+            if (locked) {
+                this.releaseLock();
+            }
         }
     }
 } 

--- a/packages/mcp/src/snapshot.ts
+++ b/packages/mcp/src/snapshot.ts
@@ -45,6 +45,7 @@ export class SnapshotManager {
                 console.log(`[SNAPSHOT-DEBUG] Validated codebase: ${codebasePath}`);
             } else {
                 console.warn(`[SNAPSHOT-DEBUG] Codebase no longer exists, removing: ${codebasePath}`);
+                this.recentlyRemoved.add(codebasePath);
             }
         }
 
@@ -66,6 +67,7 @@ export class SnapshotManager {
                 // Don't add to validIndexingCodebases - treat as not indexed
             } else {
                 console.warn(`[SNAPSHOT-DEBUG] Interrupted indexing codebase no longer exists: ${codebasePath}`);
+                this.recentlyRemoved.add(codebasePath);
             }
         }
 
@@ -103,6 +105,7 @@ export class SnapshotManager {
         for (const [codebasePath, info] of Object.entries(snapshot.codebases)) {
             if (!fs.existsSync(codebasePath)) {
                 console.warn(`[SNAPSHOT-DEBUG] Codebase no longer exists, removing: ${codebasePath}`);
+                this.recentlyRemoved.add(codebasePath);
                 continue;
             }
 
@@ -359,6 +362,16 @@ export class SnapshotManager {
         codebasePath: string,
         stats: { indexedFiles: number; totalChunks: number; status: 'completed' | 'limit_reached' }
     ): void {
+        // Defensive guard: 0/0 + completed is a known-bad state that causes an
+        // infinite force-reindex loop — the client reads it as "not indexed",
+        // triggers force=true, deletes real data, and rewrites 0/0. Refuse to
+        // persist this combination regardless of who called us. See Issue #295.
+        if (stats.indexedFiles === 0 && stats.totalChunks === 0 && stats.status === 'completed') {
+            console.error(`[SNAPSHOT] Refusing to write 0/0+completed for '${codebasePath}' — invalid state. Stack trace:`);
+            console.trace();
+            return;
+        }
+
         // Add to indexed list if not already there
         if (!this.indexedCodebases.includes(codebasePath)) {
             this.indexedCodebases.push(codebasePath);

--- a/packages/mcp/src/snapshot.ts
+++ b/packages/mcp/src/snapshot.ts
@@ -17,6 +17,7 @@ export class SnapshotManager {
     private indexingCodebases: Map<string, number> = new Map(); // Map of codebase path to progress percentage
     private codebaseFileCount: Map<string, number> = new Map(); // Map of codebase path to indexed file count
     private codebaseInfoMap: Map<string, CodebaseInfo> = new Map(); // Map of codebase path to complete info
+    private recentlyRemoved: Set<string> = new Set(); // Tracks codebases removed since last save
 
     constructor() {
         // Initialize snapshot file path
@@ -437,6 +438,9 @@ export class SnapshotManager {
         this.codebaseFileCount.delete(codebasePath);
         this.codebaseInfoMap.delete(codebasePath);
 
+        // Track removal so mergeExternalEntry won't re-add it from disk
+        this.recentlyRemoved.add(codebasePath);
+
         console.log(`[SNAPSHOT-DEBUG] Completely removed codebase from snapshot: ${codebasePath}`);
     }
 
@@ -500,6 +504,7 @@ export class SnapshotManager {
 
     private mergeExternalEntry(codebasePath: string, info: CodebaseInfo): void {
         if (this.codebaseInfoMap.has(codebasePath)) return; // we already know about it
+        if (this.recentlyRemoved.has(codebasePath)) return; // explicitly removed, don't re-add from disk
         this.codebaseInfoMap.set(codebasePath, info);
         if (info.status === 'indexed') {
             if (!this.indexedCodebases.includes(codebasePath)) {
@@ -562,6 +567,9 @@ export class SnapshotManager {
             };
 
             fs.writeFileSync(this.snapshotFilePath, JSON.stringify(snapshot, null, 2));
+
+            // Clear recently removed set after successful save
+            this.recentlyRemoved.clear();
 
             const indexedCount = this.indexedCodebases.length;
             const indexingCount = this.indexingCodebases.size;

--- a/packages/mcp/src/sync.ts
+++ b/packages/mcp/src/sync.ts
@@ -126,7 +126,7 @@ export class SyncManager {
                     console.log('[SYNC-DEBUG] Collection not yet established, this is expected for new cluster users. Will retry on next sync cycle.');
                 } else {
                     console.error('[SYNC-DEBUG] Initial sync failed with unexpected error:', error);
-                    throw error;
+                    // Do not re-throw here: this callback runs via setTimeout with no caller to propagate to.
                 }
             }
         }, 5000); // Initial sync after 5 seconds

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
     "displayName": "Semantic Code Search",
     "publisher": "zilliz",
     "description": "Code indexing and semantic search (built by Claude Context)",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "private": true,
     "engines": {
         "vscode": "^1.74.0"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
     "displayName": "Semantic Code Search",
     "publisher": "zilliz",
     "description": "Code indexing and semantic search (built by Claude Context)",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "private": true,
     "engines": {
         "vscode": "^1.74.0"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
     "displayName": "Semantic Code Search",
     "publisher": "zilliz",
     "description": "Code indexing and semantic search (built by Claude Context)",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "private": true,
     "engines": {
         "vscode": "^1.74.0"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
     "displayName": "Semantic Code Search",
     "publisher": "zilliz",
     "description": "Code indexing and semantic search (built by Claude Context)",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "private": true,
     "engines": {
         "vscode": "^1.74.0"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
     "displayName": "Semantic Code Search",
     "publisher": "zilliz",
     "description": "Code indexing and semantic search (built by Claude Context)",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "private": true,
     "engines": {
         "vscode": "^1.74.0"

--- a/packages/vscode-extension/src/commands/indexCommand.ts
+++ b/packages/vscode-extension/src/commands/indexCommand.ts
@@ -75,7 +75,11 @@ export class IndexCommand {
                 // Initialize file synchronizer
                 progress.report({ increment: 0, message: 'Initializing file synchronizer...' });
                 const { FileSynchronizer } = await import("@zilliz/claude-context-core");
-                const synchronizer = new FileSynchronizer(selectedFolder.uri.fsPath, this.context.getIgnorePatterns() || []);
+                const synchronizer = new FileSynchronizer(
+                    selectedFolder.uri.fsPath,
+                    this.context.getIgnorePatterns() || [],
+                    this.context.getSupportedExtensions() || []
+                );
                 await synchronizer.initialize();
                 // Store synchronizer in the context's internal map using the collection name from context
                 await this.context.getPreparedCollection(selectedFolder.uri.fsPath);

--- a/packages/vscode-extension/src/webview/scripts/semanticSearch.js
+++ b/packages/vscode-extension/src/webview/scripts/semanticSearch.js
@@ -63,9 +63,27 @@ class SemanticSearchController {
         this.settingsButton.addEventListener('click', () => this.showSettingsView());
         this.backButton.addEventListener('click', () => this.showSearchView());
 
-        this.searchInput.addEventListener('keypress', (e) => {
+        this.searchInput.addEventListener('keydown', (e) => {
             if (e.key === 'Enter') {
                 this.performSearch();
+            }
+        });
+
+        this.extFilterInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                this.performSearch();
+            }
+        });
+
+        this.resultsList.addEventListener('click', (e) => {
+            const item = e.target.closest('.result-item');
+            if (item) {
+                this.openFile(
+                    item.dataset.path,
+                    Number(item.dataset.line),
+                    Number(item.dataset.startLine),
+                    Number(item.dataset.endLine)
+                );
             }
         });
 
@@ -81,9 +99,6 @@ class SemanticSearchController {
 
         // Handle messages from extension
         window.addEventListener('message', (event) => this.handleMessage(event));
-
-        // Check index status on load
-        window.addEventListener('load', () => this.checkIndexStatus());
     }
 
     /**
@@ -134,6 +149,7 @@ class SemanticSearchController {
         // Add default providers if not already loaded
         this.initializeDefaultProviders();
         this.requestConfig();
+        setTimeout(() => this.providerSelect.focus(), 0);
     }
 
     /**
@@ -142,6 +158,7 @@ class SemanticSearchController {
     showSearchView() {
         this.settingsView.style.display = 'none';
         this.searchView.style.display = 'block';
+        setTimeout(() => this.searchInput.focus(), 0);
     }
 
     /**
@@ -214,15 +231,29 @@ class SemanticSearchController {
      * @param {number} rank - Result rank (1-indexed)
      * @returns {string} HTML string
      */
+    escapeHtml(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
     createResultHTML(result, rank) {
+        const startLine = result.startLine || result.line;
+        const endLine = result.endLine || result.line;
         return `
-            <div class="result-item" onclick="searchController.openFile('${result.relativePath}', ${result.line}, ${result.startLine}, ${result.endLine})">
+            <div class="result-item"
+                 data-path="${this.escapeHtml(result.relativePath)}"
+                 data-line="${Number(result.line) || 0}"
+                 data-start-line="${Number(startLine) || 0}"
+                 data-end-line="${Number(endLine) || 0}">
                 <div class="result-file">
-                    <span class="result-filename">${result.file}</span>
-                    <span class="result-line">Lines ${result.startLine || result.line}-${result.endLine || result.line}</span>
+                    <span class="result-filename">${this.escapeHtml(result.file)}</span>
+                    <span class="result-line">Lines ${startLine}-${endLine}</span>
                 </div>
-                <div class="result-preview">${result.preview}</div>
-                <div class="result-context">${result.context}</div>
+                <div class="result-preview">${this.escapeHtml(result.preview)}</div>
+                <div class="result-context">${this.escapeHtml(result.context)}</div>
                 <div class="result-rank" style="margin-top: 8px; text-align: right;">Rank: ${rank}</div>
             </div>
         `;


### PR DESCRIPTION
## Summary

This PR adds support for configuring the Zilliz Cloud project name via the `ZILLIZ_PROJECT_NAME` environment variable, addressing the issue where "Default Project" was previously hardcoded.

## Problem

Previously, when auto-resolving cluster addresses from a Zilliz Cloud token, the system was hardcoded to look for a project named "Default Project". This limitation prevented users from using different project names in their Zilliz Cloud accounts.

## Solution

- Added support for the `ZILLIZ_PROJECT_NAME` environment variable
- Modified `ClusterManager.getAddressFromToken()` to accept an optional project name parameter
- The system now uses the following priority:
  1. Explicit project name parameter (if provided)
  2. `ZILLIZ_PROJECT_NAME` environment variable
  3. Falls back to "Default Project" for backward compatibility
- Improved error messages to show available projects when the specified project is not found

## Changes

- **`packages/core/src/vectordb/zilliz-utils.ts`**: Updated `getAddressFromToken` method to support configurable project names
- **`packages/mcp/src/config.ts`**: Added `zillizProjectName` to configuration interface
- **`.env.example`**: Added example configuration for `ZILLIZ_PROJECT_NAME`
- **`docs/getting-started/environment-variables.md`**: Documented the new environment variable
- **`packages/mcp/README.md`**: Added configuration example for the new variable

## Testing

- Successfully built all packages with `pnpm build`
- Maintains backward compatibility - existing configurations will continue to work without any changes
- When `ZILLIZ_PROJECT_NAME` is not set, the system defaults to "Default Project" as before

## Breaking Changes

None - this change is fully backward compatible.

## Related Issues

This addresses the limitation where users couldn't specify custom project names when using Zilliz Cloud's auto-resolution feature.