### PR TITLE
fix(vscode-extension): add explicit types for progressInfo parameters

### DIFF
--- a/packages/vscode-extension/src/commands/indexCommand.ts
+++ b/packages/vscode-extension/src/commands/indexCommand.ts
@@ -2,6 +2,14 @@ import * as vscode from 'vscode';
 import { Context } from '@zilliz/claude-context-core';
 import * as path from 'path';
 
+/** Progress callback parameter type */
+interface ProgressInfo {
+    phase: string;
+    current: number;
+    total: number;
+    percentage: number;
+}
+
 export class IndexCommand {
     private context: Context;
 
@@ -66,7 +74,7 @@ export class IndexCommand {
                 // Clear existing index first
                 await this.context.clearIndex(
                     selectedFolder.uri.fsPath,
-                    (progressInfo) => {
+                    (progressInfo: ProgressInfo) => {
                         // Clear index progress is usually fast, just show the message
                         progress.report({ increment: 0, message: progressInfo.phase });
                     }
@@ -85,7 +93,7 @@ export class IndexCommand {
                 // Start indexing with progress callback
                 indexStats = await this.context.indexCodebase(
                     selectedFolder.uri.fsPath,
-                    (progressInfo) => {
+                    (progressInfo: ProgressInfo) => {
                         // Calculate increment from last reported percentage
                         const increment = progressInfo.percentage - lastPercentage;
                         lastPercentage = progressInfo.percentage;
@@ -156,7 +164,7 @@ export class IndexCommand {
             }, async (progress) => {
                 await this.context.clearIndex(
                     workspaceFolders[0].uri.fsPath,
-                    (progressInfo) => {
+                    (progressInfo: ProgressInfo) => {
                         progress.report({
                             increment: progressInfo.percentage,
                             message: progressInfo.phase

--- a/packages/vscode-extension/src/commands/syncCommand.ts
+++ b/packages/vscode-extension/src/commands/syncCommand.ts
@@ -2,6 +2,14 @@ import * as vscode from 'vscode';
 import { Context } from '@zilliz/claude-context-core';
 import * as fs from 'fs';
 
+/** Progress callback parameter type */
+interface ProgressInfo {
+    phase: string;
+    current: number;
+    total: number;
+    percentage: number;
+}
+
 export class SyncCommand {
     private context: Context;
     private isSyncing: boolean = false;
@@ -59,7 +67,7 @@ export class SyncCommand {
                 try {
                     syncStats = await this.context.reindexByChange(
                         codebasePath,
-                        (progressInfo) => {
+                        (progressInfo: ProgressInfo) => {
                             const increment = progressInfo.percentage;
                             progress.report({
                                 increment: increment,


### PR DESCRIPTION
- Add ProgressInfo interface to indexCommand.ts and syncCommand.ts
- Fix TS7006 errors for implicit 'any' type on callback parameters
- All typecheck now passes
- 
  ## Summary
  Fix TypeScript strict mode errors (TS7006) in vscode-extension package.

  ## Changes
  - Add `ProgressInfo` interface to `indexCommand.ts` and `syncCommand.ts`
  - Add explicit types for all `progressInfo` callback parameters
  - All typecheck now passes

  ## Files Changed
  - `packages/vscode-extension/src/commands/indexCommand.ts`
  - `packages/vscode-extension/src/commands/syncCommand.ts`

  ## Testing
  - `pnpm -r run typecheck` passes for all packages
