### PR TITLE
feat(core): 添加Dart/Flutter语言支持

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
         "tree-sitter-rust": "^0.21.0",
         "tree-sitter-typescript": "^0.21.0",
         "tree-sitter-scala": "^0.24.0",
+        "tree-sitter-dart": "^1.0.0",
         "typescript": "^5.0.0",
         "voyageai": "^0.0.4"
     },

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -26,7 +26,7 @@ import { FileSynchronizer } from './sync/synchronizer';
 const DEFAULT_SUPPORTED_EXTENSIONS = [
     // Programming languages
     '.ts', '.tsx', '.js', '.jsx', '.py', '.java', '.cpp', '.c', '.h', '.hpp',
-    '.cs', '.go', '.rs', '.php', '.rb', '.swift', '.kt', '.scala', '.m', '.mm',
+    '.cs', '.go', '.rs', '.php', '.rb', '.swift', '.kt', '.scala', '.m', '.mm', '.dart',
     // Text and markup files
     '.md', '.markdown', '.ipynb',
     // '.txt',  '.json', '.yaml', '.yml', '.xml', '.html', '.htm',

--- a/packages/core/src/splitter/ast-splitter.ts
+++ b/packages/core/src/splitter/ast-splitter.ts
@@ -11,6 +11,7 @@ const Go = require('tree-sitter-go');
 const Rust = require('tree-sitter-rust');
 const CSharp = require('tree-sitter-c-sharp');
 const Scala = require('tree-sitter-scala');
+const Dart = require('tree-sitter-dart');
 
 // Node types that represent logical code units
 const SPLITTABLE_NODE_TYPES = {
@@ -22,7 +23,8 @@ const SPLITTABLE_NODE_TYPES = {
     go: ['function_declaration', 'method_declaration', 'type_declaration', 'var_declaration', 'const_declaration'],
     rust: ['function_item', 'impl_item', 'struct_item', 'enum_item', 'trait_item', 'mod_item'],
     csharp: ['method_declaration', 'class_declaration', 'interface_declaration', 'struct_declaration', 'enum_declaration'],
-    scala: ['method_declaration', 'class_declaration', 'interface_declaration', 'constructor_declaration']
+    scala: ['method_declaration', 'class_declaration', 'interface_declaration', 'constructor_declaration'],
+    dart: ['function_signature', 'class_definition', 'method_signature', 'constructor_signature', 'getter_signature', 'setter_signature', 'function_body']
 };
 
 export class AstCodeSplitter implements Splitter {
@@ -100,7 +102,8 @@ export class AstCodeSplitter implements Splitter {
             'rs': { parser: Rust, nodeTypes: SPLITTABLE_NODE_TYPES.rust },
             'cs': { parser: CSharp, nodeTypes: SPLITTABLE_NODE_TYPES.csharp },
             'csharp': { parser: CSharp, nodeTypes: SPLITTABLE_NODE_TYPES.csharp },
-            'scala': { parser: Scala, nodeTypes: SPLITTABLE_NODE_TYPES.scala }
+            'scala': { parser: Scala, nodeTypes: SPLITTABLE_NODE_TYPES.scala },
+            'dart': { parser: Dart, nodeTypes: SPLITTABLE_NODE_TYPES.dart }
         };
 
         return langMap[language.toLowerCase()] || null;
@@ -263,7 +266,8 @@ export class AstCodeSplitter implements Splitter {
     static isLanguageSupported(language: string): boolean {
         const supportedLanguages = [
             'javascript', 'js', 'typescript', 'ts', 'python', 'py',
-            'java', 'cpp', 'c++', 'c', 'go', 'rust', 'rs', 'cs', 'csharp', 'scala'
+            'java', 'cpp', 'c++', 'c', 'go', 'rust', 'rs', 'cs', 'csharp', 'scala',
+            'dart'
         ];
         return supportedLanguages.includes(language.toLowerCase());
     }


### PR DESCRIPTION
嗨，zilliz团队！

首先 非常感谢您提供的完美解决方案 我每天都在用 让Claude code变得了和cursor一样 更加智能

我希望在Flutter项目中也能使用语义搜索 所以我修改了代码来支持dart语言 下面是做的改动

  - 添加 tree-sitter-dart 依赖用于 AST 解析
  - 在 ast-splitter.ts 中添加 Dart 语言配置
  - 在默认支持的扩展名中添加 .dart

希望您觉得这个PR有用。能合并更新，谢谢！