### PR TITLE
fix: keep FileSynchronizer aligned with supported extensions (#286)

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -324,7 +324,7 @@ export class Context {
             await this.loadIgnorePatterns(codebasePath);
 
             // To be safe, let's initialize if it's not there.
-            const newSynchronizer = new FileSynchronizer(codebasePath, this.ignorePatterns);
+            const newSynchronizer = new FileSynchronizer(codebasePath, this.ignorePatterns, this.supportedExtensions);
             await newSynchronizer.initialize();
             this.synchronizers.set(collectionName, newSynchronizer);
         }

--- a/packages/core/src/sync/synchronizer.ts
+++ b/packages/core/src/sync/synchronizer.ts
@@ -10,13 +10,15 @@ export class FileSynchronizer {
     private rootDir: string;
     private snapshotPath: string;
     private ignorePatterns: string[];
+    private supportedExtensions: string[];
 
-    constructor(rootDir: string, ignorePatterns: string[] = []) {
+    constructor(rootDir: string, ignorePatterns: string[] = [], supportedExtensions: string[] = []) {
         this.rootDir = rootDir;
         this.snapshotPath = this.getSnapshotPath(rootDir);
         this.fileHashes = new Map();
         this.merkleDAG = new MerkleDAG();
         this.ignorePatterns = ignorePatterns;
+        this.supportedExtensions = supportedExtensions;
     }
 
     private getSnapshotPath(codebasePath: string): string {
@@ -81,6 +83,10 @@ export class FileSynchronizer {
             } else if (stat.isFile()) {
                 // Verify it's really a file and not ignored
                 if (!this.shouldIgnore(relativePath, false)) {
+                    const ext = path.extname(entry.name);
+                    if (this.supportedExtensions.length > 0 && !this.supportedExtensions.includes(ext)) {
+                        continue;
+                    }
                     try {
                         const hash = await this.hashFile(fullPath);
                         fileHashes.set(relativePath, hash);

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -392,7 +392,7 @@ export class ToolHandlers {
             const { FileSynchronizer } = await import("@zilliz/claude-context-core");
             const ignorePatterns = this.context.getIgnorePatterns() || [];
             console.log(`[BACKGROUND-INDEX] Using ignore patterns: ${ignorePatterns.join(', ')}`);
-            const synchronizer = new FileSynchronizer(absolutePath, ignorePatterns);
+            const synchronizer = new FileSynchronizer(absolutePath, ignorePatterns, this.context.getSupportedExtensions());
             await synchronizer.initialize();
 
             // Store synchronizer in the context (let context manage collection names)

--- a/packages/vscode-extension/src/commands/indexCommand.ts
+++ b/packages/vscode-extension/src/commands/indexCommand.ts
@@ -75,7 +75,11 @@ export class IndexCommand {
                 // Initialize file synchronizer
                 progress.report({ increment: 0, message: 'Initializing file synchronizer...' });
                 const { FileSynchronizer } = await import("@zilliz/claude-context-core");
-                const synchronizer = new FileSynchronizer(selectedFolder.uri.fsPath, this.context.getIgnorePatterns() || []);
+                const synchronizer = new FileSynchronizer(
+                    selectedFolder.uri.fsPath,
+                    this.context.getIgnorePatterns() || [],
+                    this.context.getSupportedExtensions() || []
+                );
                 await synchronizer.initialize();
                 // Store synchronizer in the context's internal map using the collection name from context
                 await this.context.getPreparedCollection(selectedFolder.uri.fsPath);


### PR DESCRIPTION
## Summary
- pass supported extensions into `FileSynchronizer` so sync only tracks files the indexer would actually process
- skip hashing unsupported files during Merkle snapshot generation
- thread the extension allowlist through the MCP handler, core reindex path, and VS Code index command

Closes #286.

## Validation
- `corepack pnpm exec tsc --build --force`
- ran a focused Node regression against the built `FileSynchronizer` to confirm `.pdf` files are skipped while `.ts` changes are still detected