### PR TITLE
feat: add trigger file watcher for instant re-index

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -197,6 +197,33 @@ CODE_CHUNKS_COLLECTION_NAME_OVERRIDE=my_project
 
 The per-codebase `<pathHash>` suffix is preserved even when the override is set, so the same MCP server can still index multiple repos without collapsing them onto one collection. The override value is sanitized to letters, numbers, and underscores, and truncated to keep the full name within Milvus's 255-char limit. If you unset the variable later, Claude Context switches back to the plain `code_chunks_<pathHash>` naming.
 
+#### Trigger File Watcher (Optional)
+
+In addition to the periodic background sync, the MCP server watches a sentinel file at `~/.context/.sync-trigger` and starts an immediate re-index whenever the file is modified. This lets external tools (Claude Code `PostToolUse` hooks, editor save hooks, CI scripts, etc.) request a sync on demand instead of waiting for the next polling tick.
+
+```bash
+# Default: watcher enabled. Set to false to disable filesystem watching entirely
+# (useful on read-only filesystems or sandboxed environments).
+CLAUDE_CONTEXT_TRIGGER_WATCHER=true
+```
+
+Example — Claude Code hook that re-indexes after every Edit/Write:
+
+```json
+"hooks": {
+  "PostToolUse": [
+    { "matcher": "Edit|Write", "hooks": [
+      { "type": "command", "command": "touch ~/.context/.sync-trigger" }
+    ]}
+  ]
+}
+```
+
+Notes:
+- The trigger fires a debounced re-index (2 s window) so rapid touches collapse to a single sync.
+- Triggered syncs go through the same global cross-process lock as background sync, so when multiple MCP processes share `$HOME` only one process performs the work per trigger.
+- The trigger file's *contents* are ignored — only the modification event matters.
+
 ## Usage with MCP Clients
 
 <details>

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -226,6 +226,16 @@ Environment Variables:
                           The per-codebase pathHash is preserved so multiple
                           codebases stay distinct under the same override.
 
+  Sync Trigger Watcher:
+  CLAUDE_CONTEXT_TRIGGER_WATCHER
+                          Enable/disable the ~/.context/.sync-trigger filesystem
+                          watcher (default: true). When enabled, touching the
+                          trigger file kicks off an immediate, debounced re-index.
+                          Triggered syncs share the same global cross-process
+                          lock as background sync, so multi-instance setups stay
+                          coordinated. Set to false to disable filesystem
+                          watching entirely (read-only / sandboxed environments).
+
 Examples:
   # Start MCP server with OpenAI (default) and explicit Milvus address
   OPENAI_API_KEY=sk-xxx MILVUS_ADDRESS=localhost:19530 npx @zilliz/claude-context-mcp@latest

