### PR TITLE
feat: add voyage-4 model series and remove unused method

### DIFF
--- a/packages/core/src/embedding/voyageai-embedding.ts
+++ b/packages/core/src/embedding/voyageai-embedding.ts
@@ -44,23 +44,6 @@ export class VoyageAIEmbedding extends Embedding {
         }
     }
 
-    private updateDimensionForModel(model: string): void {
-        const supportedModels = VoyageAIEmbedding.getSupportedModels();
-        const modelInfo = supportedModels[model];
-
-        if (modelInfo) {
-            // If dimension is a string (indicating variable dimension), use default value 1024
-            if (typeof modelInfo.dimension === 'string') {
-                this.dimension = 1024; // Default dimension
-            } else {
-                this.dimension = modelInfo.dimension;
-            }
-        } else {
-            // Use default dimension for unknown models
-            this.dimension = 1024;
-        }
-    }
-
     async detectDimension(): Promise<number> {
         // VoyageAI doesn't need dynamic detection, return configured dimension
         return this.dimension;
@@ -148,7 +131,28 @@ export class VoyageAIEmbedding extends Embedding {
      */
     static getSupportedModels(): Record<string, { dimension: number | string; contextLength: number; description: string }> {
         return {
-            // Latest recommended models
+            // Voyage 4 series (January 2026)
+            'voyage-4-large': {
+                dimension: '1024 (default), 256, 512, 2048',
+                contextLength: 32000,
+                description: 'Best general-purpose and multilingual retrieval quality (latest)'
+            },
+            'voyage-4': {
+                dimension: '1024 (default), 256, 512, 2048',
+                contextLength: 32000,
+                description: 'Optimized for general-purpose and multilingual retrieval quality'
+            },
+            'voyage-4-lite': {
+                dimension: '1024 (default), 256, 512, 2048',
+                contextLength: 32000,
+                description: 'Optimized for latency and cost'
+            },
+            'voyage-4-nano': {
+                dimension: '512 (default), 128, 256',
+                contextLength: 32000,
+                description: 'Open-weight model, smallest and fastest'
+            },
+            // Voyage 3 series
             'voyage-3-large': {
                 dimension: '1024 (default), 256, 512, 2048',
                 contextLength: 32000,


### PR DESCRIPTION
## Summary

- Add voyage-4-large, voyage-4, voyage-4-lite, and voyage-4-nano to the VoyageAI supported models list (released January 2026)
- Remove unused `updateDimensionForModel()` which duplicated logic from `updateModelSettings()`

## Changes

- `packages/core/src/embedding/voyageai-embedding.ts` — Add 4 voyage-4 models, remove dead method

## Test plan

- [ ] `pnpm build` passes
- [ ] Existing VoyageAI models still work (no regression)