### PR TITLE
fix: parse default dimension from model metadata string

### DIFF
--- a/packages/core/src/embedding/voyageai-embedding.ts
+++ b/packages/core/src/embedding/voyageai-embedding.ts
@@ -29,9 +29,10 @@ export class VoyageAIEmbedding extends Embedding {
         const modelInfo = supportedModels[model];
 
         if (modelInfo) {
-            // If dimension is a string (indicating variable dimension), use default value 1024
             if (typeof modelInfo.dimension === 'string') {
-                this.dimension = 1024; // Default dimension
+                // Parse default dimension from string like "1024 (default), 256, 512, 2048"
+                const match = modelInfo.dimension.match(/^(\d+)/);
+                this.dimension = match ? parseInt(match[1], 10) : 1024;
             } else {
                 this.dimension = modelInfo.dimension;
             }


### PR DESCRIPTION
## Summary

Fix dimension detection for variable-dimension models. Previously hardcoded 1024 for all models with string-format dimensions. Now parses the actual default from the string.

## Motivation

Models like voyage-4-nano have a default dimension of 512, not 1024. The string format `"512 (default), 128, 256"` contains the correct default but was ignored in favor of a hardcoded 1024, causing schema mismatches when creating collections.

## Changes

- `packages/core/src/embedding/voyageai-embedding.ts` — Parse leading number from dimension string with regex instead of hardcoding 1024

## Test plan

- [ ] `pnpm build` passes
- [ ] Models with 1024 default still return 1024
- [ ] Models with 512 default (e.g., voyage-4-nano) correctly return 512