### PR TITLE
Fix snapshot 0/0 entries causing infinite force-reindex loop

### DIFF
--- a/packages/core/src/vectordb/milvus-restful-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-restful-vectordb.ts
@@ -823,4 +823,25 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
         console.warn('[MilvusRestfulDB] ⚠️  checkCollectionLimit not implemented for REST API - returning true');
         return true;
     }
+
+    async getCollectionRowCount(collectionName: string): Promise<number> {
+        try {
+            const hasCol = await this.hasCollection(collectionName);
+            if (!hasCol) {
+                return 0;
+            }
+
+            const response = await this.makeRequest(
+                '/v2/vectordb/collections/get_stats',
+                'POST',
+                { collectionName }
+            );
+
+            const rowCount = response?.data?.rowCount ?? response?.data?.row_count;
+            return typeof rowCount === 'number' ? rowCount : parseInt(rowCount, 10) || 0;
+        } catch (error) {
+            console.error(`[MilvusRestfulDB] Error getting row count for '${collectionName}':`, error);
+            return 0;
+        }
+    }
 }

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -781,4 +781,44 @@ export class MilvusVectorDatabase implements VectorDatabase {
             throw error;
         }
     }
+
+    async getCollectionRowCount(collectionName: string): Promise<number> {
+        await this.ensureInitialized();
+
+        if (!this.client) {
+            throw new Error('MilvusClient is not initialized after ensureInitialized().');
+        }
+
+        try {
+            const hasCol = await this.client.hasCollection({ collection_name: collectionName });
+            if (!hasCol.value) {
+                return 0;
+            }
+
+            const result = await this.client.getCollectionStatistics({
+                collection_name: collectionName,
+            });
+
+            if (result.status.error_code !== 'Success') {
+                console.warn(`[MilvusDB] Failed to get stats for '${collectionName}': ${result.status.reason}`);
+                return 0;
+            }
+
+            // row_count is returned in the stats data array
+            const rowCountStat = result.data?.rows_count ?? result.stats?.find((s: any) => s.key === 'row_count');
+            if (typeof rowCountStat === 'number') {
+                return rowCountStat;
+            }
+            if (rowCountStat && typeof rowCountStat === 'object' && 'value' in rowCountStat) {
+                return parseInt(rowCountStat.value, 10) || 0;
+            }
+
+            // Fallback: parse from data.row_count if available
+            const rc = (result as any).data?.row_count;
+            return typeof rc === 'number' ? rc : parseInt(rc, 10) || 0;
+        } catch (error) {
+            console.error(`[MilvusDB] Error getting row count for '${collectionName}':`, error);
+            return 0;
+        }
+    }
 }

