### PR TITLE
feat(core): add Dart language to default supported extensions

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -27,6 +27,7 @@ const DEFAULT_SUPPORTED_EXTENSIONS = [
     // Programming languages
     '.ts', '.tsx', '.js', '.jsx', '.py', '.java', '.cpp', '.c', '.h', '.hpp',
     '.cs', '.go', '.rs', '.php', '.rb', '.swift', '.kt', '.scala', '.m', '.mm',
+    '.dart',
     // Text and markup files
     '.md', '.markdown', '.ipynb',
     // '.txt',  '.json', '.yaml', '.yml', '.xml', '.html', '.htm',
@@ -957,6 +958,7 @@ export class Context {
             '.scala': 'scala',
             '.m': 'objective-c',
             '.mm': 'objective-c',
+            '.dart': 'dart',
             '.ipynb': 'jupyter'
         };
         return languageMap[ext] || 'text';


### PR DESCRIPTION
## Closes #317

`.dart` files were silently skipped during indexing because the extension was missing from both `DEFAULT_SUPPORTED_EXTENSIONS` and `getLanguageFromExtension`'s `languageMap` in `packages/core/src/context.ts`.

## Change

Two one-line additions to `packages/core/src/context.ts`:

```ts
const DEFAULT_SUPPORTED_EXTENSIONS = [
    // Programming languages
    '.ts', '.tsx', '.js', '.jsx', '.py', '.java', '.cpp', '.c', '.h', '.hpp',
    '.cs', '.go', '.rs', '.php', '.rb', '.swift', '.kt', '.scala', '.m', '.mm',
    '.dart',  // <-- added
    ...
];
```

```ts
const languageMap: Record<string, string> = {
    ...
    '.m': 'objective-c',
    '.mm': 'objective-c',
    '.dart': 'dart',  // <-- added
    '.ipynb': 'jupyter'
};
```

No new dependency. Dart files split via the LangChain character-based splitter, matching the existing pattern for Swift/Kotlin/Scala (extension registered, no tree-sitter AST coverage). The `isLanguageSupported` whitelist in `ast-splitter.ts` only covers JS/TS/Python today, so Dart correctly falls through to the generic splitter.

## Verification

- [x] `pnpm --filter @zilliz/claude-context-core typecheck` - clean
- [x] `pnpm --filter @zilliz/claude-context-core build` - clean

## Note

Sibling open requests for Elixir (#315) and Solidity (#240) follow the same shape and would be addressed in separate PRs to keep each language scoped to its own request.

🤖 Built with assistance from Claude Code.