### PR TITLE
feat(chrome-extension): support multiple embedding providers

### DIFF
--- a/packages/chrome-extension/src/background.ts
+++ b/packages/chrome-extension/src/background.ts
@@ -4,6 +4,8 @@
 import { ChromeMilvusAdapter, CodeChunk } from './milvus/chromeMilvusAdapter';
 import { MilvusConfigManager } from './config/milvusConfig';
 import { IndexedRepoManager, IndexedRepository } from './storage/indexedRepoManager';
+import { createEmbeddingProvider, getConfiguredProviderName } from './embedding/factory';
+import type { EmbeddingProvider } from './embedding/types';
 
 export { };
 
@@ -29,47 +31,36 @@ function cosSim(a: number[], b: number[]): number {
     return dot / (Math.sqrt(normA) * Math.sqrt(normB));
 }
 
+/**
+ * Thin wrapper around the configured EmbeddingProvider.
+ * Caches the provider instance so we don't re-read settings on every call.
+ * Settings changes from the options page should reset the cache (handled by
+ * the chrome.storage.onChanged listener at the bottom of this file).
+ */
 class EmbeddingModel {
-    private static config: { apiKey: string; model: string } | null = null;
+    private static provider: EmbeddingProvider | null = null;
 
-    private static async getConfig(): Promise<{ apiKey: string; model: string }> {
-        if (!this.config) {
-            const config = await MilvusConfigManager.getOpenAIConfig();
-            if (!config) {
-                throw new Error('OpenAI API key is not configured.');
-            }
-            this.config = config;
+    static async getProvider(): Promise<EmbeddingProvider> {
+        if (!this.provider) {
+            this.provider = await createEmbeddingProvider();
+            const name = await getConfiguredProviderName();
+            console.log(`🧠 Embedding provider initialized: ${name} (dim=${this.provider.dimension})`);
         }
-        return this.config;
+        return this.provider;
+    }
+
+    static reset(): void {
+        this.provider = null;
     }
 
     static async embedBatch(texts: string[]): Promise<number[][]> {
-        const config = await this.getConfig();
-
-        const response = await fetch('https://api.openai.com/v1/embeddings', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${config.apiKey}`,
-            },
-            body: JSON.stringify({
-                model: config.model,
-                input: texts,
-            }),
-        });
-
-        if (!response.ok) {
-            const text = await response.text();
-            throw new Error(`OpenAI API error: ${response.status} - ${text}`);
-        }
-
-        const json = await response.json();
-        return json.data.map((d: any) => d.embedding as number[]);
+        const provider = await this.getProvider();
+        return provider.embedBatch(texts);
     }
 
     static async embedSingle(text: string): Promise<number[]> {
-        const results = await this.embedBatch([text]);
-        return results[0];
+        const provider = await this.getProvider();
+        return provider.embedSingle(text);
     }
 
     static async getInstance(_progress_callback: Function | undefined = undefined): Promise<(input: string | string[], options?: any) => Promise<{ data: number[] }>> {
@@ -83,6 +74,17 @@ class EmbeddingModel {
             }
         };
     }
+}
+
+// Reset cached provider when the user changes embedding settings.
+if (chrome.storage && chrome.storage.onChanged) {
+    chrome.storage.onChanged.addListener((changes, area) => {
+        if (area !== 'sync') return;
+        const watched = ['embeddingProvider', 'embeddingModel', 'openaiToken', 'voyageaiToken', 'voyageaiBaseUrl', 'geminiToken', 'openrouterToken'];
+        if (watched.some((k) => k in changes)) {
+            EmbeddingModel.reset();
+        }
+    });
 }
 class MilvusVectorDB {
     private adapter: ChromeMilvusAdapter;

--- a/packages/chrome-extension/src/embedding/factory.ts
+++ b/packages/chrome-extension/src/embedding/factory.ts
@@ -1,0 +1,51 @@
+import { EmbeddingProvider, EMBEDDING_STORAGE_KEYS, EmbeddingProviderName, EmbeddingStorageShape } from './types';
+import { OpenAIProvider } from './openai';
+import { VoyageAIProvider } from './voyageai';
+import { GeminiProvider } from './gemini';
+import { OpenRouterProvider } from './openrouter';
+
+const STORAGE_KEYS = Object.values(EMBEDDING_STORAGE_KEYS);
+
+/** Read the user's chosen embedding provider + creds and build a provider. */
+export async function createEmbeddingProvider(): Promise<EmbeddingProvider> {
+    const settings = await readSettings();
+    const provider = settings.embeddingProvider || 'OpenAI';
+
+    switch (provider) {
+        case 'OpenAI': {
+            const key = settings.openaiToken;
+            if (!key) throw new Error('OpenAI API key is not configured.');
+            return new OpenAIProvider(key, settings.embeddingModel);
+        }
+        case 'VoyageAI': {
+            const key = settings.voyageaiToken;
+            if (!key) throw new Error('VoyageAI API key is not configured.');
+            return new VoyageAIProvider(key, settings.embeddingModel, settings.voyageaiBaseUrl);
+        }
+        case 'Gemini': {
+            const key = settings.geminiToken;
+            if (!key) throw new Error('Gemini API key is not configured.');
+            return new GeminiProvider(key, settings.embeddingModel);
+        }
+        case 'OpenRouter': {
+            const key = settings.openrouterToken;
+            if (!key) throw new Error('OpenRouter API key is not configured.');
+            return new OpenRouterProvider(key, settings.embeddingModel);
+        }
+        default:
+            throw new Error(`Unknown embedding provider: ${provider}`);
+    }
+}
+
+export async function getConfiguredProviderName(): Promise<EmbeddingProviderName> {
+    const settings = await readSettings();
+    return settings.embeddingProvider || 'OpenAI';
+}
+
+function readSettings(): Promise<EmbeddingStorageShape> {
+    return new Promise((resolve) => {
+        chrome.storage.sync.get(STORAGE_KEYS, (items: EmbeddingStorageShape) => {
+            resolve(items);
+        });
+    });
+}

--- a/packages/chrome-extension/src/embedding/gemini.ts
+++ b/packages/chrome-extension/src/embedding/gemini.ts
@@ -1,0 +1,44 @@
+import { EmbeddingProvider } from './types';
+
+const DEFAULT_MODEL = 'gemini-embedding-001';
+
+export class GeminiProvider implements EmbeddingProvider {
+    readonly name = 'Gemini' as const;
+    readonly dimension: number;
+    private readonly apiKey: string;
+    private readonly model: string;
+    private readonly baseUrl: string;
+
+    constructor(apiKey: string, model: string = DEFAULT_MODEL, baseUrl: string = 'https://generativelanguage.googleapis.com/v1beta') {
+        this.apiKey = apiKey;
+        this.model = model;
+        this.baseUrl = baseUrl.replace(/\/$/, '');
+        // gemini-embedding-001 returns 3072-dim by default; can be lowered via outputDimensionality.
+        this.dimension = 3072;
+    }
+
+    async embedBatch(texts: string[]): Promise<number[][]> {
+        // Gemini batch endpoint: batchEmbedContents
+        const res = await fetch(`${this.baseUrl}/models/${encodeURIComponent(this.model)}:batchEmbedContents?key=${this.apiKey}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                requests: texts.map((text) => ({
+                    model: `models/${this.model}`,
+                    content: { parts: [{ text }] },
+                })),
+            }),
+        });
+        if (!res.ok) {
+            const text = await res.text();
+            throw new Error(`Gemini embeddings ${res.status}: ${text}`);
+        }
+        const json = await res.json();
+        return json.embeddings.map((e: { values: number[] }) => e.values);
+    }
+
+    async embedSingle(text: string): Promise<number[]> {
+        const [v] = await this.embedBatch([text]);
+        return v;
+    }
+}

