### PR TITLE
fix(core): support root-anchored directory ignore patterns

### DIFF
--- a/packages/core/src/context.ignore-patterns.test.ts
+++ b/packages/core/src/context.ignore-patterns.test.ts
@@ -3,8 +3,8 @@ import * as os from 'os';
 import * as path from 'path';
 import { Context } from './context';
 import { Embedding, EmbeddingVector } from './embedding';
-import { FileSynchronizer } from './sync/synchronizer';
 import { Splitter, CodeChunk } from './splitter';
+import { FileSynchronizer } from './sync/synchronizer';
 import { VectorDatabase } from './vectordb';
 
 class TestEmbedding extends Embedding {
@@ -181,4 +181,49 @@ describe('Context ignore pattern isolation', () => {
         }
     });
 
+    it('treats leading-slash directory ignore patterns as root-anchored and recursive during indexing', async () => {
+        const project = path.join(tempRoot, 'project');
+        await fs.mkdir(path.join(project, 'Library'), { recursive: true });
+        await fs.mkdir(path.join(project, 'src', 'Library'), { recursive: true });
+        await fs.writeFile(path.join(project, '.gitignore'), '/Library/\n');
+        await fs.writeFile(path.join(project, 'Library', 'generated.md'), 'root library should be ignored');
+        await fs.writeFile(path.join(project, 'src', 'Library', 'nested.md'), 'nested library should stay');
+        await fs.writeFile(path.join(project, 'src', 'keep.md'), 'regular file should stay');
+
+        const vectorDatabase = createVectorDatabase();
+        const context = new Context({
+            embedding: new TestEmbedding(),
+            vectorDatabase,
+            codeSplitter: new TestSplitter(),
+        });
+
+        await context.indexCodebase(project);
+
+        const insertedDocuments = vectorDatabase.insert.mock.calls
+            .flatMap(([, documents]) => documents);
+        const indexedPaths = insertedDocuments
+            .map(document => document.relativePath.replace(/\\/g, '/'))
+            .sort();
+
+        expect(indexedPaths).toEqual([
+            'src/Library/nested.md',
+            'src/keep.md',
+        ]);
+    });
+
+    it('treats leading-slash directory ignore patterns as root-anchored and recursive during sync', async () => {
+        const project = path.join(tempRoot, 'project');
+        await fs.mkdir(path.join(project, 'Library'), { recursive: true });
+        await fs.mkdir(path.join(project, 'src', 'Library'), { recursive: true });
+        await fs.writeFile(path.join(project, 'Library', 'generated.md'), 'root library should be ignored');
+        await fs.writeFile(path.join(project, 'src', 'Library', 'nested.md'), 'nested library should stay');
+        await fs.writeFile(path.join(project, 'src', 'keep.md'), 'regular file should stay');
+
+        const synchronizer = new FileSynchronizer(project, ['/Library/'], ['.md']);
+        const fileHashes = await (synchronizer as any).generateFileHashes(project) as Map<string, string>;
+
+        expect(fileHashes.has(path.join('Library', 'generated.md'))).toBe(false);
+        expect(fileHashes.has(path.join('src', 'Library', 'nested.md'))).toBe(true);
+        expect(fileHashes.has(path.join('src', 'keep.md'))).toBe(true);
+    });
 });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1187,22 +1187,53 @@ export class Context {
      * @returns True if pattern matches
      */
     private isPatternMatch(filePath: string, pattern: string): boolean {
+        const cleanPath = filePath.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+        const normalizedPattern = pattern.replace(/\\/g, '/');
+        const cleanPattern = normalizedPattern.replace(/^\/+|\/+$/g, '');
+        const isRootAnchored = normalizedPattern.startsWith('/');
+        const isDirectoryPattern = normalizedPattern.endsWith('/');
+
+        if (!cleanPath || !cleanPattern) {
+            return false;
+        }
+
         // Handle directory patterns (ending with /)
-        if (pattern.endsWith('/')) {
-            const dirPattern = pattern.slice(0, -1);
-            const pathParts = filePath.split('/');
-            return pathParts.some(part => this.simpleGlobMatch(part, dirPattern));
+        if (isDirectoryPattern) {
+            if (isRootAnchored) {
+                return this.simpleGlobMatch(cleanPath, cleanPattern) ||
+                    cleanPath.startsWith(`${cleanPattern}/`);
+            }
+
+            return this.matchesDirectoryPattern(cleanPath, cleanPattern);
+        }
+
+        if (isRootAnchored) {
+            return this.simpleGlobMatch(cleanPath, cleanPattern);
         }
 
         // Handle file patterns
-        if (pattern.includes('/')) {
+        if (cleanPattern.includes('/')) {
             // Pattern with path separator - match exact path
-            return this.simpleGlobMatch(filePath, pattern);
+            return this.simpleGlobMatch(cleanPath, cleanPattern);
         } else {
             // Pattern without path separator - match filename in any directory
-            const fileName = path.basename(filePath);
-            return this.simpleGlobMatch(fileName, pattern);
+            const fileName = path.basename(cleanPath);
+            return this.simpleGlobMatch(fileName, cleanPattern);
         }
+    }
+
+    private matchesDirectoryPattern(filePath: string, dirPattern: string): boolean {
+        const pathParts = filePath.split('/');
+        const dirPartCount = dirPattern.split('/').length;
+
+        for (let i = 0; i <= pathParts.length - dirPartCount; i++) {
+            const candidate = pathParts.slice(i, i + dirPartCount).join('/');
+            if (this.simpleGlobMatch(candidate, dirPattern)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/packages/core/src/sync/synchronizer.ts
+++ b/packages/core/src/sync/synchronizer.ts
@@ -57,7 +57,7 @@ export class FileSynchronizer {
             const relativePath = path.relative(this.rootDir, fullPath);
 
             // Check if this path should be ignored BEFORE any file system operations
-            if (this.shouldIgnore(relativePath, entry.isDirectory())) {
+            if (this.shouldIgnore(relativePath)) {
                 continue; // Skip completely - no access at all
             }
 
@@ -72,7 +72,7 @@ export class FileSynchronizer {
 
             if (stat.isDirectory()) {
                 // Verify it's really a directory and not ignored
-                if (!this.shouldIgnore(relativePath, true)) {
+                if (!this.shouldIgnore(relativePath)) {
                     const subHashes = await this.generateFileHashes(fullPath);
                     const entries = Array.from(subHashes.entries());
                     for (let i = 0; i < entries.length; i++) {
@@ -82,7 +82,7 @@ export class FileSynchronizer {
                 }
             } else if (stat.isFile()) {
                 // Verify it's really a file and not ignored
-                if (!this.shouldIgnore(relativePath, false)) {
+                if (!this.shouldIgnore(relativePath)) {
                     const ext = path.extname(entry.name);
                     if (this.supportedExtensions.length > 0 && !this.supportedExtensions.includes(ext)) {
                         continue;
@@ -101,7 +101,7 @@ export class FileSynchronizer {
         return fileHashes;
     }
 
-    private shouldIgnore(relativePath: string, isDirectory: boolean = false): boolean {
+    private shouldIgnore(relativePath: string): boolean {
         // Always ignore hidden files and directories (starting with .)
         const pathParts = relativePath.split(path.sep);
         if (pathParts.some(part => part.startsWith('.'))) {
@@ -121,7 +121,7 @@ export class FileSynchronizer {
 
         // Check direct pattern matches first
         for (const pattern of this.ignorePatterns) {
-            if (this.matchPattern(normalizedPath, pattern, isDirectory)) {
+            if (this.matchPattern(normalizedPath, pattern)) {
                 return true;
             }
         }
@@ -131,25 +131,8 @@ export class FileSynchronizer {
         for (let i = 0; i < normalizedPathParts.length; i++) {
             const partialPath = normalizedPathParts.slice(0, i + 1).join('/');
             for (const pattern of this.ignorePatterns) {
-                // Check directory patterns
-                if (pattern.endsWith('/')) {
-                    const dirPattern = pattern.slice(0, -1);
-                    if (this.simpleGlobMatch(partialPath, dirPattern) ||
-                        this.simpleGlobMatch(normalizedPathParts[i], dirPattern)) {
-                        return true;
-                    }
-                }
-                // Check exact path patterns
-                else if (pattern.includes('/')) {
-                    if (this.simpleGlobMatch(partialPath, pattern)) {
-                        return true;
-                    }
-                }
-                // Check filename patterns against any path component
-                else {
-                    if (this.simpleGlobMatch(normalizedPathParts[i], pattern)) {
-                        return true;
-                    }
+                if (this.matchPattern(partialPath, pattern)) {
+                    return true;
                 }
             }
         }
@@ -157,23 +140,30 @@ export class FileSynchronizer {
         return false;
     }
 
-    private matchPattern(filePath: string, pattern: string, isDirectory: boolean = false): boolean {
+    private matchPattern(filePath: string, pattern: string): boolean {
         // Clean both path and pattern
         const cleanPath = filePath.replace(/^\/+|\/+$/g, '');
-        const cleanPattern = pattern.replace(/^\/+|\/+$/g, '');
+        const normalizedPattern = pattern.replace(/\\/g, '/');
+        const cleanPattern = normalizedPattern.replace(/^\/+|\/+$/g, '');
+        const isRootAnchored = normalizedPattern.startsWith('/');
+        const isDirectoryPattern = normalizedPattern.endsWith('/');
 
         if (!cleanPath || !cleanPattern) {
             return false;
         }
 
         // Handle directory patterns (ending with /)
-        if (pattern.endsWith('/')) {
-            if (!isDirectory) return false; // Directory pattern only matches directories
-            const dirPattern = cleanPattern.slice(0, -1);
+        if (isDirectoryPattern) {
+            if (isRootAnchored) {
+                return this.simpleGlobMatch(cleanPath, cleanPattern) ||
+                    cleanPath.startsWith(`${cleanPattern}/`);
+            }
 
-            // Direct match or any path component matches
-            return this.simpleGlobMatch(cleanPath, dirPattern) ||
-                cleanPath.split('/').some(part => this.simpleGlobMatch(part, dirPattern));
+            return this.matchesDirectoryPattern(cleanPath, cleanPattern);
+        }
+
+        if (isRootAnchored) {
+            return this.simpleGlobMatch(cleanPath, cleanPattern);
         }
 
         // Handle path patterns (containing /)
@@ -184,6 +174,20 @@ export class FileSynchronizer {
         // Handle filename patterns (no /) - match against basename
         const fileName = path.basename(cleanPath);
         return this.simpleGlobMatch(fileName, cleanPattern);
+    }
+
+    private matchesDirectoryPattern(filePath: string, dirPattern: string): boolean {
+        const pathParts = filePath.split('/');
+        const dirPartCount = dirPattern.split('/').length;
+
+        for (let i = 0; i <= pathParts.length - dirPartCount; i++) {
+            const candidate = pathParts.slice(i, i + dirPartCount).join('/');
+            if (this.simpleGlobMatch(candidate, dirPattern)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private simpleGlobMatch(text: string, pattern: string): boolean {


### PR DESCRIPTION
## Summary
- handle root-anchored directory ignore patterns like `/Library/` as recursive directory excludes
- keep `/Library/` anchored to the codebase root so nested `src/Library` directories are not skipped
- apply the same matching semantics to initial indexing and `FileSynchronizer` change detection

## Tests
- `pnpm --filter @zilliz/claude-context-core test`
- `pnpm --filter @zilliz/claude-context-core typecheck`
- `pnpm --filter @zilliz/claude-context-core build`

Fixes #200