### PR TITLE
fix: prevent snapshot 0/0 entries causing infinite force-reindex loop

### DIFF
--- a/packages/core/src/vectordb/milvus-restful-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-restful-vectordb.ts
@@ -823,4 +823,48 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
         console.warn('[MilvusRestfulDB] ⚠️  checkCollectionLimit not implemented for REST API - returning true');
         return true;
     }
+
+    /**
+     * Get the number of entities (rows) in a collection.
+     * Returns -1 on any failure (collection missing, RPC error, malformed response).
+     * -1 means "unknown" — callers must NOT treat it as "empty".
+     *
+     * Uses count(*) via /entities/query rather than /collections/get_stats: stats
+     * are computed from sealed segments and lag recent inserts (returning 0 for
+     * a freshly-indexed but unflushed collection), while count(*) reads the real
+     * current state. A stale 0 would fool recovery into thinking the collection
+     * is truly empty and cause Issue #295-style false-negative "not indexed"
+     * errors even when data exists.
+     */
+    async getCollectionRowCount(collectionName: string): Promise<number> {
+        await this.ensureInitialized();
+        try {
+            const restfulConfig = this.config as MilvusRestfulConfig;
+
+            const hasResponse = await this.makeRequest('/collections/has', 'POST', {
+                collectionName,
+                dbName: restfulConfig.database
+            });
+            if (!hasResponse.data?.has) return -1;
+
+            // count(*) requires the collection to be loaded.
+            await this.ensureLoaded(collectionName);
+
+            const response = await this.makeRequest('/entities/query', 'POST', {
+                collectionName,
+                dbName: restfulConfig.database,
+                outputFields: ['count(*)'],
+            });
+
+            const row = response?.data?.[0];
+            if (!row) return -1;
+            const raw = row['count(*)'] ?? row['count'];
+            if (raw === undefined || raw === null) return -1;
+            const n = typeof raw === 'number' ? raw : parseInt(String(raw), 10);
+            return Number.isFinite(n) && n >= 0 ? n : -1;
+        } catch (error) {
+            console.error(`[MilvusRestfulDB] ❌ Error in count(*) query for '${collectionName}':`, error);
+            return -1;
+        }
+    }
 }

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -781,4 +781,49 @@ export class MilvusVectorDatabase implements VectorDatabase {
             throw error;
         }
     }
+
+    /**
+     * Get the number of entities (rows) in a collection.
+     * Returns -1 on any failure (collection missing, RPC error, malformed response).
+     * -1 means "unknown" — callers must NOT treat it as "empty".
+     *
+     * Uses count(*) via query() rather than getCollectionStatistics(): stats are
+     * computed from sealed segments and lag recent inserts (returning 0 for a
+     * freshly-indexed but unflushed collection), while count(*) reads the real
+     * current state. A stale 0 would fool recovery into thinking the collection
+     * is truly empty and cause Issue #295-style false-negative "not indexed"
+     * errors even when data exists.
+     */
+    async getCollectionRowCount(collectionName: string): Promise<number> {
+        await this.ensureInitialized();
+        if (!this.client) return -1;
+        try {
+            const hasCol = await this.client.hasCollection({ collection_name: collectionName });
+            if (!hasCol.value) return -1;
+
+            // count(*) requires the collection to be loaded.
+            await this.ensureLoaded(collectionName);
+
+            const result = await this.client.query({
+                collection_name: collectionName,
+                output_fields: ['count(*)'],
+                expr: '',
+            });
+            if (result.status.error_code !== 'Success') {
+                console.warn(`[MilvusDB] count(*) query failed for '${collectionName}': ${result.status.reason}`);
+                return -1;
+            }
+
+            // Shape observed: { data: [{ "count(*)": "<number-as-string>" }] }
+            const row = result.data?.[0] as Record<string, any> | undefined;
+            if (!row) return -1;
+            const raw = row['count(*)'] ?? row['count'];
+            if (raw === undefined || raw === null) return -1;
+            const n = typeof raw === 'number' ? raw : parseInt(String(raw), 10);
+            return Number.isFinite(n) && n >= 0 ? n : -1;
+        } catch (error) {
+            console.error(`[MilvusDB] Error in count(*) query for '${collectionName}':`, error);
+            return -1;
+        }
+    }
 }

