### PR TITLE
feat: add disk-based embedding cache

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -166,6 +166,7 @@ export class Context {
         this.embeddingCache = new EmbeddingCache(cacheModel);
         if (this.embeddingCache.isEnabled()) {
             console.log(`[Context] 💾 Embedding cache enabled for model: ${cacheModel}`);
+            this.embeddingCache.cleanup().catch(() => {});
         }
     }
 

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -162,8 +162,19 @@ export class Context {
         }
 
         // Initialize embedding cache
-        const cacheModel = `${this.embedding.getProvider()}_${this.embedding.getDimension()}`;
-        this.embeddingCache = new EmbeddingCache(cacheModel);
+        this.initEmbeddingCache();
+    }
+
+    /**
+     * (Re)create the embedding cache keyed by current provider + dimension.
+     * Called on construction and again whenever the embedding instance changes
+     * via updateEmbedding(), so cached vectors from a previous model never bleed
+     * into the new one.
+     */
+    private initEmbeddingCache(): void {
+        const dimension = this.embedding.getDimension();
+        const cacheModel = `${this.embedding.getProvider()}_${dimension}`;
+        this.embeddingCache = new EmbeddingCache(cacheModel, undefined, dimension);
         if (this.embeddingCache.isEnabled()) {
             console.log(`[Context] 💾 Embedding cache enabled for model: ${cacheModel}`);
             this.embeddingCache.cleanup().catch(() => {});
@@ -581,6 +592,10 @@ export class Context {
 
     /**
      * Embed batch with disk cache. Only calls API for uncached chunks.
+     * Also dedupes duplicate strings within the same batch — without this, two
+     * identical chunks in one batch would each hit the API since neither is
+     * cached at the start of the call. Common in monorepos with re-exports or
+     * generated boilerplate.
      */
     private async cachedEmbedBatch(contents: string[]): Promise<EmbeddingVector[]> {
         if (!this.embeddingCache || !this.embeddingCache.isEnabled()) {
@@ -594,16 +609,38 @@ export class Context {
             return results as EmbeddingVector[];
         }
 
-        const uncachedTexts = uncachedIndices.map(i => contents[i]);
-        const newEmbeddings = await this.embedding.embedBatch(uncachedTexts);
+        // Dedupe uncached texts: send each unique string once and fan results
+        // back out to every original index pointing at that string.
+        const uniqueTexts: string[] = [];
+        const textToUniqueIndex = new Map<string, number>();
+        const indicesByUnique: number[][] = [];
+        for (const i of uncachedIndices) {
+            const text = contents[i];
+            let uniq = textToUniqueIndex.get(text);
+            if (uniq === undefined) {
+                uniq = uniqueTexts.length;
+                textToUniqueIndex.set(text, uniq);
+                uniqueTexts.push(text);
+                indicesByUnique.push([]);
+            }
+            indicesByUnique[uniq].push(i);
+        }
 
-        for (let j = 0; j < uncachedIndices.length; j++) {
-            results[uncachedIndices[j]] = newEmbeddings[j];
-            this.embeddingCache.set(contents[uncachedIndices[j]], newEmbeddings[j]);
+        const newEmbeddings = await this.embedding.embedBatch(uniqueTexts);
+
+        for (let u = 0; u < uniqueTexts.length; u++) {
+            const embedding = newEmbeddings[u];
+            this.embeddingCache.set(uniqueTexts[u], embedding);
+            for (const i of indicesByUnique[u]) {
+                results[i] = embedding;
+            }
         }
 
         const hitRate = ((contents.length - uncachedIndices.length) / contents.length * 100).toFixed(0);
-        console.log(`[Cache] ${hitRate}% hit (${contents.length - uncachedIndices.length}/${contents.length} cached, ${uncachedIndices.length} embedded)`);
+        const dedupNote = uniqueTexts.length < uncachedIndices.length
+            ? ` (deduped ${uncachedIndices.length} → ${uniqueTexts.length} API calls)`
+            : '';
+        console.log(`[Cache] ${hitRate}% hit (${contents.length - uncachedIndices.length}/${contents.length} cached, ${uniqueTexts.length} embedded)${dedupNote}`);
 
         return results as EmbeddingVector[];
     }
@@ -692,6 +729,9 @@ export class Context {
     updateEmbedding(embedding: Embedding): void {
         this.embedding = embedding;
         console.log(`[Context] 🔄 Updated embedding provider: ${embedding.getProvider()}`);
+        // Cache key is `${provider}_${dimension}`; re-key so we don't return
+        // vectors from the previous model on the next embed call.
+        this.initEmbeddingCache();
     }
 
     /**

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -6,7 +6,8 @@ import {
 import {
     Embedding,
     EmbeddingVector,
-    OpenAIEmbedding
+    OpenAIEmbedding,
+    EmbeddingCache
 } from './embedding';
 import {
     VectorDatabase,
@@ -108,6 +109,7 @@ export class Context {
     private collectionNameOverride?: string;
     private warnedOverrideSanitization = new Set<string>();
     private synchronizers = new Map<string, FileSynchronizer>();
+    private embeddingCache: EmbeddingCache | null = null;
 
     constructor(config: ContextConfig = {}) {
         // Initialize services
@@ -157,6 +159,13 @@ export class Context {
         }
         if (envCustomIgnorePatterns.length > 0) {
             console.log(`[Context] 🚫 Loaded ${envCustomIgnorePatterns.length} custom ignore patterns from environment: ${envCustomIgnorePatterns.join(', ')}`);
+        }
+
+        // Initialize embedding cache
+        const cacheModel = `${this.embedding.getProvider()}_${this.embedding.getDimension()}`;
+        this.embeddingCache = new EmbeddingCache(cacheModel);
+        if (this.embeddingCache.isEnabled()) {
+            console.log(`[Context] 💾 Embedding cache enabled for model: ${cacheModel}`);
         }
     }
 
@@ -570,6 +579,35 @@ export class Context {
     }
 
     /**
+     * Embed batch with disk cache. Only calls API for uncached chunks.
+     */
+    private async cachedEmbedBatch(contents: string[]): Promise<EmbeddingVector[]> {
+        if (!this.embeddingCache || !this.embeddingCache.isEnabled()) {
+            return this.embedding.embedBatch(contents);
+        }
+
+        const { results, uncachedIndices } = this.embeddingCache.getBatch(contents);
+
+        if (uncachedIndices.length === 0) {
+            console.log(`[Cache] ✅ All ${contents.length} embeddings from cache`);
+            return results as EmbeddingVector[];
+        }
+
+        const uncachedTexts = uncachedIndices.map(i => contents[i]);
+        const newEmbeddings = await this.embedding.embedBatch(uncachedTexts);
+
+        for (let j = 0; j < uncachedIndices.length; j++) {
+            results[uncachedIndices[j]] = newEmbeddings[j];
+            this.embeddingCache.set(contents[uncachedIndices[j]], newEmbeddings[j]);
+        }
+
+        const hitRate = ((contents.length - uncachedIndices.length) / contents.length * 100).toFixed(0);
+        console.log(`[Cache] ${hitRate}% hit (${contents.length - uncachedIndices.length}/${contents.length} cached, ${uncachedIndices.length} embedded)`);
+
+        return results as EmbeddingVector[];
+    }
+
+    /**
      * Check if index exists for codebase
      * @param codebasePath Codebase path to check
      * @returns Whether index exists
@@ -865,9 +903,9 @@ export class Context {
     private async processChunkBatch(chunks: CodeChunk[], codebasePath: string): Promise<void> {
         const isHybrid = this.getIsHybrid();
 
-        // Generate embedding vectors
+        // Generate embedding vectors (with cache)
         const chunkContents = chunks.map(chunk => chunk.content);
-        const embeddings = await this.embedding.embedBatch(chunkContents);
+        const embeddings = await this.cachedEmbedBatch(chunkContents);
 
         if (isHybrid === true) {
             // Create hybrid vector documents

--- a/packages/core/src/embedding/embedding-cache.ts
+++ b/packages/core/src/embedding/embedding-cache.ts
@@ -1,0 +1,91 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as crypto from 'crypto';
+import { EmbeddingVector } from './base-embedding';
+import { envManager } from '../utils/env-manager';
+
+export class EmbeddingCache {
+    private cacheDir: string;
+    private enabled: boolean;
+
+    constructor(model: string, cacheDir?: string) {
+        this.enabled = (envManager.get('EMBEDDING_CACHE') || 'true').toLowerCase() !== 'false';
+
+        const baseDir = cacheDir
+            || envManager.get('EMBEDDING_CACHE_DIR')
+            || path.join(os.homedir(), '.context', 'embedding-cache');
+
+        // Sanitize model name for filesystem
+        const safeModel = model.replace(/[^a-zA-Z0-9_-]/g, '_');
+        this.cacheDir = path.join(baseDir, safeModel);
+
+        if (this.enabled) {
+            try {
+                fs.mkdirSync(this.cacheDir, { recursive: true });
+            } catch {
+                console.warn(`[Cache] ⚠️ Could not create cache dir: ${this.cacheDir}`);
+                this.enabled = false;
+            }
+        }
+    }
+
+    private hash(content: string): string {
+        return crypto.createHash('sha256').update(content).digest('hex');
+    }
+
+    private getCachePath(contentHash: string): string {
+        const prefix = contentHash.slice(0, 2);
+        return path.join(this.cacheDir, prefix, contentHash.slice(0, 12) + '.json');
+    }
+
+    get(content: string): EmbeddingVector | null {
+        if (!this.enabled) return null;
+
+        try {
+            const h = this.hash(content);
+            const cachePath = this.getCachePath(h);
+
+            if (!fs.existsSync(cachePath)) return null;
+
+            const data = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+            return { vector: data.v, dimension: data.d };
+        } catch {
+            return null;
+        }
+    }
+
+    set(content: string, embedding: EmbeddingVector): void {
+        if (!this.enabled) return;
+
+        try {
+            const h = this.hash(content);
+            const cachePath = this.getCachePath(h);
+
+            fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+            fs.writeFileSync(cachePath, JSON.stringify({ v: embedding.vector, d: embedding.dimension }));
+        } catch {
+            // Silently fail — cache is best-effort
+        }
+    }
+
+    getBatch(contents: string[]): { results: (EmbeddingVector | null)[]; uncachedIndices: number[] } {
+        const results: (EmbeddingVector | null)[] = new Array(contents.length).fill(null);
+        const uncachedIndices: number[] = [];
+
+        for (let i = 0; i < contents.length; i++) {
+            const cached = this.get(contents[i]);
+            if (cached) {
+                results[i] = cached;
+            } else {
+                uncachedIndices.push(i);
+            }
+        }
+
+        return { results, uncachedIndices };
+    }
+
+    isEnabled(): boolean {
+        return this.enabled;
+    }
+}

--- a/packages/core/src/embedding/embedding-cache.ts
+++ b/packages/core/src/embedding/embedding-cache.ts
@@ -88,4 +88,45 @@ export class EmbeddingCache {
     isEnabled(): boolean {
         return this.enabled;
     }
+
+    /**
+     * Delete cache files not modified in the last maxAgeDays days.
+     * Runs async, best-effort — errors are silently ignored.
+     */
+    async cleanup(maxAgeDays?: number): Promise<void> {
+        if (!this.enabled) return;
+
+        const days = maxAgeDays ?? parseInt(envManager.get('EMBEDDING_CACHE_MAX_AGE_DAYS') || '30', 10);
+        const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+        let deleted = 0;
+
+        try {
+            const prefixDirs = fs.readdirSync(this.cacheDir);
+            for (const prefix of prefixDirs) {
+                const prefixPath = path.join(this.cacheDir, prefix);
+                if (!fs.statSync(prefixPath).isDirectory()) continue;
+
+                const files = fs.readdirSync(prefixPath);
+                for (const file of files) {
+                    const filePath = path.join(prefixPath, file);
+                    const stat = fs.statSync(filePath);
+                    if (stat.mtimeMs < cutoff) {
+                        fs.unlinkSync(filePath);
+                        deleted++;
+                    }
+                }
+
+                // Remove empty prefix dirs
+                if (fs.readdirSync(prefixPath).length === 0) {
+                    fs.rmdirSync(prefixPath);
+                }
+            }
+
+            if (deleted > 0) {
+                console.log(`[Cache] 🧹 Cleaned up ${deleted} stale cache files (>${days} days old)`);
+            }
+        } catch {
+            // Best-effort cleanup
+        }
+    }
 }

--- a/packages/core/src/embedding/embedding-cache.ts
+++ b/packages/core/src/embedding/embedding-cache.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import * as crypto from 'crypto';
@@ -8,9 +9,11 @@ import { envManager } from '../utils/env-manager';
 export class EmbeddingCache {
     private cacheDir: string;
     private enabled: boolean;
+    private expectedDimension: number | null;
 
-    constructor(model: string, cacheDir?: string) {
+    constructor(model: string, cacheDir?: string, expectedDimension?: number) {
         this.enabled = (envManager.get('EMBEDDING_CACHE') || 'true').toLowerCase() !== 'false';
+        this.expectedDimension = expectedDimension ?? null;
 
         const baseDir = cacheDir
             || envManager.get('EMBEDDING_CACHE_DIR')
@@ -34,9 +37,15 @@ export class EmbeddingCache {
         return crypto.createHash('sha256').update(content).digest('hex');
     }
 
+    /**
+     * Use the FULL sha256 (64 hex chars) as the filename — truncating to 12 chars
+     * gave a birthday-collision probability of ~50% at ~78k entries, which is
+     * trivially reachable for a real codebase. Full hash makes collisions
+     * practically impossible.
+     */
     private getCachePath(contentHash: string): string {
         const prefix = contentHash.slice(0, 2);
-        return path.join(this.cacheDir, prefix, contentHash.slice(0, 12) + '.json');
+        return path.join(this.cacheDir, prefix, contentHash + '.json');
     }
 
     get(content: string): EmbeddingVector | null {
@@ -48,8 +57,16 @@ export class EmbeddingCache {
 
             if (!fs.existsSync(cachePath)) return null;
 
-            const data = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
-            return { vector: data.v, dimension: data.d };
+            const raw = fs.readFileSync(cachePath, 'utf-8');
+            const data = JSON.parse(raw);
+
+            // Shape validation — partial writes / future format changes / bit rot
+            // shouldn't return garbage to the caller. Treat anything unexpected as a miss.
+            if (!data || !Array.isArray(data.v) || typeof data.d !== 'number') return null;
+            if (data.v.length !== data.d) return null;
+            if (this.expectedDimension !== null && data.d !== this.expectedDimension) return null;
+
+            return { vector: data.v as number[], dimension: data.d };
         } catch {
             return null;
         }
@@ -91,34 +108,53 @@ export class EmbeddingCache {
 
     /**
      * Delete cache files not modified in the last maxAgeDays days.
-     * Runs async, best-effort — errors are silently ignored.
+     * Truly async (uses fs.promises) so startup cleanup never blocks the event loop.
+     * Best-effort — errors are silently ignored.
+     *
+     * `maxAgeDays <= 0` (or non-finite) disables cleanup. Documented escape hatch
+     * for users who want the cache to persist indefinitely.
      */
     async cleanup(maxAgeDays?: number): Promise<void> {
         if (!this.enabled) return;
 
         const days = maxAgeDays ?? parseInt(envManager.get('EMBEDDING_CACHE_MAX_AGE_DAYS') || '30', 10);
+        if (!Number.isFinite(days) || days <= 0) return;
+
         const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
         let deleted = 0;
 
         try {
-            const prefixDirs = fs.readdirSync(this.cacheDir);
+            const prefixDirs = await fsp.readdir(this.cacheDir);
             for (const prefix of prefixDirs) {
                 const prefixPath = path.join(this.cacheDir, prefix);
-                if (!fs.statSync(prefixPath).isDirectory()) continue;
+                let prefixStat;
+                try {
+                    prefixStat = await fsp.stat(prefixPath);
+                } catch {
+                    continue;
+                }
+                if (!prefixStat.isDirectory()) continue;
 
-                const files = fs.readdirSync(prefixPath);
+                const files = await fsp.readdir(prefixPath);
                 for (const file of files) {
                     const filePath = path.join(prefixPath, file);
-                    const stat = fs.statSync(filePath);
-                    if (stat.mtimeMs < cutoff) {
-                        fs.unlinkSync(filePath);
-                        deleted++;
+                    try {
+                        const stat = await fsp.stat(filePath);
+                        if (stat.mtimeMs < cutoff) {
+                            await fsp.unlink(filePath);
+                            deleted++;
+                        }
+                    } catch {
+                        // file vanished mid-scan, fine
                     }
                 }
 
                 // Remove empty prefix dirs
-                if (fs.readdirSync(prefixPath).length === 0) {
-                    fs.rmdirSync(prefixPath);
+                try {
+                    const remaining = await fsp.readdir(prefixPath);
+                    if (remaining.length === 0) await fsp.rmdir(prefixPath);
+                } catch {
+                    // best-effort
                 }
             }
 

--- a/packages/core/src/embedding/index.ts
+++ b/packages/core/src/embedding/index.ts
@@ -5,4 +5,5 @@ export * from './base-embedding';
 export * from './openai-embedding';
 export * from './voyageai-embedding';
 export * from './ollama-embedding';
-export * from './gemini-embedding'; 
+export * from './gemini-embedding';
+export * from './embedding-cache';


### PR DESCRIPTION
## Summary

Add a transparent, disk-based embedding cache to skip redundant embedding API calls when re-indexing the same code. On a re-index, only chunks whose content has not been embedded before hit the API; cached chunks load from disk in milliseconds.

## Motivation

Embedding API calls are the slowest and most expensive step in indexing. When a codebase is re-indexed (after `force: true`, switching machines, or recovering from a failed run), every chunk is sent through the embedding provider again — even if its content is byte-identical to a previous run.

In practice this wastes:
- **API quota / cost** — large monorepos can re-burn $1–$5 per re-index
- **Latency** — re-indexing a 10k-file repo against VoyageAI takes minutes purely for embeddings
- **Provider rate limits** — easy to hit on Gemini / OpenAI free tiers

A small content-addressed cache keyed by `SHA256(content)` per `(provider, dimension)` eliminates this waste entirely for unchanged chunks.

## Changes

- **`packages/core/src/embedding/embedding-cache.ts`** *(new, ~130 LOC)* — `EmbeddingCache` class with `get`, `set`, `getBatch`, `cleanup` methods. Storage: `~/.context/embedding-cache/{provider}_{dimension}/XX/{sha256}.json` (hierarchical to avoid single-dir overflow). No external dependencies — uses Node `fs` / `crypto` / `path` / `os`.
- **`packages/core/src/embedding/index.ts`** — Export `EmbeddingCache`.
- **`packages/core/src/context.ts`** — Initialize `EmbeddingCache` in constructor keyed by `${provider}_${dimension}`. New private `cachedEmbedBatch()` wraps `embedding.embedBatch()`: returns cached vectors instantly, only sends uncached chunks to the API. Indexing path now calls `cachedEmbedBatch()` instead of `embedding.embedBatch()` directly. Async TTL cleanup runs once on startup (non-blocking).

Behavior:
- Per-model isolation prevents cross-contamination when switching providers (e.g., `voyage-code-3` vs `text-embedding-3-small`).
- Best-effort design: any cache I/O error falls back to a normal API call. Corrupted JSON, missing files, permission errors all degrade gracefully.
- Hit rate logged per batch: `[Cache] 75% hit (3/4 cached, 1 embedded)`.
- Stale entries auto-removed on startup based on `EMBEDDING_CACHE_MAX_AGE_DAYS` (default 30).

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `EMBEDDING_CACHE` | `true` | Enable/disable. Set to `false` to opt out completely. |
| `EMBEDDING_CACHE_DIR` | `~/.context/embedding-cache` | Storage location. |
| `EMBEDDING_CACHE_MAX_AGE_DAYS` | `30` | TTL for cleanup-on-startup. Set `0` to disable cleanup. |

## Usage

Zero-config — cache is on by default. Re-indexing the same content shows the hit rate:

```
[Context] 💾 Embedding cache enabled for model: VoyageAI_1024
[Cache] ✅ All 47 embeddings from cache
[Cache] 88% hit (44/50 cached, 6 embedded)
```

Disable temporarily:
```bash
EMBEDDING_CACHE=false npx @zilliz/claude-context-mcp@latest
```

Move cache to a shared location:
```bash
EMBEDDING_CACHE_DIR=/mnt/team-cache/embeddings npx @zilliz/claude-context-mcp@latest
```

## Test plan

- [x] `pnpm build` passes (core + mcp)
- [ ] Index a small repo, then re-index → cache hit rate should be ~100%
- [ ] Edit one file, re-index → only changed chunks re-embedded
- [ ] Switch `EMBEDDING_PROVIDER` → new cache directory created, old one untouched
- [ ] `EMBEDDING_CACHE=false` → no cache directory created, no `[Cache]` logs
- [ ] Delete `~/.context/embedding-cache/` mid-run → next batch falls back to API gracefully

## Notes for reviewers

- Cache files are JSON `{"v": [vector...], "d": dimension}` — small (~6KB per 1024-dim float vector) but consider compression in a follow-up if storage becomes a concern.
- No write locking; concurrent indexers writing the same key would race, but the result is functionally identical so this is intentionally not guarded.
- Old cache entries from previous models are *not* deleted on provider switch (only TTL cleanup applies). Trade-off: simpler logic vs slightly larger disk usage. A `clear_cache` MCP tool could be added in a follow-up.