--- a/packages/mcp/src/sync.ts
+++ b/packages/mcp/src/sync.ts
@@ -214,6 +214,13 @@ export class SyncManager {
     public startBackgroundSync(): void {
         console.log('[SYNC-DEBUG] startBackgroundSync() called');
 
+        // Set up the trigger file watcher FIRST, independent of polling. Polling may
+        // be gated off by other configuration (e.g. opt-in CLAUDE_CONTEXT_BACKGROUND_SYNC
+        // discussed in #285 / #314); the watcher is the on-demand counterpart and should
+        // remain available so external tools (Claude Code PostToolUse hooks, CI scripts)
+        // can still request a sync by touching ~/.context/.sync-trigger.
+        this.setupTriggerWatcher();
+
         // Execute initial sync immediately after a short delay to let server initialize
         console.log('[SYNC-DEBUG] Scheduling initial sync in 5 seconds...');
         setTimeout(async () => {
@@ -239,9 +246,23 @@ export class SyncManager {
         }, 5 * 60 * 1000); // every 5 minutes
 
         console.log('[SYNC-DEBUG] Background sync setup complete. Interval ID:', syncInterval);
+    }
 
-        // Set up trigger file watcher for instant re-index (e.g., from Claude Code hooks)
-        this.setupTriggerWatcher();
+    /**
+     * Read CLAUDE_CONTEXT_TRIGGER_WATCHER. Default ON — the watcher is cheap and only
+     * fires when an external process explicitly touches the trigger file. Users who want
+     * zero filesystem watching (e.g. read-only filesystems, sandboxed envs) can disable it.
+     */
+    private isTriggerWatcherEnabled(): boolean {
+        const v = (envManager.get('CLAUDE_CONTEXT_TRIGGER_WATCHER') ?? '').trim().toLowerCase();
+        if (!v) return true;
+        if (['1', 'true', 'yes', 'on'].includes(v)) return true;
+        if (['0', 'false', 'no', 'off'].includes(v)) return false;
+        console.warn(
+            `[SYNC-DEBUG] Invalid CLAUDE_CONTEXT_TRIGGER_WATCHER value '${v}'. ` +
+            'Expected true/false. Trigger watcher will remain enabled.'
+        );
+        return true;
     }
 
     /**
@@ -250,6 +271,11 @@ export class SyncManager {
      * after Write/Edit operations to trigger immediate re-indexing.
      */
     private setupTriggerWatcher(): void {
+        if (!this.isTriggerWatcherEnabled()) {
+            console.log('[SYNC-DEBUG] Trigger watcher disabled via CLAUDE_CONTEXT_TRIGGER_WATCHER');
+            return;
+        }
+
         // Guard against double-initialization (hot reload, repeated test setup).
         if (this.triggerWatcher) {
             console.log('[SYNC-DEBUG] Trigger watcher already active, skipping re-init');

--- a/packages/mcp/src/sync.ts
+++ b/packages/mcp/src/sync.ts
@@ -12,6 +12,8 @@ export class SyncManager {
     private snapshotManager: SnapshotManager;
     private isSyncing: boolean = false;
     private syncLockToken: string | null = null;
+    private triggerWatcher: fs.FSWatcher | null = null;
+    private triggerDebounceTimer: NodeJS.Timeout | null = null;
 
     constructor(context: Context, snapshotManager: SnapshotManager) {
         this.context = context;
@@ -248,27 +250,72 @@ export class SyncManager {
      * after Write/Edit operations to trigger immediate re-indexing.
      */
     private setupTriggerWatcher(): void {
+        // Guard against double-initialization (hot reload, repeated test setup).
+        if (this.triggerWatcher) {
+            console.log('[SYNC-DEBUG] Trigger watcher already active, skipping re-init');
+            return;
+        }
+
         const contextDir = path.join(os.homedir(), '.context');
         const triggerFile = '.sync-trigger';
-        let debounceTimer: NodeJS.Timeout | null = null;
+        const triggerPath = path.join(contextDir, triggerFile);
 
         try {
             // Ensure context dir exists before watching (snapshot manager
             // also creates it, but be defensive in case watcher starts first).
             fs.mkdirSync(contextDir, { recursive: true });
 
-            fs.watch(contextDir, (event, filename) => {
-                if (filename === triggerFile) {
-                    if (debounceTimer) clearTimeout(debounceTimer);
-                    debounceTimer = setTimeout(() => {
-                        console.log('[SYNC] 🔔 Trigger file detected, starting instant re-index...');
-                        this.handleSyncIndex();
-                    }, 2000);
-                }
+            // Pass encoding so `filename` is consistently a string across platforms
+            // (default can be Buffer on some Node builds).
+            const watcher = fs.watch(contextDir, { encoding: 'utf8' }, (_event, filename) => {
+                // With encoding: 'utf8', filename is `string | null`. null happens on
+                // some platforms when the underlying event lacks a name; treat as no-op.
+                if (typeof filename !== 'string' || filename !== triggerFile) return;
+
+                if (this.triggerDebounceTimer) clearTimeout(this.triggerDebounceTimer);
+                this.triggerDebounceTimer = setTimeout(() => {
+                    console.log('[SYNC] 🔔 Trigger file detected, starting instant re-index...');
+                    // Fire-and-forget with explicit catch so an unhandled rejection
+                    // can't crash the process from inside the setTimeout callback.
+                    void this.handleSyncIndex().catch((error) => {
+                        const errorMessage = error instanceof Error ? error.message : String(error);
+                        if (errorMessage.includes('Failed to query collection')) {
+                            console.log('[SYNC-DEBUG] Collection not yet established during trigger sync; will retry on next cycle.');
+                        } else {
+                            console.error('[SYNC-DEBUG] Triggered sync failed with unexpected error:', error);
+                        }
+                    });
+                }, 2000);
             });
-            console.log(`[SYNC-DEBUG] Trigger watcher active on ${contextDir}/${triggerFile}`);
+
+            // fs.watch can emit `error` asynchronously (e.g. dir deleted, fs unmounted).
+            // Without a listener this would crash the process.
+            watcher.on('error', (err) => {
+                console.warn('[SYNC-DEBUG] Trigger watcher error:', err instanceof Error ? err.message : String(err));
+                this.stopTriggerWatcher();
+            });
+
+            this.triggerWatcher = watcher;
+            console.log(`[SYNC-DEBUG] Trigger watcher active on ${triggerPath}`);
         } catch (error) {
-            console.warn(`[SYNC-DEBUG] Could not set up trigger watcher: ${error}`);
+            if (error instanceof Error) {
+                console.warn('[SYNC-DEBUG] Could not set up trigger watcher:', error.message);
+                if (error.stack) console.warn(error.stack);
+            } else {
+                console.warn('[SYNC-DEBUG] Could not set up trigger watcher:', String(error));
+            }
+        }
+    }
+
+    /** Stop the watcher (idempotent). Useful for tests or graceful shutdown. */
+    public stopTriggerWatcher(): void {
+        if (this.triggerDebounceTimer) {
+            clearTimeout(this.triggerDebounceTimer);
+            this.triggerDebounceTimer = null;
+        }
+        if (this.triggerWatcher) {
+            try { this.triggerWatcher.close(); } catch { /* already closed */ }
+            this.triggerWatcher = null;
         }
     }
 }

--- a/packages/mcp/src/sync.ts
+++ b/packages/mcp/src/sync.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { Context, FileSynchronizer } from "@zilliz/claude-context-core";
+import { Context, FileSynchronizer, envManager } from "@zilliz/claude-context-core";
 import { SnapshotManager } from "./snapshot.js";
 
 const DEFAULT_SYNC_LOCK_STALE_MS = 10 * 60 * 1000;
@@ -237,5 +237,38 @@ export class SyncManager {
         }, 5 * 60 * 1000); // every 5 minutes
 
         console.log('[SYNC-DEBUG] Background sync setup complete. Interval ID:', syncInterval);
+
+        // Set up trigger file watcher for instant re-index (e.g., from Claude Code hooks)
+        this.setupTriggerWatcher();
+    }
+
+    /**
+     * Watch for trigger file changes to enable instant re-index.
+     * Claude Code PostToolUse hooks can touch ~/.context/.sync-trigger
+     * after Write/Edit operations to trigger immediate re-indexing.
+     */
+    private setupTriggerWatcher(): void {
+        const contextDir = path.join(os.homedir(), '.context');
+        const triggerFile = '.sync-trigger';
+        let debounceTimer: NodeJS.Timeout | null = null;
+
+        try {
+            // Ensure context dir exists before watching (snapshot manager
+            // also creates it, but be defensive in case watcher starts first).
+            fs.mkdirSync(contextDir, { recursive: true });
+
+            fs.watch(contextDir, (event, filename) => {
+                if (filename === triggerFile) {
+                    if (debounceTimer) clearTimeout(debounceTimer);
+                    debounceTimer = setTimeout(() => {
+                        console.log('[SYNC] 🔔 Trigger file detected, starting instant re-index...');
+                        this.handleSyncIndex();
+                    }, 2000);
+                }
+            });
+            console.log(`[SYNC-DEBUG] Trigger watcher active on ${contextDir}/${triggerFile}`);
+        } catch (error) {
+            console.warn(`[SYNC-DEBUG] Could not set up trigger watcher: ${error}`);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Add a file-system watcher on `~/.context/.sync-trigger` so external tools (e.g., Claude Code's `PostToolUse` hooks) can request an immediate re-index instead of waiting up to 5 minutes for the existing background poll.

## Relation to #285 / #314

Filed concurrently with @jmmaloney4's **#285** (multi-instance MCP CPU churn) and @txhno's **#314** (opt-in background sync, which fixes #285). Their work addresses the *polling* side; this PR addresses the *on-demand* side. They are complementary — together they let users pick how aggressive sync should be:

| `CLAUDE_CONTEXT_BACKGROUND_SYNC` (#314) | `CLAUDE_CONTEXT_TRIGGER_WATCHER` (this PR) | Result |
|---|---|---|
| `true` | `true` (default) | Polling + on-demand both active (belt-and-braces) |
| unset / `false` | `true` (default) | **On-demand only — recommended for multi-instance setups (addresses #285 directly: zero idle CPU, instant re-index on explicit trigger)** |
| `true` | `false` | Polling only, no FS watcher |
| `false` | `false` | No background sync; manual `index_codebase` only |

This PR is structured to be merge-order independent: `setupTriggerWatcher()` is now invoked at the top of `startBackgroundSync()`, before the polling block, so #314 can land in either order without conflict and without accidentally skipping the watcher.

## Motivation

The MCP server currently re-indexes every 5 minutes via a `setInterval`. That's fine for passive polling, but creates a frustrating gap when the user (or an agent) makes a code change and immediately runs a search — the search hits stale embeddings.

A trigger file is the simplest possible coordination primitive:
- **No new dependencies** — `fs.watch` is built in.
- **No port / IPC** — works across users, containers, CI, and editor extensions.
- **One-line integration** — any tool can `touch ~/.context/.sync-trigger` to request a re-index.

Concrete use case (Claude Code `settings.json`):
```json
"hooks": {
  "PostToolUse": [
    { "matcher": "Edit|Write", "hooks": [
      { "type": "command", "command": "touch ~/.context/.sync-trigger" }
    ]}
  ]
}
```
After this, every Edit/Write the agent makes triggers a debounced re-index — no manual `index_codebase` call, no 5-minute wait.

## Changes

`packages/mcp/src/sync.ts`:
- Import `path`, `os`, `envManager`.
- New private `setupTriggerWatcher()` and `isTriggerWatcherEnabled()` methods.
- `setupTriggerWatcher()` is invoked at the **start** of `startBackgroundSync()`, independent of the polling block. This makes the watcher coexist cleanly with #314's opt-in polling gate (the watcher still runs even when periodic sync is disabled).
- Watcher uses `fs.watch()` on `~/.context/` (not the file directly — files don't exist until first touch and watching a non-existent path throws).
- `fs.mkdirSync(contextDir, { recursive: true })` ensures dir exists before watching (snapshot manager already creates it, but being defensive avoids race on cold start).
- `fs.watch(contextDir, { encoding: 'utf8' }, ...)` — explicit encoding so `filename` is a string across platforms; null/non-string filenames guarded.
- Captured `FSWatcher` with `on('error', ...)` listener so async watcher errors (dir deletion, fs unmount) don't crash the process.
- Filename filter: only react when the changed entry is `.sync-trigger`.
- 2-second debounce so rapid edits (`save → save → save`) collapse to a single re-index.
- `handleSyncIndex()` invocation inside the debounce is wrapped in `.catch(...)` to avoid unhandled promise rejection from the `setTimeout` callback.
- Class-level `triggerWatcher` / `triggerDebounceTimer` fields guard against double-init (hot reload, repeated test setup).
- New public `stopTriggerWatcher()` for graceful shutdown / tests.

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `CLAUDE_CONTEXT_TRIGGER_WATCHER` | `true` | Enable/disable the trigger file watcher. Watcher is cheap (one `fs.watch` on a single directory) but can be disabled on read-only or sandboxed filesystems. |

## Behavior

```
[SYNC-DEBUG] Trigger watcher active on /home/user/.context/.sync-trigger
... (user edits files, hook touches trigger) ...
[SYNC] 🔔 Trigger file detected, starting instant re-index...
```

If the watcher fails to start (filesystem doesn't support `fs.watch`, e.g., some CIFS mounts), a warning is logged with `error.message` + stack and operation continues — graceful degradation.

## Test plan

- [x] `pnpm build` passes
- [ ] Start MCP server → `[SYNC-DEBUG] Trigger watcher active` appears in logs
- [ ] `touch ~/.context/.sync-trigger` → `[SYNC] 🔔 Trigger file detected` within 2s
- [ ] Touch the file 5 times rapidly → only one re-index runs (debounce works)
- [ ] `CLAUDE_CONTEXT_TRIGGER_WATCHER=false` → log shows watcher disabled, no FS watch active
- [ ] Delete `~/.context/` while server runs → watcher emits error, server logs warning, polling (if enabled) continues
- [ ] Run on a filesystem without `fs.watch` support → warning logged, polling (if enabled) still works
- [ ] Combined with #314: `CLAUDE_CONTEXT_BACKGROUND_SYNC=false` → polling skipped, watcher still active

## Notes for reviewers

- `fs.watch` semantics differ across platforms (recursive on macOS, not on Linux), but we only watch a single directory non-recursively, so cross-platform behavior is consistent.
- Trigger file path is hardcoded. Could be made configurable via `SYNC_TRIGGER_FILE` env var in a follow-up if needed, but a hardcoded sentinel is simpler for hook authors.
- 2s debounce is conservative — most editors save in <1s bursts. Adjustable in a follow-up if users report it being too slow.
- Trigger file content is ignored — only the modification event matters. We never read it. Tools can leave it empty or write a timestamp / change list for human debugging.
- Credit to @jmmaloney4 (#285) and @txhno (#314) — the placement of `setupTriggerWatcher()` was deliberately moved above the polling block in response to that work to keep the three PRs orthogonal.
