### PR TITLE
Security: GitHub token embedded in clone URL may leak credentials

### DIFF
--- a/evaluation/utils/file_management.py
+++ b/evaluation/utils/file_management.py
@@ -123,7 +123,12 @@ def clone_repo(repo, root_dir, token):
     repo_dir = Path(root_dir, f"repo__{repo.replace('/', '__')}")
 
     if not repo_dir.exists():
-        repo_url = f"https://{token}@github.com/{repo}.git"
+        repo_url = f"https://github.com/{repo}.git"
+        clone_kwargs = {}
+        if token:
+            clone_kwargs["multi_options"] = [
+                f"-c http.extraheader=AUTHORIZATION: bearer {token}"
+            ]
         logger.info(f"Cloning {repo} {os.getpid()}")
-        Repo.clone_from(repo_url, repo_dir)
+        Repo.clone_from(repo_url, repo_dir, **clone_kwargs)
     return repo_dir


### PR DESCRIPTION
## Problem

The repository cloning logic constructs an HTTPS URL containing the raw GitHub token (`https://<token>@github.com/...`). Tokens embedded in URLs can leak through process listings, crash logs, shell history, proxy logs, or be persisted in `.git/config` as the remote origin URL.

**Severity**: `high`
**File**: `evaluation/utils/file_management.py`

## Solution

Avoid embedding credentials in URLs. Use Git credential helpers, `GIT_ASKPASS`, or authenticated headers/SSH deploy keys. If HTTPS tokens must be used, ensure they are not persisted in remotes and scrub/redact them from all logs.

## Changes

- `evaluation/utils/file_management.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
