### PR TITLE
docs: add MILVUS_ADDRESS to Claude Code quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Use the command line interface to add the Claude Context MCP server:
 ```bash
 claude mcp add claude-context \
   -e OPENAI_API_KEY=sk-your-openai-api-key \
+  -e MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint \
   -e MILVUS_TOKEN=your-zilliz-cloud-api-key \
   -- npx @zilliz/claude-context-mcp@latest
 ```


### PR DESCRIPTION
Fixes #258 — Claude Code quick-start is missing MILVUS_ADDRESS, causing 'Address is required and could not be resolved from token' crash on startup.

All other MCP client examples in the README (VS Code, Codex CLI, Cline, etc.) include MILVUS_ADDRESS, but the Claude Code CLI command omitted it. This change adds it consistently.

## Changes
- Added `-e MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint` to the Claude Code quick-start command in README.md

## Testing
The fix matches the pattern already used by Codex CLI, VS Code, and other clients documented in the same README.