### PR TITLE
docs: update Node.js 24 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ Copy your key and use it in the configuration examples below as `your-openai-api
 
 **System Requirements:**
 
-- Node.js >= 20.0.0 and < 24.0.0
-
-> Claude Context is not compatible with Node.js 24.0.0, you need downgrade it first if your node version is greater or equal to 24.
+- Node.js >= 20.0.0
 
 #### Configuration
 
@@ -616,7 +614,7 @@ Integrates Claude Context directly into your IDE. Provides an intuitive interfac
 
 #### Prerequisites
 
-- Node.js 20.x or 22.x
+- Node.js 20.x, 22.x, or 24.x
 - pnpm (recommended package manager)
 
 #### Cross-Platform Setup


### PR DESCRIPTION
## Summary
- Remove the outdated Node.js 24 incompatibility note from the README
- Document Node.js 24 as a supported development runtime
- Add Node.js 24 to the CI matrix

## Testing
- git diff --check -- README.md .github/workflows/ci.yml
- pnpm -r --filter='!./examples/*' build