### PR TITLE
fix: index branch name as well & fix incorrect file url when not `main`

### DIFF
--- a/packages/chrome-extension/src/content.ts
+++ b/packages/chrome-extension/src/content.ts
@@ -366,6 +366,7 @@ function displayResults(results: any[]) {
         const [owner, repo] = window.location.pathname.slice(1).split('/');
 
         // Format the file path to show it nicely
+        const branch = result.branch;
         const filePath = result.relativePath;
         const fileExt = filePath.split('.').pop();
 
@@ -383,7 +384,7 @@ function displayResults(results: any[]) {
                 <svg class="octicon mr-2 color-fg-muted" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
                     <path fill-rule="evenodd" d="M3.75 1.5a.25.25 0 00-.25.25v11.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25V6H9.75A1.75 1.75 0 018 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0112.25 15h-8.5A1.75 1.75 0 012 13.25V1.75z"></path>
                 </svg>
-                <a href="https://github.com/${owner}/${repo}/blob/main/${result.relativePath}#L${result.startLine}" class="Link--primary flex-auto" style="font-weight: 600;">
+                <a href="https://github.com/${owner}/${repo}/blob/${branch}/${result.relativePath}#L${result.startLine}" class="Link--primary flex-auto" style="font-weight: 600;">
                     ${result.relativePath}
                 </a>
                 <span class="Label Label--secondary ml-1">${fileExt}</span>

--- a/packages/chrome-extension/src/milvus/chromeMilvusAdapter.ts
+++ b/packages/chrome-extension/src/milvus/chromeMilvusAdapter.ts
@@ -9,6 +9,7 @@ import { MilvusRestfulVectorDatabase } from '../stubs/milvus-vectordb-stub';
 export interface CodeChunk {
     id: string;
     content: string;
+    branch: string;
     relativePath: string;
     startLine: number;
     endLine: number;
@@ -20,6 +21,7 @@ export interface CodeChunk {
 export interface SearchResult {
     id: string;
     content: string;
+    branch: string;
     relativePath: string;
     startLine: number;
     endLine: number;
@@ -113,6 +115,7 @@ export class ChromeMilvusAdapter {
             id: chunk.id,
             vector: chunk.vector || [],
             content: chunk.content,
+            branch: chunk.branch,
             relativePath: chunk.relativePath,
             startLine: chunk.startLine,
             endLine: chunk.endLine,
@@ -149,6 +152,7 @@ export class ChromeMilvusAdapter {
             const searchResults = results.map(result => ({
                 id: result.document.id,
                 content: result.document.content,
+                branch: result.document.branch,
                 relativePath: result.document.relativePath,
                 startLine: result.document.startLine,
                 endLine: result.document.endLine,

--- a/packages/chrome-extension/src/stubs/milvus-vectordb-stub.ts
+++ b/packages/chrome-extension/src/stubs/milvus-vectordb-stub.ts
@@ -6,6 +6,7 @@ export interface VectorDocument {
     id: string;
     vector: number[];
     content: string;
+    branch: string;
     relativePath: string;
     startLine: number;
     endLine: number;
@@ -142,6 +143,13 @@ export class MilvusRestfulVectorDatabase {
                             }
                         },
                         {
+                            fieldName: "branch",
+                            dataType: "VarChar",
+                            elementTypeParams: {
+                                max_length: 512
+                            }
+                        },
+                        {
                             fieldName: "relativePath",
                             dataType: "VarChar",
                             elementTypeParams: {
@@ -247,6 +255,7 @@ export class MilvusRestfulVectorDatabase {
                 id: doc.id,
                 vector: doc.vector,
                 content: doc.content,
+                branch: doc.branch,
                 relativePath: doc.relativePath,
                 startLine: doc.startLine,
                 endLine: doc.endLine,
@@ -280,6 +289,7 @@ export class MilvusRestfulVectorDatabase {
                 limit: topK,
                 outputFields: [
                     "content",
+                    "branch",
                     "relativePath",
                     "startLine",
                     "endLine",
@@ -308,6 +318,7 @@ export class MilvusRestfulVectorDatabase {
                         id: item.id?.toString() || '',
                         vector: queryVector,
                         content: item.content || '',
+                        branch: item.branch || '',
                         relativePath: item.relativePath || '',
                         startLine: item.startLine || 0,
                         endLine: item.endLine || 0,


### PR DESCRIPTION
Currently, the branch name is hard-coded as `main` in frontend side, so if index this (https://github.com/zilliztech/claude-context itself) repository and search for any word (such as `voyageai`), the URL link will return a 404 Not Found error.

Indexing branch name as well for future use like support non default branch indexing. And fix the incorrect file url as the hard-coded `main` branch name