### PR TITLE
feat(chrome-extension): add retryWithBackoff utility

### DIFF
--- a/packages/chrome-extension/src/utils/retryWithBackoff.ts
+++ b/packages/chrome-extension/src/utils/retryWithBackoff.ts
@@ -1,0 +1,108 @@
+/**
+ * Retry an async operation with exponential backoff.
+ *
+ * Mirrors the retry pattern used in `packages/core/src/vectordb/milvus-vectordb.ts`
+ * but generalized for browser-side use (GitHub API, Milvus/Qdrant fetch calls).
+ *
+ * @param operation  Async function to retry. Receives the attempt number (1-based).
+ * @param options    Retry tuning. All optional.
+ *   - maxRetries:        max attempts including the first try (default 5)
+ *   - initialDelayMs:    delay before the first retry (default 500)
+ *   - maxDelayMs:        clamp for backoff (default 30_000)
+ *   - backoffMultiplier: multiplier per attempt (default 2)
+ *   - jitter:            randomize delay +-25% to avoid thundering herds (default true)
+ *   - shouldRetry:       predicate; default retries on any thrown error.
+ *                        Useful for opting out of 4xx (caller error) but retrying 5xx / network.
+ *   - onRetry:           optional hook for logging/telemetry between attempts.
+ */
+
+export interface RetryOptions {
+    maxRetries?: number;
+    initialDelayMs?: number;
+    maxDelayMs?: number;
+    backoffMultiplier?: number;
+    jitter?: boolean;
+    shouldRetry?: (error: unknown, attempt: number) => boolean;
+    onRetry?: (error: unknown, attempt: number, delayMs: number) => void;
+}
+
+export async function retryWithBackoff<T>(
+    operation: (attempt: number) => Promise<T>,
+    options: RetryOptions = {}
+): Promise<T> {
+    const {
+        maxRetries = 5,
+        initialDelayMs = 500,
+        maxDelayMs = 30_000,
+        backoffMultiplier = 2,
+        jitter = true,
+        shouldRetry = defaultShouldRetry,
+        onRetry,
+    } = options;
+
+    let lastError: unknown;
+    let delay = initialDelayMs;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+            return await operation(attempt);
+        } catch (error) {
+            lastError = error;
+
+            const isLastAttempt = attempt === maxRetries;
+            if (isLastAttempt || !shouldRetry(error, attempt)) {
+                throw error;
+            }
+
+            const wait = jitter ? jitterize(delay) : delay;
+            onRetry?.(error, attempt, wait);
+            await sleep(wait);
+            delay = Math.min(delay * backoffMultiplier, maxDelayMs);
+        }
+    }
+
+    // Unreachable in practice; the loop returns or throws on every path.
+    throw lastError;
+}
+
+/**
+ * Default predicate: retry on network errors and HTTP 5xx / 429.
+ * Skip retry on 4xx (other than 429) since those are usually caller bugs.
+ */
+function defaultShouldRetry(error: unknown): boolean {
+    if (!error) return false;
+    if (error instanceof Error) {
+        const status = extractStatus(error);
+        if (status === undefined) {
+            // Network errors, AbortError, TypeError from fetch -> retry.
+            return true;
+        }
+        if (status === 429) return true;
+        if (status >= 500) return true;
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Pull an HTTP status out of common error shapes (custom property, formatted message).
+ */
+function extractStatus(error: Error): number | undefined {
+    const anyErr = error as unknown as { status?: unknown };
+    if (typeof anyErr.status === 'number') return anyErr.status;
+
+    // Matches messages like: "Qdrant PUT /... failed: 503 Service Unavailable".
+    const match = /\b([45]\d\d)\b/.exec(error.message);
+    if (match) return Number(match[1]);
+
+    return undefined;
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function jitterize(ms: number): number {
+    const span = ms * 0.25;
+    return Math.max(0, ms + (Math.random() * 2 - 1) * span);
+}


### PR DESCRIPTION
## Summary

Add a small, dependency-free `retryWithBackoff` utility to the Chrome Extension package. Network calls in the extension (GitHub API, Milvus, Qdrant) currently have zero retry logic — a single 502 from GitHub or a transient network blip aborts an entire indexing run. This utility will be wired into the GitHub client and the vector DB adapters in follow-up PRs; this PR is just the building block.

## Motivation

The MCP server already does this in `packages/core/src/vectordb/milvus-vectordb.ts`:
```ts
async loadCollectionWithRetry(name, maxRetries = 5, initialInterval = 1000, backoffMultiplier = 2)
```
The Chrome Extension does not. As a result:
- GitHub rate limit (`429`) → indexing dies, user re-clicks, eats more quota
- Milvus/Qdrant cold start (`502`/`503` for a few seconds) → first index after deploy fails
- Transient TCP RST → fetch throws, no retry

A generic helper lets us add retry to all three call sites (GitHub, Milvus, Qdrant) with one line each, sharing the same defaults and observability.

## Changes

`packages/chrome-extension/src/utils/retryWithBackoff.ts` *(new, 108 lines)*:

```ts
export async function retryWithBackoff<T>(
    operation: (attempt: number) => Promise<T>,
    options?: RetryOptions
): Promise<T>
```

**Defaults** (tuned for browser-side use, same shape as the existing Milvus retry):
- `maxRetries = 5`
- `initialDelayMs = 500`
- `maxDelayMs = 30_000`
- `backoffMultiplier = 2`
- `jitter = true` (±25%)
- `shouldRetry`: network errors + HTTP 5xx + 429; skip on other 4xx

**Hooks:**
- `shouldRetry(error, attempt)` — opt out of retry for certain errors
- `onRetry(error, attempt, delayMs)` — log, increment metrics, etc.

**Status extraction** handles two common error shapes:
- `error.status` (when the call sites attach it)
- Status embedded in the message (e.g. `"Qdrant PUT /... failed: 503 Service Unavailable"` — matches our existing adapter error format)

## Usage (preview — actual integrations come in follow-up PRs)

```ts
import { retryWithBackoff } from '../utils/retryWithBackoff';

const json = await retryWithBackoff(
    async (attempt) => {
        const res = await fetch(githubUrl, { headers });
        if (!res.ok) {
            const err: any = new Error(`GitHub ${res.status}`);
            err.status = res.status;
            throw err;
        }
        return res.json();
    },
    {
        onRetry: (err, attempt, delay) =>
            console.warn(`[GitHub] retry ${attempt} after ${delay}ms:`, err),
    }
);
```

## Test plan

- [x] `tsc --noEmit` clean
- [ ] (Manual) Wrap a flaky URL → verify 3 retries with exponential backoff
- [ ] (Manual) Throw a non-retryable error → verify single attempt, no retry
- [ ] Unit tests will be added in PR 8 alongside the test framework setup

## Notes for reviewers

- Intentionally no dependency — no `p-retry`, no `async-retry`. Keeps the bundle small and keeps semantics under our control.
- `jitterize()` is local to avoid pulling in `Math.random` mocking in tests; the predicate passed to `retryWithBackoff` is the seam for testing the timing.
- This PR adds the utility but does NOT wire it into existing call sites. That's intentional — keeps the diff reviewable and lets us add tests for the utility before changing behavior of the GitHub/Milvus paths.
- Follow-up PR will replace bare `await fetch(...)` calls in `background.ts` and the adapters with `retryWithBackoff(() => fetch(...))`.
