### PR TITLE
fix: remove dead code in MerkleDAG.compare() — modified detection is unreachable

### DIFF
--- a/packages/core/src/sync/merkle.ts
+++ b/packages/core/src/sync/merkle.ts
@@ -78,22 +78,13 @@ export class MerkleDAG {
         return dag;
     }
 
-    public static compare(dag1: MerkleDAG, dag2: MerkleDAG): { added: string[], removed: string[], modified: string[] } {
-        const nodes1 = new Map(Array.from(dag1.getAllNodes()).map(n => [n.id, n]));
-        const nodes2 = new Map(Array.from(dag2.getAllNodes()).map(n => [n.id, n]));
+    public static compare(dag1: MerkleDAG, dag2: MerkleDAG): { added: string[], removed: string[] } {
+        const nodes1 = new Set(Array.from(dag1.getAllNodes()).map(n => n.id));
+        const nodes2 = new Set(Array.from(dag2.getAllNodes()).map(n => n.id));
 
-        const added = Array.from(nodes2.keys()).filter(k => !nodes1.has(k));
-        const removed = Array.from(nodes1.keys()).filter(k => !nodes2.has(k));
-        
-        // For modified, we'll check if the data has changed for nodes that exist in both
-        const modified: string[] = [];
-        for (const [id, node1] of Array.from(nodes1.entries())) {
-            const node2 = nodes2.get(id);
-            if (node2 && node1.data !== node2.data) {
-                modified.push(id);
-            }
-        }
+        const added = Array.from(nodes2).filter(k => !nodes1.has(k));
+        const removed = Array.from(nodes1).filter(k => !nodes2.has(k));
 
-        return { added, removed, modified };
+        return { added, removed };
     }
 } 

--- a/packages/core/src/sync/synchronizer.ts
+++ b/packages/core/src/sync/synchronizer.ts
@@ -230,8 +230,8 @@ export class FileSynchronizer {
         // Compare the DAGs
         const changes = MerkleDAG.compare(this.merkleDAG, newMerkleDAG);
 
-        // If there are any changes in the DAG, we should also do a file-level comparison
-        if (changes.added.length > 0 || changes.removed.length > 0 || changes.modified.length > 0) {
+        // If there are any changes in the DAG, do a file-level comparison
+        if (changes.added.length > 0 || changes.removed.length > 0) {
             console.log('[Synchronizer] Merkle DAG has changed. Comparing file states...');
             const fileChanges = this.compareStates(this.fileHashes, newFileHashes);
 


### PR DESCRIPTION
## Problem
`MerkleDAG.compare()` contains a `modified` detection loop that can never produce results:
```typescript
const modified: string[] = [];
for (const [id, node1] of Array.from(nodes1.entries())) {
    const node2 = nodes2.get(id);
    if (node2 && node1.data !== node2.data) {
        modified.push(id);
    }
}
Node IDs are computed as SHA-256(data). Since the ID is the hash of the data, it is cryptographically impossible for two nodes to share the same ID but have different data. The condition node2 && node1.data !== node2.data can never be true.

When a file is modified, its content hash changes, which changes its node data ("path:hash"), which changes its node ID. The old node ID appears in removed and the new one appears in added — but modified is always [].

Why the system still works correctly
MerkleDAG.compare() is only used as a fast "did anything change?" boolean gate inside FileSynchronizer.checkForChanges(). The actual categorization of files into added/removed/modified is done by compareStates(), which compares Map<filePath, contentHash> — keyed by file path, not content hash — so it correctly identifies modifications.

MerkleDAG.compare()     →  "something changed" (boolean gate)
    ↓
compareStates()         →  "here's exactly what changed" (added/removed/modified)
Changes
merkle.ts: Removed the unreachable modified loop from compare(). Simplified the return type from { added, removed, modified } to { added, removed }. Replaced Map with Set since only node IDs are needed for the comparison.
synchronizer.ts: Removed changes.modified check from the DAG comparison condition to match the updated return type.
Verification
pnpm build:core — passes
pnpm build:mcp — passes
No behavioral change: file modification detection continues to work via compareStates() in FileSynchronizer