### PR TITLE
feat(core): make chunk limit configurable via CHUNK_LIMIT environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ EMBEDDING_MODEL=text-embedding-3-small
 # You can customize it according to the throughput of your embedding model. Generally, larger batch size means less indexing time.
 EMBEDDING_BATCH_SIZE=100
 
+# Maximum number of chunks to process during indexing (default: 450000)
+# CHUNK_LIMIT=450000
+
 # =============================================================================
 # OpenAI Configuration
 # =============================================================================

--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -60,6 +60,7 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 |----------|-------------|---------|
 | `HYBRID_MODE` | Enable hybrid search (BM25 + dense vector). Set to `false` for dense-only search | `true` |
 | `EMBEDDING_BATCH_SIZE` | Batch size for processing. Larger batch size means less indexing time | `100` |
+| `CHUNK_LIMIT` | Maximum number of chunks to process during indexing | `450000` |
 | `SPLITTER_TYPE` | Code splitter type: `ast`, `langchain` | `ast` |
 | `CUSTOM_EXTENSIONS` | Additional file extensions to include (comma-separated, e.g., `.vue,.svelte,.astro`) | None |
 | `CUSTOM_IGNORE_PATTERNS` | Additional ignore patterns (comma-separated, e.g., `temp/**,*.backup,private/**`) | None |

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -702,8 +702,9 @@ export class Context {
     ): Promise<{ processedFiles: number; totalChunks: number; status: 'completed' | 'limit_reached' }> {
         const isHybrid = this.getIsHybrid();
         const EMBEDDING_BATCH_SIZE = Math.max(1, parseInt(envManager.get('EMBEDDING_BATCH_SIZE') || '100', 10));
-        const CHUNK_LIMIT = 450000;
+        const CHUNK_LIMIT = Math.max(1, parseInt(envManager.get('CHUNK_LIMIT') || '450000', 10));
         console.log(`[Context] 🔧 Using EMBEDDING_BATCH_SIZE: ${EMBEDDING_BATCH_SIZE}`);
+        console.log(`[Context] 🔧 Using CHUNK_LIMIT: ${CHUNK_LIMIT}`);
 
         let chunkBuffer: Array<{ chunk: CodeChunk; codebasePath: string }> = [];
         let processedFiles = 0;

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -203,6 +203,12 @@ Environment Variables:
   MILVUS_ADDRESS          Milvus address (optional, can be auto-resolved from token)
   MILVUS_TOKEN            Milvus token (optional, used for authentication and address resolution)
 
+  Advanced Configuration:
+  EMBEDDING_BATCH_SIZE    Batch size for processing (default: 100)
+  CHUNK_LIMIT             Maximum number of chunks to process during indexing (default: 450000)
+  HYBRID_MODE             Enable hybrid search (default: true)
+  SPLITTER_TYPE           Code splitter type: ast, langchain (default: ast)
+
 Examples:
   # Start MCP server with OpenAI (default) and explicit Milvus address
   OPENAI_API_KEY=sk-xxx MILVUS_ADDRESS=localhost:19530 npx @zilliz/claude-context-mcp@latest


### PR DESCRIPTION
## Summary
Makes the hardcoded chunk limit of 450,000 configurable through the `CHUNK_LIMIT` environment variable, following the same pattern as other configuration options like `EMBEDDING_BATCH_SIZE`.

## Motivation
The chunk limit was previously hardcoded at 450,000, which limited flexibility for different use cases. Users with larger codebases or different performance requirements can now configure this value to suit their needs.

## Changes
- ✅ Read `CHUNK_LIMIT` from environment variable with default of 450000
- ✅ Add validation to ensure minimum value of 1
- ✅ Add logging to display configured chunk limit value
- ✅ Update `docs/getting-started/environment-variables.md` with new variable
- ✅ Add `CHUNK_LIMIT` to `.env.example`
- ✅ Update MCP help message with advanced configuration section

## Usage Examples
**Global configuration** (`~/.context/.env`):
\`\`\`bash
CHUNK_LIMIT=1000000
\`\`\`

**Process environment variable**:
\`\`\`bash
CHUNK_LIMIT=1000000 npx @zilliz/claude-context-mcp@latest
\`\`\`

**Default behavior** (no configuration):
- Falls back to 450000 (maintains backward compatibility)

## Testing
- [x] Follows the same pattern as `EMBEDDING_BATCH_SIZE`
- [x] Backward compatible (defaults to 450000)
- [x] Input validation (minimum value of 1)
- [x] Logging added for debugging

## Checklist
- [x] Follows conventional commit format
- [x] Documentation updated
- [x] No breaking changes
- [x] Consistent with existing codebase patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)