### PR TITLE
feat(core): support custom collection-name override via env var

### DIFF
--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -63,6 +63,9 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 | `SPLITTER_TYPE` | Code splitter type: `ast`, `langchain` | `ast` |
 | `CUSTOM_EXTENSIONS` | Additional file extensions to include (comma-separated, e.g., `.vue,.svelte,.astro`) | None |
 | `CUSTOM_IGNORE_PATTERNS` | Additional ignore patterns (comma-separated, e.g., `temp/**,*.backup,private/**`) | None |
+| `CODE_CHUNKS_COLLECTION_NAME_OVERRIDE` | Optional custom prefix for collection names. Produces `code_chunks_<suffix>_<pathHash>` or `hybrid_code_chunks_<suffix>_<pathHash>` after sanitization. The path hash stays appended so collections remain unique per codebase even when the override is set | None |
+
+When `CODE_CHUNKS_COLLECTION_NAME_OVERRIDE` is set, Claude Context writes to an override-named collection instead of the default `code_chunks_<pathHash>`. The per-codebase `<pathHash>` suffix is preserved to keep multiple codebases distinct under the same override. If you later unset the variable, Claude Context returns to the plain hash-based naming for that path.
 
 ## 🚀 Quick Setup
 

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -94,14 +94,19 @@ export interface ContextConfig {
     ignorePatterns?: string[];
     customExtensions?: string[]; // New: custom extensions from MCP
     customIgnorePatterns?: string[]; // New: custom ignore patterns from MCP
+    collectionNameOverride?: string; // Optional: custom collection name suffix
 }
 
 export class Context {
+    private static readonly MAX_COLLECTION_NAME_LENGTH = 255;
+
     private embedding: Embedding;
     private vectorDatabase: VectorDatabase;
     private codeSplitter: Splitter;
     private supportedExtensions: string[];
     private ignorePatterns: string[];
+    private collectionNameOverride?: string;
+    private warnedOverrideSanitization = new Set<string>();
     private synchronizers = new Map<string, FileSynchronizer>();
 
     constructor(config: ContextConfig = {}) {
@@ -144,6 +149,7 @@ export class Context {
         ];
         // Remove duplicates
         this.ignorePatterns = [...new Set(allIgnorePatterns)];
+        this.collectionNameOverride = config.collectionNameOverride;
 
         console.log(`[Context] 🔧 Initialized with ${this.supportedExtensions.length} supported extensions and ${this.ignorePatterns.length} ignore patterns`);
         if (envCustomExtensions.length > 0) {
@@ -233,10 +239,58 @@ export class Context {
      */
     public getCollectionName(codebasePath: string): string {
         const isHybrid = this.getIsHybrid();
-        const normalizedPath = path.resolve(codebasePath);
-        const hash = crypto.createHash('md5').update(normalizedPath).digest('hex');
         const prefix = isHybrid === true ? 'hybrid_code_chunks' : 'code_chunks';
-        return `${prefix}_${hash.substring(0, 8)}`;
+        const normalizedPath = path.resolve(codebasePath);
+        const pathHash = crypto.createHash('md5').update(normalizedPath).digest('hex').substring(0, 8);
+
+        // Overrides always keep the per-codebase `_<pathHash>` suffix so that multiple
+        // codebases indexed by the same MCP server can't collapse into one collection.
+        const configOverride = this.getValidOverrideValue(this.collectionNameOverride);
+        if (configOverride) {
+            const suffix = this.sanitizeCollectionNameSuffix(configOverride, prefix, pathHash, 'Context config');
+            return `${prefix}_${suffix}`;
+        }
+
+        const envOverride = this.getValidOverrideValue(envManager.get('CODE_CHUNKS_COLLECTION_NAME_OVERRIDE'));
+        if (envOverride) {
+            const suffix = this.sanitizeCollectionNameSuffix(envOverride, prefix, pathHash, 'CODE_CHUNKS_COLLECTION_NAME_OVERRIDE');
+            return `${prefix}_${suffix}`;
+        }
+
+        return `${prefix}_${pathHash}`;
+    }
+
+    private getValidOverrideValue(value?: string): string | undefined {
+        if (!value) {
+            return undefined;
+        }
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+    }
+
+    private sanitizeCollectionNameSuffix(value: string, prefix: string, pathHash: string, source: string): string {
+        const hashSuffix = `_${pathHash}`;
+        // Leave room for both the prefix and the trailing `_<pathHash>` disambiguator.
+        const maxReadableLength = Context.MAX_COLLECTION_NAME_LENGTH - `${prefix}_`.length - hashSuffix.length;
+        const normalized = value.trim();
+        let sanitized = normalized.replace(/[^A-Za-z0-9_]/g, '_');
+        sanitized = sanitized.slice(0, Math.max(0, maxReadableLength));
+
+        if (sanitized.length === 0) {
+            sanitized = 'custom';
+        }
+
+        const full = `${sanitized}${hashSuffix}`;
+
+        if (sanitized !== normalized) {
+            const warningKey = `${source}:${normalized}:${sanitized}`;
+            if (!this.warnedOverrideSanitization.has(warningKey)) {
+                console.warn(`[Context] ⚠️ Sanitized collection name override from "${normalized}" to "${sanitized}" (${source}); final suffix "${full}"`);
+                this.warnedOverrideSanitization.add(warningKey);
+            }
+        }
+
+        return full;
     }
 
     /**

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -183,6 +183,17 @@ CUSTOM_IGNORE_PATTERNS=temp/**,*.backup,private/**,uploads/**
 
 These settings work in combination with tool parameters - patterns from both sources will be merged together.
 
+#### Custom Collection Name (Optional)
+
+Use this when you want a human-readable prefix on collection names in Milvus/Zilliz instead of the bare hash:
+
+```bash
+# Creates code_chunks_my_project_<pathHash> or hybrid_code_chunks_my_project_<pathHash>
+CODE_CHUNKS_COLLECTION_NAME_OVERRIDE=my_project
+```
+
+The per-codebase `<pathHash>` suffix is preserved even when the override is set, so the same MCP server can still index multiple repos without collapsing them onto one collection. The override value is sanitized to letters, numbers, and underscores, and truncated to keep the full name within Milvus's 255-char limit. If you unset the variable later, Claude Context switches back to the plain `code_chunks_<pathHash>` naming.
+
 ## Usage with MCP Clients
 
 <details>

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -18,6 +18,7 @@ export interface ContextMcpConfig {
     // Vector database configuration
     milvusAddress?: string; // Optional, can be auto-resolved from token
     milvusToken?: string;
+    collectionNameOverride?: string;
 }
 
 // Legacy format (v1) - for backward compatibility
@@ -111,6 +112,7 @@ export function createMcpConfig(): ContextMcpConfig {
     console.log(`[DEBUG]   GEMINI_API_KEY: ${envManager.get('GEMINI_API_KEY') ? 'SET (length: ' + envManager.get('GEMINI_API_KEY')!.length + ')' : 'NOT SET'}`);
     console.log(`[DEBUG]   OPENAI_API_KEY: ${envManager.get('OPENAI_API_KEY') ? 'SET (length: ' + envManager.get('OPENAI_API_KEY')!.length + ')' : 'NOT SET'}`);
     console.log(`[DEBUG]   MILVUS_ADDRESS: ${envManager.get('MILVUS_ADDRESS') || 'NOT SET'}`);
+    console.log(`[DEBUG]   CODE_CHUNKS_COLLECTION_NAME_OVERRIDE: ${envManager.get('CODE_CHUNKS_COLLECTION_NAME_OVERRIDE') || 'NOT SET'}`);
     console.log(`[DEBUG]   NODE_ENV: ${envManager.get('NODE_ENV') || 'NOT SET'}`);
 
     const config: ContextMcpConfig = {
@@ -130,7 +132,8 @@ export function createMcpConfig(): ContextMcpConfig {
         ollamaHost: envManager.get('OLLAMA_HOST'),
         // Vector database configuration - address can be auto-resolved from token
         milvusAddress: envManager.get('MILVUS_ADDRESS'), // Optional, can be resolved from token
-        milvusToken: envManager.get('MILVUS_TOKEN')
+        milvusToken: envManager.get('MILVUS_TOKEN'),
+        collectionNameOverride: envManager.get('CODE_CHUNKS_COLLECTION_NAME_OVERRIDE')
     };
 
     return config;
@@ -144,6 +147,9 @@ export function logConfigurationSummary(config: ContextMcpConfig): void {
     console.log(`[MCP]   Embedding Provider: ${config.embeddingProvider}`);
     console.log(`[MCP]   Embedding Model: ${config.embeddingModel}`);
     console.log(`[MCP]   Milvus Address: ${config.milvusAddress || (config.milvusToken ? '[Auto-resolve from token]' : '[Not configured]')}`);
+    if (config.collectionNameOverride) {
+        console.log(`[MCP]   Collection Name Override: ✅ Configured`);
+    }
 
     // Log provider-specific configuration without exposing sensitive data
     switch (config.embeddingProvider) {
@@ -202,6 +208,12 @@ Environment Variables:
   Vector Database Configuration:
   MILVUS_ADDRESS          Milvus address (optional, can be auto-resolved from token)
   MILVUS_TOKEN            Milvus token (optional, used for authentication and address resolution)
+  CODE_CHUNKS_COLLECTION_NAME_OVERRIDE
+                          Optional readable prefix for collection names.
+                          Uses code_chunks_<override>_<pathHash> (or hybrid_...)
+                          after sanitization (letters/digits/underscore, 255 chars max).
+                          The per-codebase pathHash is preserved so multiple
+                          codebases stay distinct under the same override.
 
 Examples:
   # Start MCP server with OpenAI (default) and explicit Milvus address
@@ -221,5 +233,8 @@ Examples:
   
   # Start MCP server with Ollama and specific model (using EMBEDDING_MODEL)
   EMBEDDING_PROVIDER=Ollama EMBEDDING_MODEL=nomic-embed-text MILVUS_TOKEN=your-token npx @zilliz/claude-context-mcp@latest
+
+  # Start MCP server with a human-readable collection name override
+  OPENAI_API_KEY=sk-xxx MILVUS_TOKEN=your-token CODE_CHUNKS_COLLECTION_NAME_OVERRIDE=my_project npx @zilliz/claude-context-mcp@latest
         `);
-} 
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -68,7 +68,8 @@ class ContextMcpServer {
         // Initialize Claude Context
         this.context = new Context({
             embedding,
-            vectorDatabase
+            vectorDatabase,
+            collectionNameOverride: config.collectionNameOverride
         });
 
         // Initialize managers


### PR DESCRIPTION
## Summary

Adds an opt-in override for the collection name so the Zilliz/Milvus console shows `code_chunks_my_project_a1b2c3d4` instead of just `code_chunks_a1b2c3d4`. Default behavior (no override set) is byte-identical to today.

## Why this matters

Today `getCollectionName()` in `packages/core/src/context.ts` returns `code_chunks_<md5(abs_path).slice(0,8)>`. In [#299](https://github.com/zilliztech/claude-context/issues/299) the reporter points out this makes the Zilliz console unusable for humans - `code_chunks_a1b2c3d4` tells you nothing about which project it belongs to. Neighbor issue [#271](https://github.com/zilliztech/claude-context/issues/271) asks for the same readability from the team-sharing angle (git-remote-based naming).

This PR is a minimal opt-in readability win. It intentionally does NOT try to solve #271's cross-machine sharing story - that's a separate design.

## Changes

New resolution order in `getCollectionName()`:

1. `ContextConfig.collectionNameOverride` (explicit constructor arg)
2. `CODE_CHUNKS_COLLECTION_NAME_OVERRIDE` env var
3. Plain md5 path hash (today's default - unchanged)

The override:

- Gets the existing `code_chunks_` / `hybrid_code_chunks_` prefix so it can't collide with auto-named collections
- Is sanitized per Milvus naming rules (alphanumeric + underscore, truncated to fit the 255-char name limit)
- Keeps the per-codebase path hash appended: final shape is `code_chunks_<override>_<pathHash>`. An MCP server that indexes multiple repos under the same override won't collapse them onto one collection
- Deduplicates sanitization warnings per (source, input) to avoid log spam

Wires the env var through the MCP config layer (`packages/mcp/src/config.ts` + `index.ts`) and adds it to the help text, env-var docs, and README examples.

## Testing

`pnpm install --frozen-lockfile && pnpm build` passes locally on Node 22. No Milvus integration harness exists in the repo - the new sanitizer has no test coverage yet; happy to add a small unit test if the repo adds a test framework for the core package.

## Explicit non-goals

- No auto-derive-from-folder-name behavior. Two folders named `monorepo` on two machines would clash - opt-in prevents accidents
- No git-remote-based naming (that's #271, larger scope, needs its own design discussion)
- No migration of existing hash-named collections. Setting or unsetting the override creates a fresh collection at the new name - documented as "opt-in-sticky" in the README

## Preempting reviewer questions

- **What happens on reconnect if I unset the env var?** The next `getCollectionName()` call returns to plain `code_chunks_<pathHash>` for that codebase path. The override-named collection data stays in Milvus but the MCP server no longer references it. Documented in the README.
- **Why keep the path hash suffix when the whole point is readability?** Without it, multi-codebase MCP sessions silently merge data across codebases. The hash costs 9 characters and keeps the override safe. The name still reads as "this is the my_project collection for path-variant a1b2c3d4" in the Zilliz console.
- **Why not solve #271 at the same time?** Different problem shape (cross-machine git-remote lookups, config format for multi-project teams). Layering that on top of this opt-in is trivial once the maintainer decides the approach.

Fixes #299