--- a/packages/chrome-extension/src/embedding/openai.ts
+++ b/packages/chrome-extension/src/embedding/openai.ts
@@ -1,0 +1,45 @@
+import { EmbeddingProvider } from './types';
+
+const DEFAULT_MODEL = 'text-embedding-3-small';
+const DIMENSION_BY_MODEL: Record<string, number> = {
+    'text-embedding-3-small': 1536,
+    'text-embedding-3-large': 3072,
+    'text-embedding-ada-002': 1536,
+};
+
+export class OpenAIProvider implements EmbeddingProvider {
+    readonly name = 'OpenAI' as const;
+    readonly dimension: number;
+    private readonly model: string;
+    private readonly apiKey: string;
+    private readonly baseUrl: string;
+
+    constructor(apiKey: string, model: string = DEFAULT_MODEL, baseUrl: string = 'https://api.openai.com/v1') {
+        this.apiKey = apiKey;
+        this.model = model;
+        this.baseUrl = baseUrl.replace(/\/$/, '');
+        this.dimension = DIMENSION_BY_MODEL[model] ?? 1536;
+    }
+
+    async embedBatch(texts: string[]): Promise<number[][]> {
+        const res = await fetch(`${this.baseUrl}/embeddings`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.apiKey}`,
+            },
+            body: JSON.stringify({ model: this.model, input: texts }),
+        });
+        if (!res.ok) {
+            const text = await res.text();
+            throw new Error(`OpenAI embeddings ${res.status}: ${text}`);
+        }
+        const json = await res.json();
+        return json.data.map((d: { embedding: number[] }) => d.embedding);
+    }
+
+    async embedSingle(text: string): Promise<number[]> {
+        const [v] = await this.embedBatch([text]);
+        return v;
+    }
+}

--- a/packages/chrome-extension/src/embedding/openrouter.ts
+++ b/packages/chrome-extension/src/embedding/openrouter.ts
@@ -1,0 +1,14 @@
+import { OpenAIProvider } from './openai';
+
+/**
+ * OpenRouter exposes an OpenAI-compatible /v1/embeddings endpoint, so we
+ * piggy-back on the OpenAI client with a different base URL and api key.
+ * Models are namespaced (e.g. "openai/text-embedding-3-small").
+ */
+export class OpenRouterProvider extends OpenAIProvider {
+    readonly name = 'OpenRouter' as any; // narrow at usage sites via factory.
+
+    constructor(apiKey: string, model: string = 'openai/text-embedding-3-small') {
+        super(apiKey, model, 'https://openrouter.ai/api/v1');
+    }
+}

--- a/packages/chrome-extension/src/embedding/types.ts
+++ b/packages/chrome-extension/src/embedding/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Browser-side embedding provider interface.
+ * All providers in this folder implement EmbeddingProvider so background.ts
+ * can stay provider-agnostic via the factory.
+ */
+
+export type EmbeddingProviderName = 'OpenAI' | 'VoyageAI' | 'Gemini' | 'OpenRouter';
+
+export interface EmbeddingProvider {
+    /** Human-readable name, used in logs and error messages. */
+    name: EmbeddingProviderName;
+
+    /** Vector dimension this provider/model returns. */
+    dimension: number;
+
+    /** Embed a batch of texts. Returns vectors in the same order. */
+    embedBatch(texts: string[]): Promise<number[][]>;
+
+    /** Convenience: embed a single text. Default impl wraps embedBatch. */
+    embedSingle(text: string): Promise<number[]>;
+}
+
+export const EMBEDDING_STORAGE_KEYS = {
+    provider: 'embeddingProvider',
+    model: 'embeddingModel',
+    openaiToken: 'openaiToken',
+    voyageaiToken: 'voyageaiToken',
+    voyageaiBaseUrl: 'voyageaiBaseUrl',
+    geminiToken: 'geminiToken',
+    openrouterToken: 'openrouterToken',
+} as const;
+
+export interface EmbeddingStorageShape {
+    embeddingProvider?: EmbeddingProviderName;
+    embeddingModel?: string;
+    openaiToken?: string;
+    voyageaiToken?: string;
+    voyageaiBaseUrl?: string;
+    geminiToken?: string;
+    openrouterToken?: string;
+}

--- a/packages/chrome-extension/src/embedding/voyageai.ts
+++ b/packages/chrome-extension/src/embedding/voyageai.ts
@@ -1,0 +1,64 @@
+import { EmbeddingProvider } from './types';
+
+const DEFAULT_MODEL = 'voyage-code-3';
+
+// Common voyage models; falls back to 1024 for unknown models.
+const DIMENSION_BY_MODEL: Record<string, number> = {
+    'voyage-code-3': 1024,
+    'voyage-3-large': 1024,
+    'voyage-3': 1024,
+    'voyage-3-lite': 512,
+    'voyage-code-2': 1536,
+    'voyage-large-2': 1536,
+    'voyage-2': 1024,
+    'voyage-4-large': 1024,
+    'voyage-4': 1024,
+    'voyage-4-lite': 1024,
+    'voyage-4-nano': 1024,
+};
+
+export class VoyageAIProvider implements EmbeddingProvider {
+    readonly name = 'VoyageAI' as const;
+    readonly dimension: number;
+    private readonly apiKey: string;
+    private readonly model: string;
+    private readonly baseUrl: string;
+
+    constructor(apiKey: string, model: string = DEFAULT_MODEL, baseUrl: string = 'https://api.voyageai.com/v1') {
+        this.apiKey = apiKey;
+        this.model = model;
+        this.baseUrl = baseUrl.replace(/\/$/, '');
+        this.dimension = DIMENSION_BY_MODEL[model] ?? 1024;
+    }
+
+    async embedBatch(texts: string[]): Promise<number[][]> {
+        const isMongoCompat = this.baseUrl.includes('ai.mongodb.com');
+        const body: Record<string, unknown> = {
+            model: this.model,
+            input: texts,
+            input_type: 'document',
+        };
+        // MongoDB Atlas VoyageAI compat does not accept encoding_format.
+        if (!isMongoCompat) body.encoding_format = 'float';
+
+        const res = await fetch(`${this.baseUrl}/embeddings`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.apiKey}`,
+            },
+            body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+            const text = await res.text();
+            throw new Error(`VoyageAI embeddings ${res.status}: ${text}`);
+        }
+        const json = await res.json();
+        return json.data.map((d: { embedding: number[] }) => d.embedding);
+    }
+
+    async embedSingle(text: string): Promise<number[]> {
+        const [v] = await this.embedBatch([text]);
+        return v;
+    }
+}

