### PR TITLE
chore: bump version to 0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "claude-context",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "description": "A powerful code indexing tool with multi-platform support",
     "private": true,
     "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-core",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "description": "Core indexing engine for Claude Context",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zilliz/claude-context-mcp",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "description": "Model Context Protocol integration for Claude Context",
     "type": "module",
     "main": "dist/index.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
     "displayName": "Semantic Code Search",
     "publisher": "zilliz",
     "description": "Code indexing and semantic search (built by Claude Context)",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "private": true,
     "engines": {
         "vscode": "^1.74.0"


### PR DESCRIPTION
## Summary
- Bump package versions to 0.1.10 for the next release

## Testing
- pnpm --filter @zilliz/claude-context-core build
- pnpm --filter @zilliz/claude-context-mcp build
- pnpm --filter semanticcodesearch compile
- git diff --check -- package.json packages/core/package.json packages/mcp/package.json packages/vscode-extension/package.json