### PR TITLE
docs(readme): add MILVUS_ADDRESS to Claude Code setup

### DIFF
--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -73,6 +73,7 @@ cat > ~/.context/.env << 'EOF'
 EMBEDDING_PROVIDER=OpenAI
 OPENAI_API_KEY=sk-your-openai-api-key
 EMBEDDING_MODEL=text-embedding-3-small
+MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint
 MILVUS_TOKEN=your-zilliz-cloud-api-key
 EOF
 ```
@@ -83,7 +84,11 @@ See the [Example File](../../.env.example) for more details.
 
 **Claude Code:**
 ```bash
-claude mcp add claude-context -- npx @zilliz/claude-context-mcp@latest
+claude mcp add claude-context \
+  -e OPENAI_API_KEY=sk-your-openai-api-key \
+  -e MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint \
+  -e MILVUS_TOKEN=your-zilliz-cloud-api-key \
+  -- npx @zilliz/claude-context-mcp@latest
 ```
 
 **Cursor/Windsurf/Others:**
@@ -102,4 +107,3 @@ claude mcp add claude-context -- npx @zilliz/claude-context-mcp@latest
 
 For detailed information about file processing rules and how custom patterns work, see:
 - [What files does Claude Context decide to embed?](../troubleshooting/faq.md#q-what-files-does-claude-context-decide-to-embed)
- 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -19,6 +19,7 @@ Run this single command to add Claude Context to Claude Code:
 ```bash
 claude mcp add claude-context \
   -e OPENAI_API_KEY=sk-your-openai-api-key \
+  -e MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint \
   -e MILVUS_TOKEN=your-zilliz-cloud-api-key \
   -- npx @zilliz/claude-context-mcp@latest
 ```

--- a/packages/mcp/CONTRIBUTING.md
+++ b/packages/mcp/CONTRIBUTING.md
@@ -101,7 +101,7 @@ You can use the following configuration to configure the MCP server with a devel
 
 ### Claude Code Development Mode Configuration
 ```bash
-claude mcp add claude-context -e OPENAI_API_KEY=sk-your-openai-api-key -e MILVUS_TOKEN=your-zilliz-cloud-api-key -- node PATH_TO_CLAUDECONTEXT/packages/mcp/dist/index.js
+claude mcp add claude-context -e OPENAI_API_KEY=sk-your-openai-api-key -e MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint -e MILVUS_TOKEN=your-zilliz-cloud-api-key -- node PATH_TO_CLAUDECONTEXT/packages/mcp/dist/index.js
 ```
 And then you can start Claude Code with `claude --debug` to see the MCP server logs.
 
@@ -115,4 +115,4 @@ Use all three MCP tools:
 ## Questions?
 
 - **General questions**: See [main contributing guide](../../CONTRIBUTING.md)
-- **MCP-specific issues**: Open an issue with the `mcp` label 
+- **MCP-specific issues**: Open an issue with the `mcp` label

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -192,7 +192,7 @@ Use the command line interface to add the Claude Context MCP server:
 
 ```bash
 # Add the Claude Context MCP server
-claude mcp add claude-context -e OPENAI_API_KEY=your-openai-api-key -e MILVUS_TOKEN=your-zilliz-cloud-api-key -- npx @zilliz/claude-context-mcp@latest
+claude mcp add claude-context -e OPENAI_API_KEY=your-openai-api-key -e MILVUS_ADDRESS=your-zilliz-cloud-public-endpoint -e MILVUS_TOKEN=your-zilliz-cloud-api-key -- npx @zilliz/claude-context-mcp@latest
 
 ```
 


### PR DESCRIPTION
## Summary
- add `MILVUS_ADDRESS` to the remaining Claude Code setup examples
- align the MCP package docs and contributing guide with the already-correct root README
- update the docs environment-variable quick start so the global config example matches the Claude Code command

Closes #311
