### PR TITLE
feat(mcp): add ability to set milvus db via env and put it into milvus client config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,9 @@ MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint
 # https://github.com/zilliztech/claude-context/blob/master/assets/signup_and_get_apikey.png
 MILVUS_TOKEN=your-zilliz-cloud-api-key
 
+# Milvus database name (optional, defaults to 'default')
+MILVUS_DB=your-zilliz-cloud-database-name
+
 
 # =============================================================================
 # Code Splitter Configuration

--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -47,6 +47,7 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 |----------|-------------|---------|
 | `MILVUS_TOKEN` | Milvus authentication token. Get [Zilliz Personal API Key](https://github.com/zilliztech/claude-context/blob/master/assets/signup_and_get_apikey.png) | Recommended |
 | `MILVUS_ADDRESS` | Milvus server address. Optional when using Zilliz Personal API Key | Auto-resolved from token |
+| `MILVUS_DB` | Milvus database name to use | `default` |
 
 ### Ollama (Optional)
 | Variable | Description | Default |
@@ -74,6 +75,7 @@ EMBEDDING_PROVIDER=OpenAI
 OPENAI_API_KEY=sk-your-openai-api-key
 EMBEDDING_MODEL=text-embedding-3-small
 MILVUS_TOKEN=your-zilliz-cloud-api-key
+MILVUS_DB=default
 EOF
 ```
 

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -16,6 +16,7 @@ export interface MilvusConfig {
     username?: string;
     password?: string;
     ssl?: boolean;
+    database?: string;
 }
 
 
@@ -45,6 +46,7 @@ export class MilvusVectorDatabase implements VectorDatabase {
             username: milvusConfig.username,
             password: milvusConfig.password,
             token: milvusConfig.token,
+            database: milvusConfig.database,
             ssl: milvusConfig.ssl || false,
         });
     }

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -18,6 +18,7 @@ export interface ContextMcpConfig {
     // Vector database configuration
     milvusAddress?: string; // Optional, can be auto-resolved from token
     milvusToken?: string;
+    milvusDatabase?: string; // Optional, defaults to 'default'
 }
 
 // Legacy format (v1) - for backward compatibility
@@ -111,6 +112,7 @@ export function createMcpConfig(): ContextMcpConfig {
     console.log(`[DEBUG]   GEMINI_API_KEY: ${envManager.get('GEMINI_API_KEY') ? 'SET (length: ' + envManager.get('GEMINI_API_KEY')!.length + ')' : 'NOT SET'}`);
     console.log(`[DEBUG]   OPENAI_API_KEY: ${envManager.get('OPENAI_API_KEY') ? 'SET (length: ' + envManager.get('OPENAI_API_KEY')!.length + ')' : 'NOT SET'}`);
     console.log(`[DEBUG]   MILVUS_ADDRESS: ${envManager.get('MILVUS_ADDRESS') || 'NOT SET'}`);
+    console.log(`[DEBUG]   MILVUS_DB: ${envManager.get('MILVUS_DB') || 'NOT SET'}`);
     console.log(`[DEBUG]   NODE_ENV: ${envManager.get('NODE_ENV') || 'NOT SET'}`);
 
     const config: ContextMcpConfig = {
@@ -130,7 +132,8 @@ export function createMcpConfig(): ContextMcpConfig {
         ollamaHost: envManager.get('OLLAMA_HOST'),
         // Vector database configuration - address can be auto-resolved from token
         milvusAddress: envManager.get('MILVUS_ADDRESS'), // Optional, can be resolved from token
-        milvusToken: envManager.get('MILVUS_TOKEN')
+        milvusToken: envManager.get('MILVUS_TOKEN'),
+        milvusDatabase: envManager.get('MILVUS_DB') // Optional, defaults to 'default'
     };
 
     return config;
@@ -144,6 +147,7 @@ export function logConfigurationSummary(config: ContextMcpConfig): void {
     console.log(`[MCP]   Embedding Provider: ${config.embeddingProvider}`);
     console.log(`[MCP]   Embedding Model: ${config.embeddingModel}`);
     console.log(`[MCP]   Milvus Address: ${config.milvusAddress || (config.milvusToken ? '[Auto-resolve from token]' : '[Not configured]')}`);
+    console.log(`[MCP]   Milvus Database: ${config.milvusDatabase || 'default'}`);
 
     // Log provider-specific configuration without exposing sensitive data
     switch (config.embeddingProvider) {
@@ -202,6 +206,7 @@ Environment Variables:
   Vector Database Configuration:
   MILVUS_ADDRESS          Milvus address (optional, can be auto-resolved from token)
   MILVUS_TOKEN            Milvus token (optional, used for authentication and address resolution)
+  MILVUS_DB               Milvus database name (optional, defaults to 'default')
 
 Examples:
   # Start MCP server with OpenAI (default) and explicit Milvus address

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -62,7 +62,8 @@ class ContextMcpServer {
         // Initialize vector database
         const vectorDatabase = new MilvusVectorDatabase({
             address: config.milvusAddress,
-            ...(config.milvusToken && { token: config.milvusToken })
+            ...(config.milvusToken && { token: config.milvusToken }),
+            ...(config.milvusDatabase && { database: config.milvusDatabase })
         });
 
         // Initialize Claude Context

--- a/packages/vscode-extension/src/config/configManager.ts
+++ b/packages/vscode-extension/src/config/configManager.ts
@@ -5,6 +5,7 @@ import { OpenAIEmbedding, OpenAIEmbeddingConfig, VoyageAIEmbedding, VoyageAIEmbe
 export interface MilvusWebConfig {
     address: string;
     token?: string;
+    database?: string;
 }
 
 export type EmbeddingProviderConfig = {
@@ -297,12 +298,14 @@ export class ConfigManager {
         const config = vscode.workspace.getConfiguration(ConfigManager.CONFIG_KEY);
         const address = config.get<string>('milvus.address');
         const token = config.get<string>('milvus.token');
+        const database = config.get<string>('milvus.database');
 
         if (!address) return undefined;
 
         return {
             address,
-            token
+            token,
+            database
         };
     }
 
@@ -322,6 +325,7 @@ export class ConfigManager {
 
         await workspaceConfig.update('milvus.address', milvusConfig.address, vscode.ConfigurationTarget.Global);
         await workspaceConfig.update('milvus.token', milvusConfig.token ?? undefined, vscode.ConfigurationTarget.Global);
+        await workspaceConfig.update('milvus.database', milvusConfig.database ?? undefined, vscode.ConfigurationTarget.Global);
     }
 
     /**
@@ -335,6 +339,7 @@ export class ConfigManager {
         return {
             address: webConfig.address,
             token: webConfig.token,
+            database: webConfig.database,
             // Set default values
             ssl: webConfig.address.startsWith('https://'), // Enable SSL if https address
             // username and password are usually handled via token, so not set


### PR DESCRIPTION
Hi, zilliz team! 

At first, thank you for the perfect solution I use in day-to-day basis. Could you please take a look into my tiny improvement?

I got a need to split Milvus between my pet projects (to separated indexes for different codebases within the same Milvus instance). The new lines in my PR just use existing Milvus server client to put one environment variable with database name

Hope you will find this PR useful. Thank you!