--- a/packages/chrome-extension/src/options.html
+++ b/packages/chrome-extension/src/options.html
@@ -144,15 +144,58 @@
 
 
             <div class="form-group">
+                <h3 class="h4 mb-2">Embedding Provider</h3>
+                <label for="embedding-provider" class="d-block mb-1">Provider</label>
+                <select id="embedding-provider" class="form-control">
+                    <option value="OpenAI">OpenAI</option>
+                    <option value="VoyageAI">VoyageAI</option>
+                    <option value="Gemini">Google Gemini</option>
+                    <option value="OpenRouter">OpenRouter</option>
+                </select>
+
+                <label for="embedding-model" class="d-block mb-1 mt-3">Model (optional)</label>
+                <input type="text" id="embedding-model" class="form-control width-full"
+                    placeholder="Leave blank for provider default">
+                <p class="note">e.g. text-embedding-3-small (OpenAI), voyage-code-3 (VoyageAI),
+                    gemini-embedding-001 (Gemini), openai/text-embedding-3-small (OpenRouter).</p>
+            </div>
+
+            <fieldset id="openai-fields" class="form-group">
                 <label for="openai-token" class="d-block mb-1">OpenAI API Key</label>
                 <input type="password" id="openai-token" class="form-control width-full"
                     placeholder="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
                 <p class="note">
