### PR TITLE
fix(core): tolerate gRPC timeout in checkCollectionLimit and clean up orphans

### DIFF
--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -47,6 +47,7 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 |----------|-------------|---------|
 | `MILVUS_TOKEN` | Milvus authentication token. Get [Zilliz Personal API Key](https://github.com/zilliztech/claude-context/blob/master/assets/signup_and_get_apikey.png) | Recommended |
 | `MILVUS_ADDRESS` | Milvus server address. Optional when using Zilliz Personal API Key | Auto-resolved from token |
+| `MILVUS_COLLECTION_LIMIT_CHECK_TIMEOUT_MS` | Timeout for gRPC pre-check in `checkCollectionLimit()` before indexing begins | `15000` |
 
 ### Ollama (Optional)
 | Variable | Description | Default |

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -742,6 +742,8 @@ export class MilvusVectorDatabase implements VectorDatabase {
             throw new Error('MilvusClient is not initialized. Call ensureInitialized() first.');
         }
 
+        const parsedTimeoutMs = Number(process.env.MILVUS_COLLECTION_LIMIT_CHECK_TIMEOUT_MS);
+        const timeoutMs = Number.isFinite(parsedTimeoutMs) && parsedTimeoutMs > 0 ? parsedTimeoutMs : 15000;
         const collectionName = `dummy_collection_${Date.now()}`;
         const createCollectionParams = {
             collection_name: collectionName,
@@ -761,8 +763,39 @@ export class MilvusVectorDatabase implements VectorDatabase {
             ]
         };
 
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+        let timedOut = false;
         try {
-            await this.client.createCollection(createCollectionParams);
+            const createPromise = this.client.createCollection(createCollectionParams);
+            // Best-effort late cleanup ONLY if the timeout fires first. Gated by `timedOut`
+            // so we do not race the normal-path drop below on fast successes.
+            void createPromise
+                .then(async () => {
+                    if (!timedOut) return;
+                    try {
+                        if (!this.client) return;
+                        if (await this.client.hasCollection({ collection_name: collectionName })) {
+                            await this.client.dropCollection({
+                                collection_name: collectionName,
+                            });
+                        }
+                    } catch {
+                        // Best effort only: orphan cleanup is not user-visible.
+                    }
+                })
+                .catch(() => {
+                    // createCollection failed; nothing to clean up.
+                });
+
+            await Promise.race([
+                createPromise,
+                new Promise<never>((_, reject) => {
+                    timeoutHandle = setTimeout(() => {
+                        timedOut = true;
+                        reject(new Error(`checkCollectionLimit timeout after ${timeoutMs}ms`));
+                    }, timeoutMs);
+                }),
+            ]);
             // Immediately drop the collection after successful creation
             if (await this.client.hasCollection({ collection_name: collectionName })) {
                 await this.client.dropCollection({
@@ -777,8 +810,19 @@ export class MilvusVectorDatabase implements VectorDatabase {
                 // Return false for collection limit exceeded
                 return false;
             }
+            if (/deadline_exceeded|deadline exceeded|timeout/i.test(errorMessage)) {
+                console.warn(
+                    `[MilvusDB] checkCollectionLimit timed out after ${timeoutMs}ms; proceeding without limit pre-check. ` +
+                    'Set MILVUS_COLLECTION_LIMIT_CHECK_TIMEOUT_MS to increase timeout.'
+                );
+                return true;
+            }
             // Re-throw other errors as-is
             throw error;
+        } finally {
+            if (timeoutHandle) {
+                clearTimeout(timeoutHandle);
+            }
         }
     }
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -159,6 +159,9 @@ Copy your Personal Key to replace `your-zilliz-cloud-api-key` in the configurati
 
 ```bash
 MILVUS_TOKEN=your-zilliz-cloud-api-key
+
+# Optional: increase timeout for Milvus collection-limit pre-check on slow clusters (default: 15000)
+MILVUS_COLLECTION_LIMIT_CHECK_TIMEOUT_MS=30000
 ```
 
 #### Embedding Batch Size


### PR DESCRIPTION
## Summary

Makes `checkCollectionLimit()` tolerant of slow or congested Zilliz clusters. The preflight dummy-create uses the Milvus client's default 15s gRPC deadline; on free-tier or serverless clusters that deadline fires before the RPC can settle and the user sees a `DEADLINE_EXCEEDED` before any indexing starts.

## Why this matters

Two open issues with the same symptom, same Zilliz cluster address (`34.111.198.99:443`), same `checkCollectionLimit()` call:
- [#290](https://github.com/zilliztech/claude-context/issues/290) - Zilliz serverless, VoyageAI, macOS
- [#289](https://github.com/zilliztech/claude-context/issues/289) - Zilliz Free tier, same cluster, same 15s deadline

@aud1ence did the root-cause trace on #290 and located it in `packages/core/src/vectordb/milvus-vectordb.ts`.

## Changes

`checkCollectionLimit()` now wraps the dummy `createCollection` in a `Promise.race` with a configurable deadline:

- New env var `MILVUS_COLLECTION_LIMIT_CHECK_TIMEOUT_MS`, default `15000` (matches current behavior for anyone not setting it)
- On timeout or DEADLINE_EXCEEDED, warn and return `true`. The subsequent real `createCollection` surfaces a cleaner quota error if the user is actually over the limit
- Quota detection path (`exceeded the limit number of collections`) unchanged
- Other errors still re-thrown
- Orphan safety: if the gRPC create eventually resolves after the race timed out, a detached best-effort handler drops the late-arriving `dummy_collection_*`. The handler is gated by a `timedOut` flag so it only runs on the timeout path and never races the main-path drop on fast successes

Mirrors the REST backend's existing unimplemented-stub behavior (returns `true` with a warning).

## Testing

`pnpm install --frozen-lockfile && pnpm build` passes locally on Node 22.

Manual repro of the happy path (`checkCollectionLimit` completes under deadline, dummy created and dropped, return `true`) and the timeout path (set `MILVUS_COLLECTION_LIMIT_CHECK_TIMEOUT_MS=1`, expect warn-and-return-`true`) was reasoned through, not executed end-to-end against a live cluster.

## Docs

- `docs/getting-started/environment-variables.md`: added row for the new env var
- `packages/mcp/README.md`: added an example entry

## Preempting a couple of reviewer questions

- Why not swap to `listCollections().length` as @aud1ence suggested? Different semantics - Milvus collection limits count aliased/loading collections in ways that a naive length check would miss. That's a larger rework and needs its own design discussion.
- What if the user really is over quota when we time out? The next real `createCollection` for indexing fires anyway and returns the actual `exceeded the limit number of collections` error with the proper message. Trading one obscure timeout error for a clearer quota error.

Fixes #289
Fixes #290
