### PR TITLE
feat: add MiniMax as embedding provider (embo-01, 1536 dims)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 # Embedding Provider Configuration
 # =============================================================================
 
-# Embedding provider: OpenAI, VoyageAI, Gemini, Ollama
+# Embedding provider: OpenAI, VoyageAI, Gemini, Ollama, MiniMax
 EMBEDDING_PROVIDER=OpenAI
 
 # Embedding model (provider-specific)
@@ -46,6 +46,16 @@ OPENAI_API_KEY=your-openai-api-key-here
 
 # Gemini API base URL (optional, for custom endpoints)
 # GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta
+
+# =============================================================================
+# MiniMax Configuration
+# =============================================================================
+
+# MiniMax API key
+# MINIMAX_API_KEY=your-minimax-api-key-here
+
+# MiniMax API base URL (optional, default: https://api.minimax.io/v1)
+# MINIMAX_BASE_URL=https://api.minimax.io/v1
 
 # =============================================================================
 # Ollama Configuration

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Claude Context is a monorepo containing three main packages:
 
 ### Supported Technologies
 
-- **Embedding Providers**: [OpenAI](https://openai.com), [VoyageAI](https://voyageai.com), [Ollama](https://ollama.ai), [Gemini](https://gemini.google.com)
+- **Embedding Providers**: [OpenAI](https://openai.com), [VoyageAI](https://voyageai.com), [Ollama](https://ollama.ai), [Gemini](https://gemini.google.com), [MiniMax](https://platform.minimaxi.com/)
 - **Vector Databases**: [Milvus](https://milvus.io) or [Zilliz Cloud](https://zilliz.com/cloud)(fully managed vector database as a service)
 - **Code Splitters**: AST-based splitter (with automatic fallback), LangChain character-based splitter
 - **Languages**: TypeScript, JavaScript, Python, Java, C++, C#, Go, Rust, PHP, Ruby, Swift, Kotlin, Scala, Markdown

--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -20,13 +20,15 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 ### Embedding Provider
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `EMBEDDING_PROVIDER` | Provider: `OpenAI`, `VoyageAI`, `Gemini`, `Ollama` | `OpenAI` |
+| `EMBEDDING_PROVIDER` | Provider: `OpenAI`, `VoyageAI`, `Gemini`, `Ollama`, `MiniMax` | `OpenAI` |
 | `EMBEDDING_MODEL` | Embedding model name (works for all providers) | Provider-specific default |
 | `OPENAI_API_KEY` | OpenAI API key | Required for OpenAI |
 | `OPENAI_BASE_URL` | OpenAI API base URL (optional, for custom endpoints) | `https://api.openai.com/v1` |
 | `VOYAGEAI_API_KEY` | VoyageAI API key | Required for VoyageAI |
 | `GEMINI_API_KEY` | Gemini API key | Required for Gemini |
 | `GEMINI_BASE_URL` | Gemini API base URL (optional, for custom endpoints) | `https://generativelanguage.googleapis.com/v1beta` |
+| `MINIMAX_API_KEY` | MiniMax API key | Required for MiniMax |
+| `MINIMAX_BASE_URL` | MiniMax API base URL (optional, for custom endpoints) | `https://api.minimax.io/v1` |
 
 > **💡 Note:** `EMBEDDING_MODEL` is a universal environment variable that works with all embedding providers. Simply set it to the model name you want to use (e.g., `text-embedding-3-large` for OpenAI, `voyage-code-3` for VoyageAI, etc.).
 
@@ -38,6 +40,8 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 > 
 > - Gemini Models: See `getSupportedModels` in [`gemini-embedding.ts`](https://github.com/zilliztech/claude-context/blob/master/packages/core/src/embedding/gemini-embedding.ts) for the full list of supported models.
 > 
+> - MiniMax Models: See `getSupportedModels` in [`minimax-embedding.ts`](https://github.com/zilliztech/claude-context/blob/master/packages/core/src/embedding/minimax-embedding.ts) for the full list of supported models.
+>
 > - Ollama Models: Depends on the model you install locally.
 
 > **📖 For detailed provider-specific configuration examples and setup instructions, see the [MCP Configuration Guide](../../packages/mcp/README.md#embedding-provider-configuration).**

--- a/packages/core/src/embedding/__tests__/minimax-embedding.integration.test.ts
+++ b/packages/core/src/embedding/__tests__/minimax-embedding.integration.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Integration tests for MiniMax embedding provider.
+ * These tests require a valid MINIMAX_API_KEY environment variable.
+ * Run with: MINIMAX_API_KEY=your-key npx jest minimax-embedding.integration
+ *
+ * Note: MiniMax has strict RPM limits on the embedding API.
+ * Tests include delays to avoid rate limiting.
+ */
+import { MiniMaxEmbedding } from '../minimax-embedding';
+
+const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
+
+const describeIfApiKey = MINIMAX_API_KEY ? describe : describe.skip;
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describeIfApiKey('MiniMaxEmbedding Integration Tests', () => {
+    let embedding: MiniMaxEmbedding;
+
+    beforeAll(() => {
+        embedding = new MiniMaxEmbedding({
+            apiKey: MINIMAX_API_KEY!,
+        });
+    });
+
+    afterEach(async () => {
+        // Delay between tests to avoid RPM rate limiting (MiniMax has strict RPM limits)
+        await delay(12000);
+    }, 15000);
+
+    it('should detect dimension correctly', async () => {
+        const dim = await embedding.detectDimension();
+        expect(dim).toBe(1536);
+    }, 30000);
+
+    it('should embed a single text and return 1536-dimension vector', async () => {
+        const result = await embedding.embed('Hello, world!');
+        expect(result.vector).toHaveLength(1536);
+        expect(result.dimension).toBe(1536);
+        expect(result.vector.every(v => typeof v === 'number')).toBe(true);
+    }, 30000);
+
+    it('should embed batch of texts', async () => {
+        const texts = ['TypeScript class', 'Python function', 'Go struct'];
+        const results = await embedding.embedBatch(texts);
+        expect(results).toHaveLength(3);
+        results.forEach(r => {
+            expect(r.vector).toHaveLength(1536);
+            expect(r.dimension).toBe(1536);
+        });
+    }, 30000);
+});

--- a/packages/core/src/embedding/__tests__/minimax-embedding.test.ts
+++ b/packages/core/src/embedding/__tests__/minimax-embedding.test.ts
@@ -1,0 +1,300 @@
+import { MiniMaxEmbedding, MiniMaxEmbeddingConfig } from '../minimax-embedding';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+describe('MiniMaxEmbedding', () => {
+    const defaultConfig: MiniMaxEmbeddingConfig = {
+        apiKey: 'test-api-key',
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('constructor', () => {
+        it('should create instance with default config', () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+            expect(embedding.getProvider()).toBe('MiniMax');
+            expect(embedding.getDimension()).toBe(1536);
+        });
+
+        it('should accept custom model', () => {
+            const embedding = new MiniMaxEmbedding({
+                ...defaultConfig,
+                model: 'embo-01',
+            });
+            expect(embedding.getDimension()).toBe(1536);
+        });
+
+        it('should accept custom baseURL', () => {
+            const embedding = new MiniMaxEmbedding({
+                ...defaultConfig,
+                baseURL: 'https://custom-api.example.com/v1',
+            });
+            expect(embedding.getProvider()).toBe('MiniMax');
+        });
+    });
+
+    describe('getSupportedModels', () => {
+        it('should return supported models', () => {
+            const models = MiniMaxEmbedding.getSupportedModels();
+            expect(models).toHaveProperty('embo-01');
+            expect(models['embo-01'].dimension).toBe(1536);
+            expect(models['embo-01'].description).toBeDefined();
+        });
+    });
+
+    describe('getDimension', () => {
+        it('should return 1536 for embo-01', () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+            expect(embedding.getDimension()).toBe(1536);
+        });
+    });
+
+    describe('detectDimension', () => {
+        it('should return known dimension for embo-01', async () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+            const dim = await embedding.detectDimension();
+            expect(dim).toBe(1536);
+        });
+
+        it('should call API for unknown model', async () => {
+            const embedding = new MiniMaxEmbedding({
+                ...defaultConfig,
+                model: 'unknown-model',
+            });
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    vectors: [new Array(2048).fill(0.1)],
+                    total_tokens: 5,
+                    base_resp: { status_code: 0, status_msg: 'success' },
+                }),
+            });
+
+            const dim = await embedding.detectDimension('test');
+            expect(dim).toBe(2048);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('should throw on API error', async () => {
+            const embedding = new MiniMaxEmbedding({
+                ...defaultConfig,
+                model: 'unknown-model',
+            });
+
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                text: async () => 'Unauthorized',
+            });
+
+            await expect(embedding.detectDimension('test')).rejects.toThrow(
+                'Failed to detect dimension'
+            );
+        });
+    });
+
+    describe('embed', () => {
+        it('should embed single text', async () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+            const vector = new Array(1536).fill(0.1);
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    vectors: [vector],
+                    total_tokens: 10,
+                    base_resp: { status_code: 0, status_msg: 'success' },
+                }),
+            });
+
+            const result = await embedding.embed('hello world');
+            expect(result.vector).toEqual(vector);
+            expect(result.dimension).toBe(1536);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+
+            // Verify request body
+            const callArgs = mockFetch.mock.calls[0];
+            const body = JSON.parse(callArgs[1].body);
+            expect(body.model).toBe('embo-01');
+            expect(body.texts).toEqual(['hello world']);
+            expect(body.type).toBe('db');
+        });
+
+        it('should send Authorization header', async () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    vectors: [new Array(1536).fill(0)],
+                    total_tokens: 5,
+                    base_resp: { status_code: 0, status_msg: 'success' },
+                }),
+            });
+
+            await embedding.embed('test');
+            const callArgs = mockFetch.mock.calls[0];
+            expect(callArgs[1].headers['Authorization']).toBe('Bearer test-api-key');
+        });
+
+        it('should use custom baseURL', async () => {
+            const embedding = new MiniMaxEmbedding({
+                ...defaultConfig,
+                baseURL: 'https://custom.example.com/v1',
+            });
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    vectors: [new Array(1536).fill(0)],
+                    total_tokens: 5,
+                    base_resp: { status_code: 0, status_msg: 'success' },
+                }),
+            });
+
+            await embedding.embed('test');
+            const callArgs = mockFetch.mock.calls[0];
+            expect(callArgs[0]).toBe('https://custom.example.com/v1/embeddings');
+        });
+
+        it('should throw on HTTP error', async () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 500,
+                text: async () => 'Internal Server Error',
+            });
+
+            await expect(embedding.embed('test')).rejects.toThrow(
+                'Failed to generate MiniMax embedding'
+            );
+        });
+
+        it('should throw on API-level error', async () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    vectors: [],
+                    total_tokens: 0,
+                    base_resp: { status_code: 1001, status_msg: 'Invalid API key' },
+                }),
+            });
+
+            await expect(embedding.embed('test')).rejects.toThrow('Invalid API key');
+        });
+
+        it('should preprocess empty text', async () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    vectors: [new Array(1536).fill(0)],
+                    total_tokens: 1,
+                    base_resp: { status_code: 0, status_msg: 'success' },
+                }),
+            });
+
+            await embedding.embed('');
+            const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+            expect(body.texts).toEqual([' ']); // Empty string replaced with space
+        });
+    });
+
+    describe('embedBatch', () => {
+        it('should embed multiple texts', async () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+            const vectors = [
+                new Array(1536).fill(0.1),
+                new Array(1536).fill(0.2),
+                new Array(1536).fill(0.3),
+            ];
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    vectors,
+                    total_tokens: 30,
+                    base_resp: { status_code: 0, status_msg: 'success' },
+                }),
+            });
+
+            const results = await embedding.embedBatch(['hello', 'world', 'test']);
+            expect(results).toHaveLength(3);
+            expect(results[0].vector).toEqual(vectors[0]);
+            expect(results[1].vector).toEqual(vectors[1]);
+            expect(results[2].vector).toEqual(vectors[2]);
+            results.forEach(r => expect(r.dimension).toBe(1536));
+
+            // Verify all texts sent in single request
+            const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+            expect(body.texts).toEqual(['hello', 'world', 'test']);
+        });
+
+        it('should throw on batch error', async () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 429,
+                text: async () => 'Rate limit exceeded',
+            });
+
+            await expect(
+                embedding.embedBatch(['hello', 'world'])
+            ).rejects.toThrow('Failed to generate MiniMax batch embeddings');
+        });
+    });
+
+    describe('setType', () => {
+        it('should change embedding type to query', async () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+            embedding.setType('query');
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    vectors: [new Array(1536).fill(0)],
+                    total_tokens: 5,
+                    base_resp: { status_code: 0, status_msg: 'success' },
+                }),
+            });
+
+            await embedding.embed('search query');
+            const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+            expect(body.type).toBe('query');
+        });
+    });
+
+    describe('setModel', () => {
+        it('should update model and dimension for known model', async () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+            await embedding.setModel('embo-01');
+            expect(embedding.getDimension()).toBe(1536);
+        });
+
+        it('should detect dimension for unknown model', async () => {
+            const embedding = new MiniMaxEmbedding(defaultConfig);
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    vectors: [new Array(768).fill(0)],
+                    total_tokens: 5,
+                    base_resp: { status_code: 0, status_msg: 'success' },
+                }),
+            });
+
+            await embedding.setModel('custom-model');
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/packages/core/src/embedding/index.ts
+++ b/packages/core/src/embedding/index.ts
@@ -5,4 +5,5 @@ export * from './base-embedding';
 export * from './openai-embedding';
 export * from './voyageai-embedding';
 export * from './ollama-embedding';
