### PR TITLE
fix(core): skip dotfiles during initial indexing to match FileSynchronizer

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1052,11 +1052,20 @@ export class Context {
      * @returns True if path should be ignored
      */
     private matchesIgnorePattern(filePath: string, basePath: string): boolean {
+        const relativePath = path.relative(basePath, filePath);
+
+        // Always ignore dotfiles/dotdirs to stay aligned with
+        // FileSynchronizer.shouldIgnore. If these traversals diverge, files
+        // indexed here are never hashed by the synchronizer and their stale
+        // chunks linger in Milvus forever.
+        if (relativePath.split(path.sep).some(part => part.startsWith('.'))) {
+            return true;
+        }
+
         if (this.ignorePatterns.length === 0) {
             return false;
         }
 
-        const relativePath = path.relative(basePath, filePath);
         const normalizedPath = relativePath.replace(/\\/g, '/'); // Normalize path separators
 
         for (const pattern of this.ignorePatterns) {


### PR DESCRIPTION
`Context.getCodeFiles()` walks into any directory whose name starts with `.` (so `.venv`, `.next`, `.dart_tool`, whatever the user has lying around), but `FileSynchronizer.shouldIgnore()` skips every dotpath unconditionally. So the initial index quietly writes chunks for files the synchronizer can't see, and once that happens, no edit or delete inside that dir will ever propagate. The chunks just sit in Milvus.

In practice that looks like:
- search returns stuff from `.venv/` you'd never want in results
- you edit a file in there and search keeps returning the old version
- you delete a file in there and search still finds it

Quick repro:

1. `mkdir -p /tmp/repro/.myvenv && echo 'def greet(): return "ONE"' > /tmp/repro/.myvenv/lib.py`
2. index `/tmp/repro`
3. search for `greet` → finds `ONE`
4. change it to `"TWO"`, restart the MCP server, wait a bit for the initial sync
5. search again → still `ONE`

If you check `~/.context/merkle/<hash>.json` you can see `.myvenv/lib.py` is missing from `fileHashes`, which is the whole problem.

The fix moves the dotfile check into `matchesIgnorePattern()` so it always fires, even when no user ignore patterns are set, and runs against every component of the relative path, mirroring what `FileSynchronizer.shouldIgnore()` already does. That handles nested cases like `subdir/.hidden/foo.py` too.
