### PR TITLE
fix(mcp): handle non-string metadata in cloud sync handler

### DIFF
--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -83,7 +83,7 @@ export class ToolHandlers {
 
                         if (metadataStr) {
                             try {
-                                const metadata = JSON.parse(metadataStr);
+                                const metadata = typeof metadataStr === 'string' ? JSON.parse(metadataStr) : metadataStr;
                                 const codebasePath = metadata.codebasePath;
 
                                 if (codebasePath && typeof codebasePath === 'string') {


### PR DESCRIPTION
## Summary

- The cloud sync handler queries a collection for its first document's metadata to extract the `codebasePath`
- Depending on the vector DB backend, `metadata` may already be a parsed JS object rather than a JSON string
- `JSON.parse()` is called unconditionally on line 86, which throws when the value is not a string
- The catch block logs a warning and the codebase path never registers, so `search_code` reports "codebase not indexed" even after successful indexing

## Fix

Add a type guard to only parse when metadata is actually a string:

```ts
const metadata = typeof metadataStr === 'string' ? JSON.parse(metadataStr) : metadataStr;
```

Fixes #226