### PR TITLE
feat: add OpenRouter as embedding provider name

### DIFF
--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -4,7 +4,7 @@ export interface ContextMcpConfig {
     name: string;
     version: string;
     // Embedding provider configuration
-    embeddingProvider: 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama';
+    embeddingProvider: 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama' | 'OpenRouter';
     embeddingModel: string;
     // Provider-specific API keys
     openaiApiKey?: string;
@@ -12,6 +12,8 @@ export interface ContextMcpConfig {
     voyageaiApiKey?: string;
     geminiApiKey?: string;
     geminiBaseUrl?: string;
+    // OpenRouter configuration
+    openrouterApiKey?: string;
     // Ollama configuration
     ollamaModel?: string;
     ollamaHost?: string;
@@ -76,6 +78,8 @@ export function getDefaultModelForProvider(provider: string): string {
             return 'voyage-code-3';
         case 'Gemini':
             return 'gemini-embedding-001';
+        case 'OpenRouter':
+            return 'openai/text-embedding-3-small';
         case 'Ollama':
             return 'nomic-embed-text';
         default:
@@ -94,6 +98,7 @@ export function getEmbeddingModelForProvider(provider: string): string {
         case 'OpenAI':
         case 'VoyageAI':
         case 'Gemini':
+        case 'OpenRouter':
         default:
             // For all other providers, use EMBEDDING_MODEL or default
             const selectedModel = envManager.get('EMBEDDING_MODEL') || getDefaultModelForProvider(provider);
@@ -117,7 +122,7 @@ export function createMcpConfig(): ContextMcpConfig {
         name: envManager.get('MCP_SERVER_NAME') || "Context MCP Server",
         version: envManager.get('MCP_SERVER_VERSION') || "1.0.0",
         // Embedding provider configuration
-        embeddingProvider: (envManager.get('EMBEDDING_PROVIDER') as 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama') || 'OpenAI',
+        embeddingProvider: (envManager.get('EMBEDDING_PROVIDER') as 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama' | 'OpenRouter') || 'OpenAI',
         embeddingModel: getEmbeddingModelForProvider(envManager.get('EMBEDDING_PROVIDER') || 'OpenAI'),
         // Provider-specific API keys
         openaiApiKey: envManager.get('OPENAI_API_KEY'),
@@ -125,6 +130,8 @@ export function createMcpConfig(): ContextMcpConfig {
         voyageaiApiKey: envManager.get('VOYAGEAI_API_KEY'),
         geminiApiKey: envManager.get('GEMINI_API_KEY'),
         geminiBaseUrl: envManager.get('GEMINI_BASE_URL'),
+        // OpenRouter configuration
+        openrouterApiKey: envManager.get('OPENROUTER_API_KEY'),
         // Ollama configuration
         ollamaModel: envManager.get('OLLAMA_MODEL'),
         ollamaHost: envManager.get('OLLAMA_HOST'),
@@ -162,6 +169,9 @@ export function logConfigurationSummary(config: ContextMcpConfig): void {
                 console.log(`[MCP]   Gemini Base URL: ${config.geminiBaseUrl}`);
             }
             break;
+        case 'OpenRouter':
+            console.log(`[MCP]   OpenRouter API Key: ${config.openrouterApiKey ? '✅ Configured' : '❌ Missing'}`);
+            break;
         case 'Ollama':
             console.log(`[MCP]   Ollama Host: ${config.ollamaHost || 'http://127.0.0.1:11434'}`);
             console.log(`[MCP]   Ollama Model: ${config.embeddingModel}`);
@@ -185,7 +195,7 @@ Environment Variables:
   MCP_SERVER_VERSION      Server version
   
   Embedding Provider Configuration:
-  EMBEDDING_PROVIDER      Embedding provider: OpenAI, VoyageAI, Gemini, Ollama (default: OpenAI)
+  EMBEDDING_PROVIDER      Embedding provider: OpenAI, VoyageAI, Gemini, Ollama, OpenRouter (default: OpenAI)
   EMBEDDING_MODEL         Embedding model name (works for all providers)
   
   Provider-specific API Keys:
@@ -194,7 +204,8 @@ Environment Variables:
   VOYAGEAI_API_KEY        VoyageAI API key (required for VoyageAI provider)
   GEMINI_API_KEY          Google AI API key (required for Gemini provider)
   GEMINI_BASE_URL         Gemini API base URL (optional, for custom endpoints)
-  
+  OPENROUTER_API_KEY      OpenRouter API key (required for OpenRouter provider)
+
   Ollama Configuration:
   OLLAMA_HOST             Ollama server host (default: http://127.0.0.1:11434)
   OLLAMA_MODEL            Ollama model name (alternative to EMBEDDING_MODEL for Ollama)

--- a/packages/mcp/src/embedding.ts
+++ b/packages/mcp/src/embedding.ts
@@ -2,7 +2,7 @@ import { OpenAIEmbedding, VoyageAIEmbedding, GeminiEmbedding, OllamaEmbedding } 
 import { ContextMcpConfig } from "./config.js";
 
 // Helper function to create embedding instance based on provider
-export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding {
+export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding  {
     console.log(`[EMBEDDING] Creating ${config.embeddingProvider} embedding instance...`);
 
     switch (config.embeddingProvider) {
@@ -47,6 +47,21 @@ export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbeddi
             console.log(`[EMBEDDING] ✅ Gemini embedding instance created successfully`);
             return geminiEmbedding;
 
+        case 'OpenRouter':
+            if (!config.openrouterApiKey) {
+                console.error(`[EMBEDDING] ❌ OpenRouter API key is required but not provided`);
+                throw new Error('OPENROUTER_API_KEY is required for OpenRouter embedding provider');
+            }
+            console.log(`[EMBEDDING] 🔧 Configuring OpenRouter with model: ${config.embeddingModel}`);
+            // Reuse OpenAIEmbedding with OpenRouter's OpenAI-compatible endpoint
+            const openrouterEmbedding = new OpenAIEmbedding({
+                apiKey: config.openrouterApiKey,
+                model: config.embeddingModel,
+                baseURL: 'https://openrouter.ai/api/v1',
+            });
+            console.log(`[EMBEDDING] ✅ OpenRouter embedding instance created successfully`);
+            return openrouterEmbedding;
+
         case 'Ollama':
             const ollamaHost = config.ollamaHost || 'http://127.0.0.1:11434';
             console.log(`[EMBEDDING] 🔧 Configuring Ollama with model: ${config.embeddingModel}, host: ${ollamaHost}`);
@@ -77,6 +92,9 @@ export function logEmbeddingProviderInfo(config: ContextMcpConfig, embedding: Op
             break;
         case 'Gemini':
             console.log(`[EMBEDDING] Gemini configuration - API Key: ${config.geminiApiKey ? '✅ Provided' : '❌ Missing'}, Base URL: ${config.geminiBaseUrl || 'Default'}`);
+            break;
+        case 'OpenRouter':
+            console.log(`[EMBEDDING] OpenRouter configuration - API Key: ${config.openrouterApiKey ? '✅ Provided' : '❌ Missing'}`);
             break;
         case 'Ollama':
             console.log(`[EMBEDDING] Ollama configuration - Host: ${config.ollamaHost || 'http://127.0.0.1:11434'}, Model: ${config.embeddingModel}`);


### PR DESCRIPTION
## Summary

Add OpenRouter as a first-class provider name for cleaner UX. Reuses `OpenAIEmbedding` internally with OpenRouter's OpenAI-compatible endpoint — zero code duplication.

## Motivation

Users can achieve the same result via `OPENAI_BASE_URL` workaround, but a named provider gives better discoverability and simpler configuration.

## Changes (2 files, ~30 lines)

- `packages/mcp/src/config.ts` — Add `OpenRouter` to provider union, `OPENROUTER_API_KEY` env var, default model, help message
- `packages/mcp/src/embedding.ts` — Add `OpenRouter` case that creates `OpenAIEmbedding` with `baseURL: 'https://openrouter.ai/api/v1'`

No new files. No new dependencies. No code duplication.

## Usage

```bash
EMBEDDING_PROVIDER=OpenRouter \
OPENROUTER_API_KEY=sk-or-v1-xxx \
EMBEDDING_MODEL=openai/text-embedding-3-small \
npx @zilliz/claude-context-mcp@latest
```

## Test plan

- [ ] OpenRouter provider starts and connects
- [ ] Existing providers unaffected (no regression)
- [ ] `pnpm build` passes