### PR TITLE
fix: sync cloud codebases to local snapshot after MCP restart

### DIFF
--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -124,8 +124,20 @@ export class ToolHandlers {
                 }
             }
 
-            // Note: We don't add cloud codebases that are missing locally (as per user requirement)
-            console.log(`[SYNC-CLOUD] ℹ️  Skipping addition of cloud codebases not present locally (per sync policy)`);
+            // Add cloud codebases that are missing locally - this fixes the issue where
+            // after MCP server restart, the local snapshot is empty but data exists in Milvus
+            for (const cloudCodebase of cloudCodebases) {
+                if (!localCodebases.has(cloudCodebase)) {
+                    // Add to snapshot - data exists in cloud
+                    this.snapshotManager.setCodebaseIndexed(cloudCodebase, {
+                        indexedFiles: 0,  // Stats unknown from cloud query
+                        totalChunks: 0,   // Will show in status as 0 until re-indexed
+                        status: 'completed'
+                    });
+                    hasChanges = true;
+                    console.log(`[SYNC-CLOUD] ➕ Added cloud codebase to local snapshot: ${cloudCodebase}`);
+                }
+            }
 
             if (hasChanges) {
                 this.snapshotManager.saveCodebaseSnapshot();


### PR DESCRIPTION
# Fix: Sync cloud codebases to local snapshot after MCP restart

## Problem

After an MCP server restart, semantic search fails with "Codebase is not indexed" error, even though the indexed data exists in Milvus.

### Steps to Reproduce

1. Index a codebase using `index_codebase` tool
2. Verify indexing completes successfully (data is stored in Milvus)
3. Restart Claude Code session (which restarts the MCP server)
4. Run `get_indexing_status` → Shows "fully indexed and ready"
5. Run `search_code` → **Fails with "not indexed" error**
6. Run `clear_index` → Shows "No codebases are currently indexed"

### Root Cause

The `syncIndexedCodebasesFromCloud()` function in `handlers.ts` (lines 127-128):

```typescript
// Note: We don't add cloud codebases that are missing locally (as per user requirement)
console.log(`[SYNC-CLOUD] ℹ️  Skipping addition of cloud codebases not present locally (per sync policy)`);
```

**This "sync policy" prevents re-hydrating the local snapshot from Milvus data after restarts.**

The sync process:
1. ✅ Finds collections in Milvus (e.g., `hybrid_code_chunks_b0ad15bc`)
2. ✅ Extracts codebase paths from collection metadata
3. ❌ **Skips adding them to local snapshot** (`~/.context/mcp-codebase-snapshot.json`)
4. ❌ `getIndexedCodebases()` returns empty array
5. ❌ Search fails with "not indexed"

### Why This Happens

- `get_indexing_status` queries Milvus directly → finds collections → reports "indexed"
- `search_code` checks local snapshot → finds nothing → reports "not indexed"
- The two data sources are out of sync after MCP restart

## Solution

Sync cloud codebases **to** the local snapshot when missing locally. This preserves indexed data across MCP server restarts.

### Changes

**File:** `packages/mcp/src/handlers.ts`

Replace the skip logic with:

```typescript
// Add cloud codebases that are missing locally - this fixes the issue where
// after MCP server restart, the local snapshot is empty but data exists in Milvus
for (const cloudCodebase of cloudCodebases) {
    if (!localCodebases.has(cloudCodebase)) {
        // Add to snapshot - data exists in cloud
        this.snapshotManager.setCodebaseIndexed(cloudCodebase, {
            indexedFiles: 0,  // Stats unknown from cloud query
            totalChunks: 0,   // Will show in status as 0 until re-indexed
            status: 'completed'
        });
        hasChanges = true;
        console.log(`[SYNC-CLOUD] ➕ Added cloud codebase to local snapshot: ${cloudCodebase}`);
    }
}
```

### Benefits

1. ✅ Semantic search works immediately after MCP restart
2. ✅ No need to re-index (expensive: embeddings + API costs)
3. ✅ Existing vector embeddings in Milvus remain accessible
4. ✅ Stats show as 0 until re-indexed (accurate - unknown from cloud query)
5. ✅ User can optionally re-index to get accurate file/chunk counts

## Testing

### Before Fix

```bash
# Index codebase
/index-start
✅ Indexing completed: 710 files, 5450 chunks

# Restart Claude Code
exit
claude

# Try to search
/search-code "dependency injection"
❌ Error: Codebase is not indexed
```

### After Fix

```bash
# Index codebase
/index-start
✅ Indexing completed: 710 files, 5450 chunks

# Restart Claude Code
exit
claude

# Try to search
/search-code "dependency injection"
✅ Found 10 results for query...
```

## Verification

The fix was tested with:
- **Milvus**: v2.6.7 (local deployment at `127.0.0.1:19530`)
- **Embedding**: Voyage AI `voyage-code-2`
- **MCP Server**: `@zilliz/claude-context-mcp@latest`
- **Codebase**: 710 files, 5450 chunks (C# .NET project)

Verified that:
1. Collection exists in Milvus: `hybrid_code_chunks_b0ad15bc`
2. Collection hash matches codebase path
3. After MCP restart with fix, search works without re-indexing

## Impact

- **Breaking Changes**: None
- **Backward Compatibility**: Fully compatible
- **Migration**: Automatic on next MCP restart

## Alternative Considered

**Force re-index on every restart**: Rejected because:
- Expensive: Re-generates embeddings (Voyage AI API costs)
- Slow: AST parsing + embedding generation takes time
- Wasteful: Vector data already exists in Milvus

The fix reuses existing embeddings, making restarts instant.
