### PR TITLE
feat: add maxDepth traversal flag

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -95,6 +95,7 @@ export interface ContextConfig {
     customExtensions?: string[]; // New: custom extensions from MCP
     customIgnorePatterns?: string[]; // New: custom ignore patterns from MCP
     collectionNameOverride?: string; // Optional: custom collection name suffix
+    maxDepth?: number; // Optional: max directory traversal depth
 }
 
 export class Context {
@@ -106,6 +107,7 @@ export class Context {
     private supportedExtensions: string[];
     private ignorePatterns: string[];
     private collectionNameOverride?: string;
+    private maxDepth?: number;
     private warnedOverrideSanitization = new Set<string>();
     private synchronizers = new Map<string, FileSynchronizer>();
 
@@ -150,6 +152,7 @@ export class Context {
         // Remove duplicates
         this.ignorePatterns = [...new Set(allIgnorePatterns)];
         this.collectionNameOverride = config.collectionNameOverride;
+        this.maxDepth = config?.maxDepth || (parseInt(envManager.get("MAX_DEPTH") || "") || undefined);
 
         console.log(`[Context] 🔧 Initialized with ${this.supportedExtensions.length} supported extensions and ${this.ignorePatterns.length} ignore patterns`);
         if (envCustomExtensions.length > 0) {
@@ -716,7 +719,7 @@ export class Context {
     private async getCodeFiles(codebasePath: string): Promise<string[]> {
         const files: string[] = [];
 
-        const traverseDirectory = async (currentPath: string) => {
+        const traverseDirectory = async (currentPath: string, depth: number = 0) => {
             const entries = await fs.promises.readdir(currentPath, { withFileTypes: true });
 
             for (const entry of entries) {
@@ -728,7 +731,8 @@ export class Context {
                 }
 
                 if (entry.isDirectory()) {
-                    await traverseDirectory(fullPath);
+                    if (this.maxDepth !== undefined && depth >= this.maxDepth) continue;
+                    await traverseDirectory(fullPath, depth + 1);
                 } else if (entry.isFile()) {
                     const ext = path.extname(entry.name);
                     if (this.supportedExtensions.includes(ext)) {
@@ -738,7 +742,7 @@ export class Context {
             }
         };
 
-        await traverseDirectory(codebasePath);
+        await traverseDirectory(codebasePath, 0);
         return files;
     }
 

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -219,6 +219,10 @@ Environment Variables:
   Vector Database Configuration:
   MILVUS_ADDRESS          Milvus address (optional, can be auto-resolved from token)
   MILVUS_TOKEN            Milvus token (optional, used for authentication and address resolution)
+  MAX_DEPTH              Max directory traversal depth (optional)
+
+  Directory Traversal:
+  MAX_DEPTH              Maximum directory traversal depth (optional, limits how deep to recurse)
   CODE_CHUNKS_COLLECTION_NAME_OVERRIDE
                           Optional readable prefix for collection names.
                           Uses code_chunks_<override>_<pathHash> (or hybrid_...)


### PR DESCRIPTION
Fixes #324. Adds `maxDepth` to `ContextConfig` and `MAX_DEPTH` env var.

**Changes:**
- Added `maxDepth?: number` to `ContextConfig` interface
- Added `MAX_DEPTH` environment variable support
- Modified `traverseDirectory` to accept depth parameter and limit recursion
- Updated MCP config help docs

**Non-breaking:** Existing behavior unchanged when option is omitted.

**Note:** This replaces #325 which accidentally included `package-lock.json`.