--- a/packages/core/src/vectordb/types.ts
+++ b/packages/core/src/vectordb/types.ts
@@ -138,6 +138,14 @@ export interface VectorDatabase {
      * Returns true if collection can be created, false if limit exceeded
      */
     checkCollectionLimit(): Promise<boolean>;
+
+    /**
+     * Get the number of entities (rows) in a collection.
+     * Used by snapshot recovery to get actual stats instead of hardcoding zeros.
+     * @param collectionName Collection name
+     * @returns Number of entities in the collection, or 0 if collection doesn't exist
+     */
+    getCollectionRowCount(collectionName: string): Promise<number>;
 }
 
 /**

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -19,6 +19,76 @@ export class ToolHandlers {
     }
 
     /**
+     * Query Milvus for actual collection stats to use in snapshot recovery,
+     * instead of hardcoding indexedFiles: 0, totalChunks: 0.
+     */
+    private async getCollectionStats(codebasePath: string): Promise<{ indexedFiles: number; totalChunks: number }> {
+        try {
+            const collectionName = this.context.getCollectionName(codebasePath);
+            const rowCount = await this.context.getVectorDatabase().getCollectionRowCount(collectionName);
+            // We can't distinguish files from chunks without querying metadata,
+            // but rowCount == totalChunks is accurate. For indexedFiles we return
+            // 0 only if the collection is truly empty; otherwise use a sentinel
+            // that indicates "unknown but non-zero" — the snapshot will be
+            // corrected on the next full index.
+            if (rowCount > 0) {
+                return { indexedFiles: rowCount, totalChunks: rowCount };
+            }
+        } catch (error) {
+            console.warn(`[SNAPSHOT-RECOVERY] Failed to query Milvus stats for '${codebasePath}':`, error);
+        }
+        return { indexedFiles: 0, totalChunks: 0 };
+    }
+
+    /**
+     * Validate snapshot entries that claim status='indexed' but have 0 files/chunks.
+     * These entries are typically left behind by interrupted indexing or buggy recovery
+     * paths. If Milvus actually has data, update the snapshot with real stats.
+     * If Milvus has no data either, remove the stale entry.
+     */
+    private async validateSnapshotZeroEntries(): Promise<void> {
+        try {
+            const indexedCodebases = this.snapshotManager.getIndexedCodebases();
+            let hasChanges = false;
+
+            for (const codebasePath of indexedCodebases) {
+                const info = this.snapshotManager.getCodebaseInfo(codebasePath);
+                if (!info || info.status !== 'indexed') continue;
+
+                // Only validate entries with suspiciously zero stats
+                if ('indexedFiles' in info && info.indexedFiles === 0 &&
+                    'totalChunks' in info && info.totalChunks === 0) {
+
+                    const hasVectorIndex = await this.context.hasIndex(codebasePath);
+                    if (hasVectorIndex) {
+                        const stats = await this.getCollectionStats(codebasePath);
+                        if (stats.totalChunks > 0) {
+                            console.log(`[SNAPSHOT-VALIDATE] Fixing 0/0 entry for '${codebasePath}' — Milvus has ${stats.totalChunks} chunks`);
+                            this.snapshotManager.setCodebaseIndexed(codebasePath, {
+                                ...stats,
+                                status: 'completed' as const
+                            });
+                            hasChanges = true;
+                        }
+                    } else {
+                        // Snapshot says indexed with 0/0, but Milvus has no collection — remove stale entry
+                        console.warn(`[SNAPSHOT-VALIDATE] Removing stale 0/0 entry for '${codebasePath}' — no Milvus collection found`);
+                        this.snapshotManager.removeCodebaseCompletely(codebasePath);
+                        hasChanges = true;
+                    }
+                }
+            }
+
+            if (hasChanges) {
+                this.snapshotManager.saveCodebaseSnapshot();
+                console.log(`[SNAPSHOT-VALIDATE] Snapshot updated after 0/0 validation`);
+            }
+        } catch (error) {
+            console.warn(`[SNAPSHOT-VALIDATE] Error during 0/0 validation (non-fatal):`, error);
+        }
+    }
+
+    /**
      * Sync indexed codebases from Zilliz Cloud collections
      * This method fetches all collections from the vector database,
      * extracts codebasePath from collection description (preferred) or falls back
@@ -149,13 +219,13 @@ export class ToolHandlers {
             // Add cloud codebases that are missing from local snapshot (recovery)
             for (const cloudCodebase of cloudCodebases) {
                 if (!localCodebases.has(cloudCodebase)) {
+                    const stats = await this.getCollectionStats(cloudCodebase);
                     this.snapshotManager.setCodebaseIndexed(cloudCodebase, {
-                        indexedFiles: 0,
-                        totalChunks: 0,
+                        ...stats,
                         status: 'completed' as const
                     });
                     hasChanges = true;
-                    console.log(`[SYNC-CLOUD] ➕ Recovered codebase from cloud: ${cloudCodebase}`);
+                    console.log(`[SYNC-CLOUD] ➕ Recovered codebase from cloud: ${cloudCodebase} (${stats.totalChunks} chunks from Milvus)`);
                 }
             }
 
@@ -181,6 +251,9 @@ export class ToolHandlers {
         const customIgnorePatterns = ignorePatterns || [];
 
         try {
+            // Validate any 0/0 snapshot entries against actual Milvus state
+            await this.validateSnapshotZeroEntries();
+
             // Sync indexed codebases from cloud first
             await this.syncIndexedCodebasesFromCloud();
 
@@ -243,7 +316,8 @@ export class ToolHandlers {
             if (snapshotHasIndex !== vectorDbHasIndex) {
                 if (vectorDbHasIndex && !snapshotHasIndex) {
                     console.warn(`[INDEX-VALIDATION] Recovering missing snapshot for '${absolutePath}'`);
-                    this.snapshotManager.setCodebaseIndexed(absolutePath, { indexedFiles: 0, totalChunks: 0, status: 'completed' as const });
+                    const recoveredStats = await this.getCollectionStats(absolutePath);
+                    this.snapshotManager.setCodebaseIndexed(absolutePath, { ...recoveredStats, status: 'completed' as const });
                     this.snapshotManager.saveCodebaseSnapshot();
                 } else if (!vectorDbHasIndex && snapshotHasIndex) {
                     console.warn(`[INDEX-VALIDATION] Clearing stale snapshot for '${absolutePath}'`);
@@ -462,6 +536,9 @@ export class ToolHandlers {
         const resultLimit = limit || 10;
 
         try {
+            // Validate any 0/0 snapshot entries against actual Milvus state
+            await this.validateSnapshotZeroEntries();
+
             // Sync indexed codebases from cloud first
             await this.syncIndexedCodebasesFromCloud();
 
@@ -502,7 +579,8 @@ export class ToolHandlers {
                 const hasVectorIndex = await this.context.hasIndex(absolutePath);
                 if (hasVectorIndex) {
                     console.warn(`[SEARCH] Snapshot missing but VectorDB has index for '${absolutePath}', recovering snapshot`);
-                    this.snapshotManager.setCodebaseIndexed(absolutePath, { indexedFiles: 0, totalChunks: 0, status: 'completed' as const });
+                    const recoveredStats = await this.getCollectionStats(absolutePath);
+                    this.snapshotManager.setCodebaseIndexed(absolutePath, { ...recoveredStats, status: 'completed' as const });
                     this.snapshotManager.saveCodebaseSnapshot();
                     // Continue with search (don't return error)
                 } else {


### PR DESCRIPTION
## Summary

Fixes #295 — snapshot recovery paths write \`indexedFiles: 0, totalChunks: 0\` without querying Milvus for actual stats, creating an infinite reindex loop.

**The bug:** When a force reindex clears data or recovery fires, the snapshot is written with 0/0 stats. If indexing subsequently fails, every new session sees 0/0 → treats it as unindexed → passes \`force: true\` → nukes the real Milvus data → writes 0/0 again.

**The fix (3 parts):**

1. **New \`getCollectionRowCount()\` method** on \`VectorDatabase\` interface + both implementations (SDK and REST). Queries actual Milvus collection statistics instead of hardcoding zeros.

2. **Fixed 3 recovery paths** in \`handlers.ts\` that hardcoded \`{ indexedFiles: 0, totalChunks: 0 }\`:
   - \`syncIndexedCodebasesFromCloud()\` — cloud recovery
   - \`handleIndexCodebase()\` — snapshot/VectorDB desync recovery
   - \`handleSearchCode()\` — search fallback recovery
   
   All three now call \`getCollectionRowCount()\` to get real stats from Milvus.

3. **New \`validateSnapshotZeroEntries()\` method** that runs at the start of index/search operations. For any snapshot entry with status=indexed but 0/0 stats:
   - If Milvus has data → updates snapshot with real row count
   - If Milvus has no collection → removes the stale entry

## Changes

| File | Change |
|------|--------|
| \`packages/core/src/vectordb/types.ts\` | Add \`getCollectionRowCount()\` to \`VectorDatabase\` interface |
| \`packages/core/src/vectordb/milvus-vectordb.ts\` | Implement via \`getCollectionStatistics()\` SDK method |
| \`packages/core/src/vectordb/milvus-restful-vectordb.ts\` | Implement via REST \`/v2/vectordb/collections/get_stats\` |
| \`packages/mcp/src/handlers.ts\` | Fix 3 recovery paths + add startup validation |

## Test plan

- [x] \`pnpm typecheck\` passes across all packages
- [x] \`pnpm build:core\` and \`pnpm build:mcp\` compile cleanly
- [ ] Manual test: corrupt snapshot to 0/0, verify recovery queries Milvus and restores real stats
- [ ] Manual test: remove Milvus collection but leave snapshot entry, verify stale entry is cleaned up