### PR TITLE
fix(core): handle malformed metadata JSON in search results

### DIFF
--- a/packages/core/src/vectordb/milvus-restful-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-restful-vectordb.ts
@@ -774,20 +774,29 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
             console.log(`[MilvusRestfulDB] ✅ Found ${results.length} results from hybrid search`);
 
             // Transform response to HybridSearchResult format
-            return results.map((result: any) => ({
-                document: {
-                    id: result.id,
-                    content: result.content,
-                    vector: [], // Vector not returned in search results
-                    sparse_vector: [], // Vector not returned in search results
-                    relativePath: result.relativePath,
-                    startLine: result.startLine,
-                    endLine: result.endLine,
-                    fileExtension: result.fileExtension,
-                    metadata: JSON.parse(result.metadata || '{}'),
-                },
-                score: result.score || result.distance || 0,
-            }));
+            return results.map((result: any) => {
+                let metadata = {};
+                try {
+                    metadata = JSON.parse(result.metadata || '{}');
+                } catch (error) {
+                    console.warn(`[MilvusRestfulDB] Failed to parse metadata for item ${result.id}:`, error);
+                }
+
+                return {
+                    document: {
+                        id: result.id,
+                        content: result.content,
+                        vector: [], // Vector not returned in search results
+                        sparse_vector: [], // Vector not returned in search results
+                        relativePath: result.relativePath,
+                        startLine: result.startLine,
+                        endLine: result.endLine,
+                        fileExtension: result.fileExtension,
+                        metadata,
+                    },
+                    score: result.score || result.distance || 0,
+                };
+            });
 
         } catch (error) {
             console.error(`[MilvusRestfulDB] ❌ Failed to perform hybrid search on collection '${collectionName}':`, error);

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -394,19 +394,28 @@ export class MilvusVectorDatabase implements VectorDatabase {
             return [];
         }
 
-        return searchResult.results.map((result: any) => ({
-            document: {
-                id: result.id,
-                vector: queryVector,
-                content: result.content,
-                relativePath: result.relativePath,
-                startLine: result.startLine,
-                endLine: result.endLine,
-                fileExtension: result.fileExtension,
-                metadata: JSON.parse(result.metadata || '{}'),
-            },
-            score: result.score,
-        }));
+        return searchResult.results.map((result: any) => {
+            let metadata = {};
+            try {
+                metadata = JSON.parse(result.metadata || '{}');
+            } catch (error) {
+                console.warn(`[MilvusDB] Failed to parse metadata for item ${result.id}:`, error);
+            }
+
+            return {
+                document: {
+                    id: result.id,
+                    vector: queryVector,
+                    content: result.content,
+                    relativePath: result.relativePath,
+                    startLine: result.startLine,
+                    endLine: result.endLine,
+                    fileExtension: result.fileExtension,
+                    metadata,
+                },
+                score: result.score,
+            };
+        });
     }
 
     async delete(collectionName: string, ids: string[]): Promise<void> {


### PR DESCRIPTION
## Problem

`JSON.parse(metadata)` is called unconditionally inside `.map()` in two search code paths:

1. **gRPC `search()`** (`milvus-vectordb.ts:406`) — no error handling
2. **REST `hybridSearch()`** (`milvus-restful-vectordb.ts:787`) — no error handling

If **any** result row contains corrupted, truncated, or non-string metadata, the `JSON.parse` throws and the **entire search fails** with zero results.

Notably, the REST client's own `search()` method (line 433-439) already handles this correctly with a try/catch fallback to `{}`. The other two paths were missed.

## Fix

Wrap `JSON.parse(metadata)` in try/catch for both affected locations, falling back to `{}` and logging a warning with the item ID. Consistent with the existing pattern in `MilvusRestfulVectorDatabase.search()`.

## Testing

- TypeScript compilation passes (`tsc --noEmit` clean)
- Follows the same pattern already used in the REST search handler

## Files Changed

- `packages/core/src/vectordb/milvus-vectordb.ts` — gRPC search()
- `packages/core/src/vectordb/milvus-restful-vectordb.ts` — REST hybridSearch()