-export * from './gemini-embedding'; 
+export * from './gemini-embedding';
+export * from './minimax-embedding';

--- a/packages/core/src/embedding/minimax-embedding.ts
+++ b/packages/core/src/embedding/minimax-embedding.ts
@@ -1,0 +1,166 @@
+import { Embedding, EmbeddingVector } from './base-embedding';
+
+export interface MiniMaxEmbeddingConfig {
+    apiKey: string;
+    model?: string;
+    baseURL?: string;
+    /** Embedding type: 'db' for storage/indexing, 'query' for search queries */
+    type?: 'db' | 'query';
+}
+
+interface MiniMaxEmbeddingResponse {
+    vectors: number[][];
+    total_tokens: number;
+    base_resp: {
+        status_code: number;
+        status_msg: string;
+    };
+}
+
+export class MiniMaxEmbedding extends Embedding {
+    private config: MiniMaxEmbeddingConfig;
+    private dimension: number = 1536; // embo-01 outputs 1536 dimensions
+    protected maxTokens: number = 4096; // MiniMax embedding token limit
+
+    constructor(config: MiniMaxEmbeddingConfig) {
+        super();
+        this.config = {
+            model: 'embo-01',
+            baseURL: 'https://api.minimax.io/v1',
+            type: 'db',
+            ...config,
+        };
+    }
+
+    async detectDimension(testText: string = "test"): Promise<number> {
+        const model = this.config.model || 'embo-01';
+        const knownModels = MiniMaxEmbedding.getSupportedModels();
+
+        if (knownModels[model]) {
+            return knownModels[model].dimension;
+        }
+
+        // For unknown models, make API call to detect dimension
+        try {
+            const processedText = this.preprocessText(testText);
+            const response = await this.callApi([processedText]);
+            return response.vectors[0].length;
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to detect dimension for model ${model}: ${errorMessage}`);
+        }
+    }
+
+    async embed(text: string): Promise<EmbeddingVector> {
+        const processedText = this.preprocessText(text);
+
+        try {
+            const response = await this.callApi([processedText]);
+            this.dimension = response.vectors[0].length;
+
+            return {
+                vector: response.vectors[0],
+                dimension: this.dimension
+            };
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to generate MiniMax embedding: ${errorMessage}`);
+        }
+    }
+
+    async embedBatch(texts: string[]): Promise<EmbeddingVector[]> {
+        const processedTexts = this.preprocessTexts(texts);
+
+        try {
+            const response = await this.callApi(processedTexts);
+            this.dimension = response.vectors[0].length;
+
+            return response.vectors.map((vector) => ({
+                vector,
+                dimension: this.dimension
+            }));
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Failed to generate MiniMax batch embeddings: ${errorMessage}`);
+        }
+    }
+
+    getDimension(): number {
+        const model = this.config.model || 'embo-01';
+        const knownModels = MiniMaxEmbedding.getSupportedModels();
+
+        if (knownModels[model]) {
+            return knownModels[model].dimension;
+        }
+
+        return this.dimension;
+    }
+
+    getProvider(): string {
+        return 'MiniMax';
+    }
+
+    /**
+     * Set model type
+     * @param model Model name
+     */
+    async setModel(model: string): Promise<void> {
+        this.config.model = model;
+        const knownModels = MiniMaxEmbedding.getSupportedModels();
+        if (knownModels[model]) {
+            this.dimension = knownModels[model].dimension;
+        } else {
+            this.dimension = await this.detectDimension();
+        }
+    }
+
+    /**
+     * Set embedding type
+     * @param type 'db' for storage/indexing, 'query' for search queries
+     */
+    setType(type: 'db' | 'query'): void {
+        this.config.type = type;
+    }
+
+    /**
+     * Get list of supported models
+     */
+    static getSupportedModels(): Record<string, { dimension: number; description: string }> {
+        return {
+            'embo-01': {
+                dimension: 1536,
+                description: 'MiniMax general-purpose embedding model (1536 dimensions)'
+            }
+        };
+    }
+
+    private async callApi(texts: string[]): Promise<MiniMaxEmbeddingResponse> {
+        const url = `${this.config.baseURL}/embeddings`;
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${this.config.apiKey}`,
+            },
+            body: JSON.stringify({
+                model: this.config.model || 'embo-01',
+                texts,
+                type: this.config.type || 'db',
+            }),
+        });
+
+        if (!response.ok) {
+            const errorBody = await response.text();
+            throw new Error(`MiniMax API error (${response.status}): ${errorBody}`);
+        }
+
+        const data = await response.json() as MiniMaxEmbeddingResponse;
+
+        if (data.base_resp && data.base_resp.status_code !== 0) {
+            throw new Error(`MiniMax API error: ${data.base_resp.status_msg}`);
+        }
+
+        return data;
+    }
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -20,7 +20,7 @@ Model Context Protocol (MCP) allows you to integrate Claude Context with your fa
 
 Before using the MCP server, make sure you have:
 
