### PR TITLE
fix(mcp): sync from cloud in handleGetIndexingStatus

### DIFF
--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -938,6 +938,8 @@ export class ToolHandlers {
                 };
             }
 
+            await this.syncIndexedCodebasesFromCloud();
+
             // Check indexing status using new status system
             const status = this.snapshotManager.getCodebaseStatus(absolutePath);
             const info = this.snapshotManager.getCodebaseInfo(absolutePath);


### PR DESCRIPTION
## Summary

`handleGetIndexingStatus` reads local snapshot state without first calling `syncIndexedCodebasesFromCloud()`, so a freshly-started MCP server can return stale or empty indexing status even when cloud collections exist.

## Changes

Added a single `await this.syncIndexedCodebasesFromCloud();` at the top of `handleGetIndexingStatus`'s try block, after path validation and before snapshot reads. Mirrors the pattern already in place at `packages/mcp/src/handlers.ts:316` (`handleIndexCodebase`) and `:605` (`handleSearchCode`). The existing try/catch keeps status reporting resilient if the sync call fails.

```ts
// packages/mcp/src/handlers.ts, inside handleGetIndexingStatus
+ await this.syncIndexedCodebasesFromCloud();

  const status = this.snapshotManager.getCodebaseStatus(absolutePath);
  const info   = this.snapshotManager.getCodebaseInfo(absolutePath);
```

## Testing

`pnpm build` passes.

Manual verification:
1. Start MCP server against a cloud workspace that already has an indexed collection
2. Before this change: `get_indexing_status` returns empty until another handler (search or index) triggers the cloud sync
3. With this change: `get_indexing_status` returns reconciled state on the first call

Fixes #252
