### PR TITLE
fix: update broken and outdated links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](assets/claude-context.png)
 
-> 🆕 **Looking for persistent memory for Claude Code?** Check out [memsearch Claude Code plugin](https://github.com/zilliztech/memsearch/tree/main/ccplugin) — a markdown-first memory system that gives your AI agent long-term memory across sessions.
+> 🆕 **Looking for persistent memory for Claude Code?** Check out [memsearch Claude Code plugin](https://github.com/zilliztech/memsearch/tree/main/plugins/claude-code) — a markdown-first memory system that gives your AI agent long-term memory across sessions.
 
 ### Your entire codebase as Claude's context
 
@@ -152,11 +152,9 @@ Create or edit the `~/.qwen/settings.json` file and add the following configurat
 <details>
 <summary><strong>Cursor</strong></summary>
 
-<a href="https://cursor.com/install-mcp?name=claude-context&config=JTdCJTIyY29tbWFuZCUyMiUzQSUyMm5weCUyMC15JTIwJTQwemlsbGl6JTJGY29kZS1jb250ZXh0LW1jcCU0MGxhdGVzdCUyMiUyQyUyMmVudiUyMiUzQSU3QiUyMk9QRU5BSV9BUElfS0VZJTIyJTNBJTIyeW91ci1vcGVuYWktYXBpLWtleSUyMiUyQyUyMk1JTFZVU19BRERSRVNTJTIyJTNBJTIybG9jYWxob3N0JTNBMTk1MzAlMjIlN0QlN0Q%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add claude-context MCP server to Cursor" height="32" /></a>
-
 Go to: `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`
 
-Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) for more info.
+Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more info.
 
 ```json
 {
@@ -545,7 +543,7 @@ Claude Context is a monorepo containing three main packages:
 
 ### Supported Technologies
 
-- **Embedding Providers**: [OpenAI](https://openai.com), [VoyageAI](https://voyageai.com), [Ollama](https://ollama.ai), [Gemini](https://gemini.google.com)
+- **Embedding Providers**: [OpenAI](https://openai.com), [VoyageAI](https://voyageai.com), [Ollama](https://ollama.com), [Gemini](https://gemini.google.com)
 - **Vector Databases**: [Milvus](https://milvus.io) or [Zilliz Cloud](https://zilliz.com/cloud)(fully managed vector database as a service)
 - **Code Splitters**: AST-based splitter (with automatic fallback), LangChain character-based splitter
 - **Languages**: TypeScript, JavaScript, Python, Java, C++, C#, Go, Rust, PHP, Ruby, Swift, Kotlin, Scala, Markdown

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -23,7 +23,7 @@ Before setting up Claude Context, ensure you have the following requirements met
 - **Quota**: Check current quotas and limits
 
 #### Option 4: Ollama (Local)
-- **Installation**: Download from [ollama.ai](https://ollama.ai/)
+- **Installation**: Download from [ollama.com](https://ollama.com/)
 - **Models**: Pull embedding models like `nomic-embed-text`
 - **Hardware**: Sufficient RAM for model loading (varies by model)
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -122,7 +122,7 @@ Create or edit the `~/.qwen/settings.json` file and add the following configurat
 
 Go to: `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`
 
-Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) for more info.
+Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more info.
 
 **OpenAI Configuration (Default):**
 ```json

--- a/docs/troubleshooting/troubleshooting-guide.md
+++ b/docs/troubleshooting/troubleshooting-guide.md
@@ -33,7 +33,7 @@ If Step 1 doesn't reveal the issue, collect detailed debug information:
 - If you use Cursor-like GUI IDEs, find the MCP logs in the Output panel, e.g. Cursor:
   1. Open the Output panel in Cursor (⌘⇧U)
   2. Select "MCP Logs" from the dropdown
-  3. See [Cursor MCP FAQ](https://docs.cursor.com/en/context/mcp#faq) for details
+  3. See [Cursor MCP FAQ](https://cursor.com/docs/context/mcp) for details
 
 **Check your MCP Client Setting:**
 If logs don't solve the problem, note:
@@ -57,7 +57,7 @@ If you locate the problem at [Step 1](#step-1-check-indexing-status-first) or [S
   /mcp refresh
   ```
   For more details, see [this PR](https://github.com/google-gemini/gemini-cli/pull/4566).
-- **Cursor and other GUI IDEs**: Look for a toggle icon or restart button to restart the MCP connection. e.g. [Cursor MCP FAQ](https://docs.cursor.com/en/context/mcp#faq)
+- **Cursor and other GUI IDEs**: Look for a toggle icon or restart button to restart the MCP connection. e.g. [Cursor MCP FAQ](https://cursor.com/docs/context/mcp)
 
 After reconnecting, test if your issue is resolved and the system works normally.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -134,7 +134,7 @@ OLLAMA_HOST=http://127.0.0.1:11434
 
 **Setup Instructions:**
 
-1. Install Ollama from [ollama.ai](https://ollama.ai/)
+1. Install Ollama from [ollama.com](https://ollama.com/)
 2. Pull the embedding model:
 
    ```bash
@@ -278,7 +278,7 @@ Create or edit the `~/.qwen/settings.json` file and add the following configurat
 
 Go to: `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`
 
-Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) for more info.
+Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file is the recommended approach. You may also install in a specific project by creating `.cursor/mcp.json` in your project folder. See [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more info.
 
 **OpenAI Configuration (Default):**
 


### PR DESCRIPTION
## Summary
- Update memsearch plugin link to new path (`plugins/claude-code`)
- Remove broken Cursor one-click install button (returns 404)
- Update Cursor docs links from `docs.cursor.com` to `cursor.com/docs` (old domain 308 redirects to generic page)
- Update Ollama links from `ollama.ai` to `ollama.com` (301 permanent redirect)

## Files changed
- `README.md`
- `docs/getting-started/prerequisites.md`
- `docs/getting-started/quick-start.md`
- `docs/troubleshooting/troubleshooting-guide.md`
- `packages/mcp/README.md`