### PR TITLE
fix(mcp): use computed Ollama host with default fallback

### DIFF
--- a/packages/mcp/src/embedding.ts
+++ b/packages/mcp/src/embedding.ts
@@ -67,7 +67,7 @@ export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbeddi
             console.log(`[EMBEDDING] 🔧 Configuring Ollama with model: ${config.embeddingModel}, host: ${ollamaHost}`);
             const ollamaEmbedding = new OllamaEmbedding({
                 model: config.embeddingModel,
-                host: config.ollamaHost
+                host: ollamaHost
             });
             console.log(`[EMBEDDING] ✅ Ollama embedding instance created successfully`);
             return ollamaEmbedding;


### PR DESCRIPTION
  The OllamaEmbedding constructor received config.ollamaHost (undefined when OLLAMA_HOST is unset) instead of the ollamaHost variable that includes the documented default http://127.0.0.1:11434. This caused connection failures for Ollama users who relied on the default host.