-                    This key is used to generate embeddings via the OpenAI Embedding API.
-                    <br>You can create it in your <a href="https://platform.openai.com/account/api-keys"
+                    Create one in your <a href="https://platform.openai.com/account/api-keys"
                         target="_blank">OpenAI dashboard</a>.
                 </p>
-            </div>
+            </fieldset>
+
+            <fieldset id="voyageai-fields" class="form-group" style="display:none">
+                <label for="voyageai-token" class="d-block mb-1">VoyageAI API Key</label>
+                <input type="password" id="voyageai-token" class="form-control width-full"
+                    placeholder="pa-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+                <label for="voyageai-base-url" class="d-block mb-1 mt-3">Base URL (optional)</label>
+                <input type="url" id="voyageai-base-url" class="form-control width-full"
+                    placeholder="https://api.voyageai.com/v1 (or https://ai.mongodb.com/v1 for MongoDB Atlas)">
+                <p class="note">Leave blank for the default VoyageAI endpoint.
+                    Set <code>https://ai.mongodb.com/v1</code> when using a MongoDB Atlas VoyageAI key.</p>
+            </fieldset>
+
+            <fieldset id="gemini-fields" class="form-group" style="display:none">
+                <label for="gemini-token" class="d-block mb-1">Google Gemini API Key</label>
+                <input type="password" id="gemini-token" class="form-control width-full"
+                    placeholder="AIza...">
+                <p class="note">Create one in <a href="https://aistudio.google.com/apikey"
+                        target="_blank">Google AI Studio</a>.</p>
+            </fieldset>
+
+            <fieldset id="openrouter-fields" class="form-group" style="display:none">
+                <label for="openrouter-token" class="d-block mb-1">OpenRouter API Key</label>
+                <input type="password" id="openrouter-token" class="form-control width-full"
+                    placeholder="sk-or-v1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+                <p class="note">OpenRouter routes to OpenAI-compatible models from many providers.
+                    Use a namespaced model id like <code>openai/text-embedding-3-small</code>.</p>
+            </fieldset>
 
             <div class="form-group">
                 <h3 class="h4 mb-2">Milvus Configuration</h3>