-- API key for your chosen embedding provider (OpenAI, VoyageAI, Gemini, or Ollama setup)
+- API key for your chosen embedding provider (OpenAI, VoyageAI, Gemini, MiniMax, or Ollama setup)
 - Milvus vector database (local or cloud)
 
 > 💡 **Setup Help:** See the [main project setup guide](../../README.md#-quick-start) for detailed installation instructions.
@@ -34,7 +34,7 @@ Claude Context MCP supports multiple embedding providers. Choose the one that be
 > 📋 **Quick Reference**: For a complete list of environment variables and their descriptions, see the [Environment Variables Guide](../../docs/getting-started/environment-variables.md).
 
 ```bash
-# Supported providers: OpenAI, VoyageAI, Gemini, Ollama
+# Supported providers: OpenAI, VoyageAI, Gemini, Ollama, MiniMax
 EMBEDDING_PROVIDER=OpenAI
 ```
 
@@ -120,7 +120,35 @@ See `getSupportedModels` in [`gemini-embedding.ts`](https://github.com/zilliztec
 </details>
 
 <details>
-<summary><strong>4. Ollama Configuration (Local/Self-hosted)</strong></summary>
+<summary><strong>4. MiniMax Configuration</strong></summary>
+
+MiniMax provides the embo-01 embedding model with 1536 dimensions, suitable for general-purpose text and code embedding.
+
+```bash
+# Required: Your MiniMax API key
+MINIMAX_API_KEY=your-minimax-api-key
+
+# Optional: Specify embedding model (default: embo-01)
+EMBEDDING_MODEL=embo-01
+
+# Optional: Custom API base URL (default: https://api.minimax.io/v1)
+MINIMAX_BASE_URL=https://api.minimax.io/v1
+```
+
+**Available Models:**
+See `getSupportedModels` in [`minimax-embedding.ts`](https://github.com/zilliztech/claude-context/blob/master/packages/core/src/embedding/minimax-embedding.ts) for the full list of supported models.
+
+**Getting API Key:**
+
+1. Visit [MiniMax Platform](https://platform.minimaxi.com/)
+2. Sign up for an account
+3. Navigate to API Keys section
+4. Create a new API key
+
+</details>
+
+<details>
+<summary><strong>5. Ollama Configuration (Local/Self-hosted)</strong></summary>
 
 Ollama allows you to run embeddings locally without sending data to external services.
 

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -4,7 +4,7 @@ export interface ContextMcpConfig {
     name: string;
     version: string;
     // Embedding provider configuration
-    embeddingProvider: 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama';
+    embeddingProvider: 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama' | 'MiniMax';
     embeddingModel: string;
     // Provider-specific API keys
     openaiApiKey?: string;
@@ -12,6 +12,8 @@ export interface ContextMcpConfig {
     voyageaiApiKey?: string;
     geminiApiKey?: string;
     geminiBaseUrl?: string;
+    minimaxApiKey?: string;
+    minimaxBaseUrl?: string;
     // Ollama configuration
     ollamaModel?: string;
     ollamaHost?: string;
@@ -78,6 +80,8 @@ export function getDefaultModelForProvider(provider: string): string {
             return 'gemini-embedding-001';
         case 'Ollama':
             return 'nomic-embed-text';
+        case 'MiniMax':
+            return 'embo-01';
         default:
             return 'text-embedding-3-small';
     }
@@ -94,6 +98,7 @@ export function getEmbeddingModelForProvider(provider: string): string {
         case 'OpenAI':
         case 'VoyageAI':
         case 'Gemini':
+        case 'MiniMax':
         default:
             // For all other providers, use EMBEDDING_MODEL or default
             const selectedModel = envManager.get('EMBEDDING_MODEL') || getDefaultModelForProvider(provider);
@@ -110,6 +115,7 @@ export function createMcpConfig(): ContextMcpConfig {
     console.log(`[DEBUG]   OLLAMA_MODEL: ${envManager.get('OLLAMA_MODEL') || 'NOT SET'}`);
     console.log(`[DEBUG]   GEMINI_API_KEY: ${envManager.get('GEMINI_API_KEY') ? 'SET (length: ' + envManager.get('GEMINI_API_KEY')!.length + ')' : 'NOT SET'}`);
     console.log(`[DEBUG]   OPENAI_API_KEY: ${envManager.get('OPENAI_API_KEY') ? 'SET (length: ' + envManager.get('OPENAI_API_KEY')!.length + ')' : 'NOT SET'}`);
+    console.log(`[DEBUG]   MINIMAX_API_KEY: ${envManager.get('MINIMAX_API_KEY') ? 'SET (length: ' + envManager.get('MINIMAX_API_KEY')!.length + ')' : 'NOT SET'}`);
     console.log(`[DEBUG]   MILVUS_ADDRESS: ${envManager.get('MILVUS_ADDRESS') || 'NOT SET'}`);
     console.log(`[DEBUG]   NODE_ENV: ${envManager.get('NODE_ENV') || 'NOT SET'}`);
 
@@ -117,7 +123,7 @@ export function createMcpConfig(): ContextMcpConfig {
         name: envManager.get('MCP_SERVER_NAME') || "Context MCP Server",
         version: envManager.get('MCP_SERVER_VERSION') || "1.0.0",
         // Embedding provider configuration
-        embeddingProvider: (envManager.get('EMBEDDING_PROVIDER') as 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama') || 'OpenAI',
+        embeddingProvider: (envManager.get('EMBEDDING_PROVIDER') as 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama' | 'MiniMax') || 'OpenAI',
         embeddingModel: getEmbeddingModelForProvider(envManager.get('EMBEDDING_PROVIDER') || 'OpenAI'),
         // Provider-specific API keys
         openaiApiKey: envManager.get('OPENAI_API_KEY'),
@@ -125,6 +131,9 @@ export function createMcpConfig(): ContextMcpConfig {
         voyageaiApiKey: envManager.get('VOYAGEAI_API_KEY'),
         geminiApiKey: envManager.get('GEMINI_API_KEY'),
         geminiBaseUrl: envManager.get('GEMINI_BASE_URL'),
+        // MiniMax configuration
+        minimaxApiKey: envManager.get('MINIMAX_API_KEY'),
+        minimaxBaseUrl: envManager.get('MINIMAX_BASE_URL'),
         // Ollama configuration
         ollamaModel: envManager.get('OLLAMA_MODEL'),
         ollamaHost: envManager.get('OLLAMA_HOST'),
@@ -162,6 +171,12 @@ export function logConfigurationSummary(config: ContextMcpConfig): void {
                 console.log(`[MCP]   Gemini Base URL: ${config.geminiBaseUrl}`);
             }
             break;
+        case 'MiniMax':
+            console.log(`[MCP]   MiniMax API Key: ${config.minimaxApiKey ? '✅ Configured' : '❌ Missing'}`);
+            if (config.minimaxBaseUrl) {
+                console.log(`[MCP]   MiniMax Base URL: ${config.minimaxBaseUrl}`);
+            }
+            break;
         case 'Ollama':
             console.log(`[MCP]   Ollama Host: ${config.ollamaHost || 'http://127.0.0.1:11434'}`);
             console.log(`[MCP]   Ollama Model: ${config.embeddingModel}`);
@@ -185,7 +200,7 @@ Environment Variables:
   MCP_SERVER_VERSION      Server version
   
   Embedding Provider Configuration:
-  EMBEDDING_PROVIDER      Embedding provider: OpenAI, VoyageAI, Gemini, Ollama (default: OpenAI)
+  EMBEDDING_PROVIDER      Embedding provider: OpenAI, VoyageAI, Gemini, Ollama, MiniMax (default: OpenAI)
   EMBEDDING_MODEL         Embedding model name (works for all providers)
   
   Provider-specific API Keys:
@@ -194,7 +209,9 @@ Environment Variables:
   VOYAGEAI_API_KEY        VoyageAI API key (required for VoyageAI provider)
   GEMINI_API_KEY          Google AI API key (required for Gemini provider)
   GEMINI_BASE_URL         Gemini API base URL (optional, for custom endpoints)
-  
+  MINIMAX_API_KEY         MiniMax API key (required for MiniMax provider)
+  MINIMAX_BASE_URL        MiniMax API base URL (optional, default: https://api.minimax.io/v1)
+
   Ollama Configuration:
   OLLAMA_HOST             Ollama server host (default: http://127.0.0.1:11434)
   OLLAMA_MODEL            Ollama model name (alternative to EMBEDDING_MODEL for Ollama)
@@ -216,6 +233,9 @@ Examples:
   # Start MCP server with Gemini and specific model
   EMBEDDING_PROVIDER=Gemini GEMINI_API_KEY=xxx EMBEDDING_MODEL=gemini-embedding-001 MILVUS_TOKEN=your-token npx @zilliz/claude-context-mcp@latest
   
+  # Start MCP server with MiniMax
+  EMBEDDING_PROVIDER=MiniMax MINIMAX_API_KEY=xxx MILVUS_TOKEN=your-token npx @zilliz/claude-context-mcp@latest
+
   # Start MCP server with Ollama and specific model (using OLLAMA_MODEL)
   EMBEDDING_PROVIDER=Ollama OLLAMA_MODEL=mxbai-embed-large MILVUS_TOKEN=your-token npx @zilliz/claude-context-mcp@latest
   

--- a/packages/mcp/src/embedding.ts
+++ b/packages/mcp/src/embedding.ts
@@ -1,8 +1,8 @@
-import { OpenAIEmbedding, VoyageAIEmbedding, GeminiEmbedding, OllamaEmbedding } from "@zilliz/claude-context-core";
+import { OpenAIEmbedding, VoyageAIEmbedding, GeminiEmbedding, OllamaEmbedding, MiniMaxEmbedding } from "@zilliz/claude-context-core";
 import { ContextMcpConfig } from "./config.js";
 
 // Helper function to create embedding instance based on provider
-export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding {
+export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding | MiniMaxEmbedding {
     console.log(`[EMBEDDING] Creating ${config.embeddingProvider} embedding instance...`);
 
     switch (config.embeddingProvider) {
@@ -47,6 +47,20 @@ export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbeddi
             console.log(`[EMBEDDING] ✅ Gemini embedding instance created successfully`);
             return geminiEmbedding;
 
+        case 'MiniMax':
+            if (!config.minimaxApiKey) {
+                console.error(`[EMBEDDING] ❌ MiniMax API key is required but not provided`);
+                throw new Error('MINIMAX_API_KEY is required for MiniMax embedding provider');
+            }
+            console.log(`[EMBEDDING] 🔧 Configuring MiniMax with model: ${config.embeddingModel}`);
+            const minimaxEmbedding = new MiniMaxEmbedding({
+                apiKey: config.minimaxApiKey,
+                model: config.embeddingModel,
+                ...(config.minimaxBaseUrl && { baseURL: config.minimaxBaseUrl })
+            });
+            console.log(`[EMBEDDING] ✅ MiniMax embedding instance created successfully`);
+            return minimaxEmbedding;
+
         case 'Ollama':
             const ollamaHost = config.ollamaHost || 'http://127.0.0.1:11434';
             console.log(`[EMBEDDING] 🔧 Configuring Ollama with model: ${config.embeddingModel}, host: ${ollamaHost}`);
@@ -63,7 +77,7 @@ export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbeddi
     }
 }
 
-export function logEmbeddingProviderInfo(config: ContextMcpConfig, embedding: OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding): void {
+export function logEmbeddingProviderInfo(config: ContextMcpConfig, embedding: OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding | MiniMaxEmbedding): void {
     console.log(`[EMBEDDING] ✅ Successfully initialized ${config.embeddingProvider} embedding provider`);
     console.log(`[EMBEDDING] Provider details - Model: ${config.embeddingModel}, Dimension: ${embedding.getDimension()}`);
 
@@ -77,6 +91,9 @@ export function logEmbeddingProviderInfo(config: ContextMcpConfig, embedding: Op
             break;
         case 'Gemini':
             console.log(`[EMBEDDING] Gemini configuration - API Key: ${config.geminiApiKey ? '✅ Provided' : '❌ Missing'}, Base URL: ${config.geminiBaseUrl || 'Default'}`);
+            break;
+        case 'MiniMax':
+            console.log(`[EMBEDDING] MiniMax configuration - API Key: ${config.minimaxApiKey ? '✅ Provided' : '❌ Missing'}, Base URL: ${config.minimaxBaseUrl || 'https://api.minimax.io/v1'}`);
             break;
         case 'Ollama':
             console.log(`[EMBEDDING] Ollama configuration - Host: ${config.ollamaHost || 'http://127.0.0.1:11434'}, Model: ${config.embeddingModel}`);


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimaxi.com/) as a new embedding provider, supporting the **embo-01** model (1536 dimensions).

MiniMax's embedding API uses a non-OpenAI-compatible format (uses `texts` array + `type` field for db/query distinction), so this implements a custom provider using native `fetch` rather than wrapping the OpenAI SDK.

## Changes

- **`packages/core/src/embedding/minimax-embedding.ts`** — `MiniMaxEmbedding` class extending the base `Embedding` abstract class with full `embed()`, `embedBatch()`, `detectDimension()`, `setModel()`, `setType()`, and `getSupportedModels()` support
- **`packages/core/src/embedding/index.ts`** — Export the new provider
- **`packages/mcp/src/embedding.ts`** — Add MiniMax to the factory pattern and logging
- **`packages/mcp/src/config.ts`** — Add `MiniMax` to provider union type, config interface, env var reading, help text, and examples
- **`packages/mcp/README.md`** — Add MiniMax configuration section with setup instructions
- **`README.md`** — Add MiniMax to supported embedding providers list
- **`docs/getting-started/environment-variables.md`** — Add `MINIMAX_API_KEY` and `MINIMAX_BASE_URL` env vars
- **`.env.example`** — Add MiniMax configuration section

## Configuration

```bash
EMBEDDING_PROVIDER=MiniMax
MINIMAX_API_KEY=your-minimax-api-key
# Optional: MINIMAX_BASE_URL=https://api.minimax.io/v1
# Optional: EMBEDDING_MODEL=embo-01
```

## Key Design Decisions

- **Custom fetch implementation** instead of OpenAI SDK wrapper, because MiniMax's embedding API differs:
  - Request uses `texts` array (not `input`)
  - Request includes `type` field (`db` for indexing, `query` for search)
  - Response uses `vectors` array (not `data[].embedding`)
- **`type` parameter support** — `setType('db' | 'query')` allows switching between storage and query embedding modes, matching MiniMax's API semantics
- **No new dependencies** — Uses native `fetch` (available in Node.js 18+)

## Test Plan

- [x] 19 unit tests covering constructor, embed, embedBatch, detectDimension, setModel, setType, error handling, auth headers, baseURL routing, and text preprocessing
- [x] 3 integration tests (require `MINIMAX_API_KEY` env var, auto-skipped without it)
- [x] TypeScript builds cleanly for both `packages/core` and `packages/mcp`
- [x] All existing provider interfaces and patterns preserved