--- a/packages/core/src/vectordb/types.ts
+++ b/packages/core/src/vectordb/types.ts
@@ -138,6 +138,13 @@ export interface VectorDatabase {
      * Returns true if collection can be created, false if limit exceeded
      */
     checkCollectionLimit(): Promise<boolean>;
+
+    /**
+     * Get the number of entities (rows) in a collection.
+     * Returns -1 if the count cannot be determined (query failed, collection missing, etc).
+     * Callers should treat -1 as "unknown" and NOT as "empty".
+     */
+    getCollectionRowCount(collectionName: string): Promise<number>;
 }
 
 /**

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -19,6 +19,131 @@ export class ToolHandlers {
     }
 
     /**
+     * Query Milvus for the real row count of a codebase's collection.
+     * Returns null if the count cannot be determined — callers must NOT write a
+     * snapshot entry in that case. Writing { indexedFiles: 0, totalChunks: 0,
+     * status: 'completed' } for an unknown-state collection poisons the client:
+     * the client treats 0/0 as "not indexed" and triggers force reindex, which
+     * deletes real data and rewrites 0/0 — an infinite loop. See Issue #295.
+     */
+    private async queryCollectionStats(codebasePath: string): Promise<{ indexedFiles: number; totalChunks: number } | null> {
+        try {
+            const collectionName = this.context.getCollectionName(codebasePath);
+            const rowCount = await this.context.getVectorDatabase().getCollectionRowCount(collectionName);
+            if (rowCount < 0) {
+                console.warn(`[SNAPSHOT-RECOVERY] Row count unknown for '${codebasePath}', skipping recovery write`);
+                return null;
+            }
+            if (rowCount === 0) {
+                console.warn(`[SNAPSHOT-RECOVERY] Collection '${collectionName}' truly empty — NOT writing recovered entry (would poison client)`);
+                return null;
+            }
+            // rowCount is chunk count, not file count. Without a metadata query
+            // we don't have the real file count; the snapshot will be corrected
+            // on the next full index. Using rowCount for both is imprecise but
+            // keeps the state non-zero so the client doesn't misread it as empty.
+            return { indexedFiles: rowCount, totalChunks: rowCount };
+        } catch (error) {
+            console.warn(`[SNAPSHOT-RECOVERY] Failed to query stats for '${codebasePath}':`, error);
+            return null;
+        }
+    }
+
+    /**
+     * One-shot startup validation: find any legacy 0/0+completed entries on disk
+     * (left over from old MCP versions, v1 snapshot migrations, or pre-fix recovery
+     * paths) and either heal them with the real Milvus row count or remove them
+     * if the underlying collection is empty/missing. See Issue #295.
+     *
+     * Safe to call multiple times but intended to run once per server start after
+     * loadCodebaseSnapshot(). Errors are caught and logged; never throws.
+     */
+    public async validateLegacyZeroEntries(): Promise<void> {
+        try {
+            const indexedCodebases = this.snapshotManager.getIndexedCodebases();
+            let healed = 0, removed = 0, skipped = 0, checked = 0;
+
+            for (const codebasePath of indexedCodebases) {
+                const info = this.snapshotManager.getCodebaseInfo(codebasePath);
+                if (!info || info.status !== 'indexed') continue;
+                // Only validate suspiciously-zero entries
+                if (info.indexedFiles !== 0 || info.totalChunks !== 0) continue;
+
+                checked++;
+                const collectionName = this.context.getCollectionName(codebasePath);
+                const vdb = this.context.getVectorDatabase();
+
+                // First probe: does the collection even exist? A "no" here is
+                // authoritative (permanent orphan), while a throw is most likely
+                // transient (Milvus unreachable) — keep those two cases distinct
+                // so we don't destroy real state on a network blip.
+                let collectionExists: boolean;
+                try {
+                    collectionExists = await vdb.hasCollection(collectionName);
+                } catch (err) {
+                    console.warn(`[SNAPSHOT-VALIDATE] hasCollection failed for '${codebasePath}' (likely transient), skipping:`, err);
+                    skipped++;
+                    continue;
+                }
+
+                if (!collectionExists) {
+                    // Permanent orphan — no matching Milvus collection, so the
+                    // 0/0+completed snapshot entry is a pure phantom. Remove it.
+                    this.snapshotManager.removeCodebaseCompletely(codebasePath);
+                    removed++;
+                    console.warn(`[SNAPSHOT-VALIDATE] Removed orphan 0/0 entry '${codebasePath}' — no matching Milvus collection`);
+                    continue;
+                }
+
+                // Collection exists — get an accurate row count.
+                let rowCount: number;
+                try {
+                    rowCount = await vdb.getCollectionRowCount(collectionName);
+                } catch (err) {
+                    console.warn(`[SNAPSHOT-VALIDATE] getCollectionRowCount failed for '${codebasePath}', skipping:`, err);
+                    skipped++;
+                    continue;
+                }
+
+                if (rowCount > 0) {
+                    // Heal: rewrite with real row count. rowCount is chunk count;
+                    // without a cheap file-count query we reuse it for both fields.
+                    // Imprecise but keeps the state non-zero and will be corrected
+                    // on the next full index.
+                    this.snapshotManager.setCodebaseIndexed(codebasePath, {
+                        indexedFiles: rowCount,
+                        totalChunks: rowCount,
+                        status: 'completed' as const,
+                    });
+                    healed++;
+                    console.log(`[SNAPSHOT-VALIDATE] Healed legacy 0/0 entry '${codebasePath}' → rows=${rowCount}`);
+                } else if (rowCount === 0) {
+                    // Collection exists but truly empty — the 0/0+completed entry
+                    // is a phantom. Remove so the user must explicitly reindex.
+                    this.snapshotManager.removeCodebaseCompletely(codebasePath);
+                    removed++;
+                    console.warn(`[SNAPSHOT-VALIDATE] Removed phantom 0/0 entry '${codebasePath}' — collection exists but empty`);
+                } else {
+                    // rowCount === -1 despite the collection existing: the count
+                    // query failed after the existence probe succeeded. Treat as
+                    // transient and leave the entry alone.
+                    skipped++;
+                    console.warn(`[SNAPSHOT-VALIDATE] Row count unavailable for existing collection '${codebasePath}', skipping`);
+                }
+            }
+
+            if (healed > 0 || removed > 0) {
+                this.snapshotManager.saveCodebaseSnapshot();
+            }
+            if (checked > 0) {
+                console.log(`[SNAPSHOT-VALIDATE] Done — checked=${checked} healed=${healed} removed=${removed} skipped=${skipped}`);
+            }
+        } catch (error) {
+            console.warn(`[SNAPSHOT-VALIDATE] Unexpected error during legacy 0/0 validation (non-fatal):`, error);
+        }
+    }
+
+    /**
      * Sync indexed codebases from Zilliz Cloud collections
      * This method fetches all collections from the vector database,
      * extracts codebasePath from collection description (preferred) or falls back
@@ -146,16 +271,22 @@ export class ToolHandlers {
                 }
             }
 
-            // Add cloud codebases that are missing from local snapshot (recovery)
+            // Add cloud codebases that are missing from local snapshot (recovery).
+            // Query Milvus for the real row count — if unknown/empty, skip the write
+            // so we don't persist a poisoning 0/0+completed entry (Issue #295).
             for (const cloudCodebase of cloudCodebases) {
                 if (!localCodebases.has(cloudCodebase)) {
-                    this.snapshotManager.setCodebaseIndexed(cloudCodebase, {
-                        indexedFiles: 0,
-                        totalChunks: 0,
-                        status: 'completed' as const
-                    });
-                    hasChanges = true;
-                    console.log(`[SYNC-CLOUD] ➕ Recovered codebase from cloud: ${cloudCodebase}`);
+                    const stats = await this.queryCollectionStats(cloudCodebase);
+                    if (stats) {
+                        this.snapshotManager.setCodebaseIndexed(cloudCodebase, {
+                            ...stats,
+                            status: 'completed' as const
+                        });
+                        hasChanges = true;
+                        console.log(`[SYNC-CLOUD] ➕ Recovered codebase from cloud: ${cloudCodebase} (rows=${stats.totalChunks})`);
+                    } else {
+                        console.log(`[SYNC-CLOUD] ⏭️  Skipped recovery for ${cloudCodebase} (row count unknown or zero)`);
+                    }
                 }
             }
 
@@ -242,9 +373,17 @@ export class ToolHandlers {
             const vectorDbHasIndex = await this.context.hasIndex(absolutePath);
             if (snapshotHasIndex !== vectorDbHasIndex) {
                 if (vectorDbHasIndex && !snapshotHasIndex) {
-                    console.warn(`[INDEX-VALIDATION] Recovering missing snapshot for '${absolutePath}'`);
-                    this.snapshotManager.setCodebaseIndexed(absolutePath, { indexedFiles: 0, totalChunks: 0, status: 'completed' as const });
-                    this.snapshotManager.saveCodebaseSnapshot();
+                    // Query Milvus for real row count. If unknown/empty, log and move on
+                    // without writing 0/0+completed (which would trigger the force-reindex
+                    // loop in Issue #295). The user is about to (re)index anyway.
+                    const stats = await this.queryCollectionStats(absolutePath);
+                    if (stats) {
+                        console.warn(`[INDEX-VALIDATION] Recovering missing snapshot for '${absolutePath}' (rows=${stats.totalChunks})`);
+                        this.snapshotManager.setCodebaseIndexed(absolutePath, { ...stats, status: 'completed' as const });
+                        this.snapshotManager.saveCodebaseSnapshot();
+                    } else {
+                        console.warn(`[INDEX-VALIDATION] VectorDB reports index for '${absolutePath}' but row count unknown/zero — not writing snapshot entry`);
+                    }
                 } else if (!vectorDbHasIndex && snapshotHasIndex) {
                     console.warn(`[INDEX-VALIDATION] Clearing stale snapshot for '${absolutePath}'`);
                     this.snapshotManager.removeCodebaseCompletely(absolutePath);
@@ -498,13 +637,27 @@ export class ToolHandlers {
             const isIndexing = this.snapshotManager.getIndexingCodebases().includes(absolutePath);
 
             if (!isIndexed && !isIndexing) {
-                // Fallback: check VectorDB directly in case snapshot is out of sync
+                // Fallback: check VectorDB directly in case snapshot is out of sync.
+                // Only recover the snapshot when we can confirm a real row count —
+                // writing 0/0+completed for an unverifiable collection poisons the
+                // client into a force-reindex loop (Issue #295).
                 const hasVectorIndex = await this.context.hasIndex(absolutePath);
                 if (hasVectorIndex) {
-                    console.warn(`[SEARCH] Snapshot missing but VectorDB has index for '${absolutePath}', recovering snapshot`);
-                    this.snapshotManager.setCodebaseIndexed(absolutePath, { indexedFiles: 0, totalChunks: 0, status: 'completed' as const });
-                    this.snapshotManager.saveCodebaseSnapshot();
-                    // Continue with search (don't return error)
+                    const stats = await this.queryCollectionStats(absolutePath);
+                    if (stats) {
+                        console.warn(`[SEARCH] Snapshot missing but VectorDB has index for '${absolutePath}', recovering snapshot (rows=${stats.totalChunks})`);
+                        this.snapshotManager.setCodebaseIndexed(absolutePath, { ...stats, status: 'completed' as const });
+                        this.snapshotManager.saveCodebaseSnapshot();
+                        // Continue with search (don't return error)
+                    } else {
+                        return {
+                            content: [{
+                                type: "text",
+                                text: `Error: Codebase '${absolutePath}' is not indexed. Please index it first using the index_codebase tool.`
+                            }],
+                            isError: true
+                        };
+                    }
                 } else {
                     return {
                         content: [{

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -249,6 +249,11 @@ This tool is versatile and can be used before completing various tasks to retrie
         console.log('[SYNC-DEBUG] MCP server start() method called');
         console.log('Starting Context MCP server...');
 
+        // One-shot startup healing for legacy 0/0+completed snapshot entries
+        // left over from pre-fix MCP versions. Runs before the transport accepts
+        // requests so clients never observe the poisoning state. See Issue #295.
+        await this.toolHandlers.validateLegacyZeroEntries();
+
         const transport = new StdioServerTransport();
         console.log('[SYNC-DEBUG] StdioServerTransport created, attempting server connection...');
 

--- a/packages/mcp/src/snapshot.ts
+++ b/packages/mcp/src/snapshot.ts
@@ -45,6 +45,7 @@ export class SnapshotManager {
                 console.log(`[SNAPSHOT-DEBUG] Validated codebase: ${codebasePath}`);
             } else {
                 console.warn(`[SNAPSHOT-DEBUG] Codebase no longer exists, removing: ${codebasePath}`);
+                this.recentlyRemoved.add(codebasePath);
             }
         }
 
@@ -66,6 +67,7 @@ export class SnapshotManager {
                 // Don't add to validIndexingCodebases - treat as not indexed
             } else {
                 console.warn(`[SNAPSHOT-DEBUG] Interrupted indexing codebase no longer exists: ${codebasePath}`);
+                this.recentlyRemoved.add(codebasePath);
             }
         }
 
@@ -103,6 +105,7 @@ export class SnapshotManager {
         for (const [codebasePath, info] of Object.entries(snapshot.codebases)) {
             if (!fs.existsSync(codebasePath)) {
                 console.warn(`[SNAPSHOT-DEBUG] Codebase no longer exists, removing: ${codebasePath}`);
+                this.recentlyRemoved.add(codebasePath);
                 continue;
             }
 
@@ -359,6 +362,16 @@ export class SnapshotManager {
         codebasePath: string,
         stats: { indexedFiles: number; totalChunks: number; status: 'completed' | 'limit_reached' }
     ): void {
+        // Defensive guard: 0/0 + completed is a known-bad state that causes an
+        // infinite force-reindex loop — the client reads it as "not indexed",
+        // triggers force=true, deletes real data, and rewrites 0/0. Refuse to
+        // persist this combination regardless of who called us. See Issue #295.
+        if (stats.indexedFiles === 0 && stats.totalChunks === 0 && stats.status === 'completed') {
+            console.error(`[SNAPSHOT] Refusing to write 0/0+completed for '${codebasePath}' — invalid state. Stack trace:`);
+            console.trace();
+            return;
+        }
+
         // Add to indexed list if not already there
         if (!this.indexedCodebases.includes(codebasePath)) {
             this.indexedCodebases.push(codebasePath);


### PR DESCRIPTION
## Summary

Fixes #295 — snapshot recovery paths wrote hardcoded `{indexedFiles: 0, totalChunks: 0, status: completed}` when restoring entries from Milvus. The client interprets 0/0 as "not indexed", triggers `force=true`, which deletes real Milvus data and rewrites 0/0 — creating an infinite reindex loop.

**Root cause**: Three recovery paths in `handlers.ts` (cloud sync, index validation, search fallback — introduced in #283) restored snapshot *existence* but not the real row count, because no method existed to query collection statistics reliably.

### Changes

| File | Change |
|------|--------|
| `packages/core/src/vectordb/types.ts` | Add `getCollectionRowCount()` to `VectorDatabase` interface |
| `packages/core/src/vectordb/milvus-vectordb.ts` | Implement via `count(*)` query (not `getCollectionStatistics` — that lags unflushed inserts) |
| `packages/core/src/vectordb/milvus-restful-vectordb.ts` | Same via REST `/entities/query` endpoint |
| `packages/mcp/src/handlers.ts` | Replace 3 hardcoded 0/0 writes with real row count queries; add startup `validateLegacyZeroEntries()` to auto-heal old 0/0 entries |
| `packages/mcp/src/index.ts` | Wire up startup validation before transport accepts requests |
| `packages/mcp/src/snapshot.ts` | Defensive guard: `setCodebaseIndexed` rejects 0/0+completed; fix `loadV1Format`/`loadV2Format` to mark skipped paths in `recentlyRemoved` so read-merge-write doesn't re-add orphan entries |

### Design decisions

- **`-1` sentinel for unknown row count** — callers that get `-1` skip the snapshot write rather than persisting a poisoning 0/0 entry. Distinguishes "unknown" from "empty".
- **`count(*)` instead of `getCollectionStatistics`** — stats are segment-based and return 0 for freshly-indexed but unflushed data. `count(*)` gives the real current count. Discovered during E2E testing.
- **Startup validation with `hasCollection` probe** — distinguishes "Milvus unreachable" (transient, skip) from "collection doesn't exist" (permanent orphan, remove). Prevents destroying state on network blips.
- **Defensive guard** is a safety net: even if future code paths forget to check, the invalid 0/0+completed state cannot be persisted.

## Test plan

- [x] Normal indexing writes real stats (4 files / 10 chunks)
- [x] Snapshot loss + existing Milvus data → recovery writes real row count, search works
- [x] Force reindex completes normally with accurate stats
- [x] Empty Milvus collection → no snapshot poisoning, returns "not indexed" error
- [x] Legacy 0/0 entries auto-healed on startup (3 variants: has data → heal, empty collection → remove, no collection → remove)
- [x] Larger codebase (67 files / 201 chunks) — Milvus rows match snapshot
- [x] User manually drops Milvus collection → cloud sync cleans snapshot
- [x] User deletes local codebase directory → orphan entry cleaned on restart
- [x] Process killed mid-indexing (481 files, 87%) → `indexfailed` state, force reindex recovers fully
- [x] Defensive guard verified: 0/0+completed blocked with stack trace, normal writes pass
- [x] Final consistency check: all entries' Milvus row count matches snapshot `totalChunks`
- [x] `pnpm build:core` and `pnpm build:mcp` pass cleanly