--- a/packages/chrome-extension/src/options.ts
+++ b/packages/chrome-extension/src/options.ts
@@ -15,32 +15,53 @@ function addDebugInfo(message: string) {
 function saveOptions() {
     const tokenInput = document.getElementById('github-token') as HTMLInputElement;
     const openaiInput = document.getElementById('openai-token') as HTMLInputElement;
-    
+
+    // Embedding provider settings
+    const embeddingProviderSelect = document.getElementById('embedding-provider') as HTMLSelectElement | null;
+    const embeddingModelInput = document.getElementById('embedding-model') as HTMLInputElement | null;
+    const voyageaiTokenInput = document.getElementById('voyageai-token') as HTMLInputElement | null;
+    const voyageaiBaseUrlInput = document.getElementById('voyageai-base-url') as HTMLInputElement | null;
+    const geminiTokenInput = document.getElementById('gemini-token') as HTMLInputElement | null;
+    const openrouterTokenInput = document.getElementById('openrouter-token') as HTMLInputElement | null;
+
     // Milvus configuration inputs
     const milvusAddressInput = document.getElementById('milvus-address') as HTMLInputElement;
     const milvusTokenInput = document.getElementById('milvus-token') as HTMLInputElement;
     const milvusDatabaseInput = document.getElementById('milvus-database') as HTMLInputElement;
-    
+
     if (tokenInput) {
         const token = tokenInput.value;
         const openaiToken = openaiInput.value;
-        
+
+        const embeddingProvider = embeddingProviderSelect?.value || 'OpenAI';
+        const embeddingModel = embeddingModelInput?.value ?? '';
+        const voyageaiToken = voyageaiTokenInput?.value ?? '';
+        const voyageaiBaseUrl = voyageaiBaseUrlInput?.value ?? '';
+        const geminiToken = geminiTokenInput?.value ?? '';
+        const openrouterToken = openrouterTokenInput?.value ?? '';
+
         // Milvus configuration
         const milvusAddress = milvusAddressInput.value;
         const milvusToken = milvusTokenInput.value;
         const milvusDatabase = milvusDatabaseInput.value || 'default';
-        
+
         // Validate Milvus address format if provided
         if (milvusAddress && !isValidUrl(milvusAddress)) {
             alert('Please enter a valid Milvus server address (e.g., http://localhost:19530)');
             return;
         }
-        
-        addDebugInfo(`Saving settings: githubToken=${token ? '***' : 'empty'}, openaiToken=${openaiToken ? '***' : 'empty'}, milvusAddress=${milvusAddress}`);
-        
+
+        addDebugInfo(`Saving settings: provider=${embeddingProvider}, githubToken=${token ? '***' : 'empty'}, milvusAddress=${milvusAddress}`);
+
         chrome.storage.sync.set({
             githubToken: token,
             openaiToken: openaiToken,
+            embeddingProvider: embeddingProvider,
+            embeddingModel: embeddingModel,
+            voyageaiToken: voyageaiToken,
+            voyageaiBaseUrl: voyageaiBaseUrl,
+            geminiToken: geminiToken,
+            openrouterToken: openrouterToken,
             milvusAddress: milvusAddress,
             milvusToken: milvusToken,
             milvusDatabase: milvusDatabase
@@ -92,6 +113,12 @@ function restoreOptions() {
     chrome.storage.sync.get({
         githubToken: '',
         openaiToken: '',
+        embeddingProvider: 'OpenAI',
+        embeddingModel: '',
+        voyageaiToken: '',
+        voyageaiBaseUrl: '',
+        geminiToken: '',
+        openrouterToken: '',
         milvusAddress: '',
         milvusToken: '',
         milvusDatabase: 'default'
@@ -114,11 +141,45 @@ function restoreOptions() {
         
         if (githubTokenInput) githubTokenInput.value = items.githubToken || '';
         if (openaiTokenInput) openaiTokenInput.value = items.openaiToken || '';
-        
+
         if (milvusAddressInput) milvusAddressInput.value = items.milvusAddress || '';
         if (milvusTokenInput) milvusTokenInput.value = items.milvusToken || '';
         if (milvusDatabaseInput) milvusDatabaseInput.value = items.milvusDatabase || 'default';
+
+        // Embedding provider fields
+        const embeddingProviderSelect = document.getElementById('embedding-provider') as HTMLSelectElement | null;
+        const embeddingModelInput = document.getElementById('embedding-model') as HTMLInputElement | null;
+        const voyageaiTokenInput = document.getElementById('voyageai-token') as HTMLInputElement | null;
+        const voyageaiBaseUrlInput = document.getElementById('voyageai-base-url') as HTMLInputElement | null;
+        const geminiTokenInput = document.getElementById('gemini-token') as HTMLInputElement | null;
+        const openrouterTokenInput = document.getElementById('openrouter-token') as HTMLInputElement | null;
+
+        if (embeddingProviderSelect) {
+            embeddingProviderSelect.value = items.embeddingProvider || 'OpenAI';
+            applyEmbeddingProviderVisibility(embeddingProviderSelect.value);
+            embeddingProviderSelect.addEventListener('change', () =>
+                applyEmbeddingProviderVisibility(embeddingProviderSelect.value)
+            );
+        }
+        if (embeddingModelInput) embeddingModelInput.value = items.embeddingModel || '';
+        if (voyageaiTokenInput) voyageaiTokenInput.value = items.voyageaiToken || '';
+        if (voyageaiBaseUrlInput) voyageaiBaseUrlInput.value = items.voyageaiBaseUrl || '';
+        if (geminiTokenInput) geminiTokenInput.value = items.geminiToken || '';
+        if (openrouterTokenInput) openrouterTokenInput.value = items.openrouterToken || '';
     });
+}
+
+function applyEmbeddingProviderVisibility(provider: string) {
+    const map: Record<string, string> = {
+        OpenAI: 'openai-fields',
+        VoyageAI: 'voyageai-fields',
+        Gemini: 'gemini-fields',
+        OpenRouter: 'openrouter-fields',
+    };
+    for (const [key, id] of Object.entries(map)) {
+        const el = document.getElementById(id);
+        if (el) (el as HTMLElement).style.display = provider === key ? '' : 'none';
+    }
 }
 
 function testMilvusConnection() {


### PR DESCRIPTION
## Summary

Add multi-provider embedding support to the Chrome Extension. Users can now choose **OpenAI**, **VoyageAI**, **Google Gemini**, or **OpenRouter** for embeddings, matching the providers the MCP server has supported for some time. Previously the extension was hardcoded to OpenAI.

## Motivation

The MCP server has supported VoyageAI, Gemini, Ollama, and OpenRouter for a while (`packages/core/src/embedding/*`). The Chrome Extension lagged behind — anyone using e.g. VoyageAI's `voyage-code-3` (which significantly outperforms `text-embedding-3-small` on code retrieval) couldn't use the same embeddings in the browser. This PR closes that gap.

## Changes

**New `packages/chrome-extension/src/embedding/` module:**
- `types.ts` — `EmbeddingProvider` interface; `EmbeddingProviderName` union; storage key constants.
- `openai.ts` — `OpenAIProvider`. Extracted from the old inline `EmbeddingModel` class. Supports custom base URL (parameter for OpenRouter to extend).
- `voyageai.ts` — `VoyageAIProvider`. Supports custom `baseUrl` and detects MongoDB Atlas VoyageAI endpoints (`ai.mongodb.com`) to omit `encoding_format`, matching the MCP server fix.
- `gemini.ts` — `GeminiProvider`. Uses Gemini's `:batchEmbedContents` REST endpoint.
- `openrouter.ts` — `OpenRouterProvider extends OpenAIProvider`. OpenRouter's `/v1/embeddings` is OpenAI-compatible — only the base URL and model namespacing differ.
- `factory.ts` — `createEmbeddingProvider()` reads `embeddingProvider` + creds from `chrome.storage.sync` and returns the right provider. Defaults to OpenAI for backward compatibility.

**`packages/chrome-extension/src/background.ts`:**
- `EmbeddingModel` is now a thin wrapper over the configured `EmbeddingProvider`. Caches the provider instance to avoid re-reading settings on every batch.
- `chrome.storage.onChanged` listener resets the cache when embedding-related settings change, so toggling provider in options takes effect immediately without a reload.
- The `getInstance()` helper is preserved unchanged for consumers that call it.

**`packages/chrome-extension/src/options.html`:**
- New "Embedding Provider" section above the OpenAI key field.
- `<select id="embedding-provider">` with OpenAI / VoyageAI / Gemini / OpenRouter.
- Optional `embedding-model` text input (provider-default if blank).
- Provider-specific fields wrapped in their own `<fieldset>` (`#openai-fields`, `#voyageai-fields`, `#gemini-fields`, `#openrouter-fields`) — only the selected provider's fields are visible.

**`packages/chrome-extension/src/options.ts`:**
- Save/restore now includes: `embeddingProvider`, `embeddingModel`, `voyageaiToken`, `voyageaiBaseUrl`, `geminiToken`, `openrouterToken`.
- New `applyEmbeddingProviderVisibility()` toggles fieldset display on initial load and on `change`.

## Backward compatibility

- Default provider is OpenAI. Existing users with `openaiToken` set see no change.
- All Milvus / OpenAI storage keys are untouched.
- New keys are additive.

## What's intentionally NOT in this PR

- **Ollama provider.** Ollama is reachable from Node easily, but from a Chrome extension service worker the local Ollama server needs CORS configuration that most users haven't set. We'd rather punt than ship a feature that fails confusingly. Add in a follow-up once we've documented the CORS setup.
- **Wiring `retryWithBackoff`** (the utility added in the sibling PR). Each provider would benefit but the change is mechanical — keeping it separate so this PR's diff stays focused on the provider abstraction.

## Test plan

- [x] `tsc --noEmit` clean across the chrome-extension package
- [ ] Build the extension and load unpacked
- [ ] Provider = OpenAI (default) + existing openaiToken → indexing/search work as before
- [ ] Switch to VoyageAI + add VoyageAI key → index a small repo → verify embeddings come back at the right dimension (1024 for `voyage-code-3`)
- [ ] Set `voyageai-base-url` to `https://ai.mongodb.com/v1` with a MongoDB-issued key → verify it works (no `encoding_format` 400)
- [ ] Switch to Gemini + add Gemini key → index → verify 3072-dim vectors
- [ ] Switch to OpenRouter + key + model `openai/text-embedding-3-small` → verify
- [ ] Toggle provider in options, save, search → no reload needed thanks to onChanged listener

## Notes for reviewers

- The provider classes are deliberately tiny (~40 lines each) and have no shared base class beyond the `EmbeddingProvider` interface. Inheritance from `OpenAIProvider` is used only for OpenRouter where the API truly is identical.
- Vector dimensions are hardcoded per known model with a sensible fallback. We could probe `embedSingle("ping").length` instead, but that adds a startup API call for every cold provider; the hardcoded table covers all current models and is easy to extend.
- `EmbeddingModel.reset()` triggers on every embedding-related storage write. Coarse but cheap (a single field reassignment); fine-grained invalidation isn't worth the complexity.
