### PR TITLE
fix(mcp): pass embedding dimension to Ollama

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -130,6 +130,9 @@ EMBEDDING_MODEL=nomic-embed-text
 
 # Optional: Specify Ollama host (default: http://127.0.0.1:11434)
 OLLAMA_HOST=http://127.0.0.1:11434
+
+# Optional: Override embedding dimension to skip runtime dimension detection
+EMBEDDING_DIMENSION=768
 ```
 
 **Setup Instructions:**
@@ -361,6 +364,7 @@ Pasting the following configuration into your Cursor `~/.cursor/mcp.json` file i
         "EMBEDDING_PROVIDER": "Ollama",
         "EMBEDDING_MODEL": "nomic-embed-text",
         "OLLAMA_HOST": "http://127.0.0.1:11434",
+        "EMBEDDING_DIMENSION": "768",
         "MILVUS_TOKEN": "your-zilliz-cloud-api-key"
       }
     }

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -17,6 +17,7 @@ export interface ContextMcpConfig {
     // Ollama configuration
     ollamaModel?: string;
     ollamaHost?: string;
+    ollamaDimension?: number;
     // Vector database configuration
     milvusAddress?: string; // Optional, can be auto-resolved from token
     milvusToken?: string;
@@ -108,11 +109,27 @@ export function getEmbeddingModelForProvider(provider: string): string {
     }
 }
 
+function getPositiveIntegerFromEnv(name: string): number | undefined {
+    const rawValue = envManager.get(name);
+    if (!rawValue) {
+        return undefined;
+    }
+
+    const parsedValue = Number(rawValue);
+    if (Number.isInteger(parsedValue) && parsedValue > 0) {
+        return parsedValue;
+    }
+
+    console.warn(`[DEBUG] ⚠️  Ignoring invalid ${name}: ${rawValue}. Expected a positive integer.`);
+    return undefined;
+}
+
 export function createMcpConfig(): ContextMcpConfig {
     // Debug: Print all environment variables related to Context
     console.log(`[DEBUG] 🔍 Environment Variables Debug:`);
     console.log(`[DEBUG]   EMBEDDING_PROVIDER: ${envManager.get('EMBEDDING_PROVIDER') || 'NOT SET'}`);
     console.log(`[DEBUG]   EMBEDDING_MODEL: ${envManager.get('EMBEDDING_MODEL') || 'NOT SET'}`);
+    console.log(`[DEBUG]   EMBEDDING_DIMENSION: ${envManager.get('EMBEDDING_DIMENSION') || 'NOT SET'}`);
     console.log(`[DEBUG]   OLLAMA_MODEL: ${envManager.get('OLLAMA_MODEL') || 'NOT SET'}`);
     console.log(`[DEBUG]   GEMINI_API_KEY: ${envManager.get('GEMINI_API_KEY') ? 'SET (length: ' + envManager.get('GEMINI_API_KEY')!.length + ')' : 'NOT SET'}`);
     console.log(`[DEBUG]   OPENAI_API_KEY: ${envManager.get('OPENAI_API_KEY') ? 'SET (length: ' + envManager.get('OPENAI_API_KEY')!.length + ')' : 'NOT SET'}`);
@@ -137,6 +154,7 @@ export function createMcpConfig(): ContextMcpConfig {
         // Ollama configuration
         ollamaModel: envManager.get('OLLAMA_MODEL'),
         ollamaHost: envManager.get('OLLAMA_HOST'),
+        ollamaDimension: getPositiveIntegerFromEnv('EMBEDDING_DIMENSION'),
         // Vector database configuration - address can be auto-resolved from token
         milvusAddress: envManager.get('MILVUS_ADDRESS'), // Optional, can be resolved from token
         milvusToken: envManager.get('MILVUS_TOKEN'),
@@ -181,6 +199,9 @@ export function logConfigurationSummary(config: ContextMcpConfig): void {
         case 'Ollama':
             console.log(`[MCP]   Ollama Host: ${config.ollamaHost || 'http://127.0.0.1:11434'}`);
             console.log(`[MCP]   Ollama Model: ${config.embeddingModel}`);
+            if (config.ollamaDimension) {
+                console.log(`[MCP]   Ollama Embedding Dimension: ${config.ollamaDimension}`);
+            }
             break;
     }
 
@@ -203,6 +224,7 @@ Environment Variables:
   Embedding Provider Configuration:
   EMBEDDING_PROVIDER      Embedding provider: OpenAI, VoyageAI, Gemini, Ollama, OpenRouter (default: OpenAI)
   EMBEDDING_MODEL         Embedding model name (works for all providers)
+  EMBEDDING_DIMENSION     Optional embedding dimension override for Ollama
   
   Provider-specific API Keys:
   OPENAI_API_KEY          OpenAI API key (required for OpenAI provider)

--- a/packages/mcp/src/embedding.ts
+++ b/packages/mcp/src/embedding.ts
@@ -64,10 +64,11 @@ export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbeddi
 
         case 'Ollama':
             const ollamaHost = config.ollamaHost || 'http://127.0.0.1:11434';
-            console.log(`[EMBEDDING] 🔧 Configuring Ollama with model: ${config.embeddingModel}, host: ${ollamaHost}`);
+            console.log(`[EMBEDDING] 🔧 Configuring Ollama with model: ${config.embeddingModel}, host: ${ollamaHost}${config.ollamaDimension ? `, dimension: ${config.ollamaDimension}` : ''}`);
             const ollamaEmbedding = new OllamaEmbedding({
                 model: config.embeddingModel,
-                host: ollamaHost
+                host: ollamaHost,
+                ...(config.ollamaDimension && { dimension: config.ollamaDimension })
             });
             console.log(`[EMBEDDING] ✅ Ollama embedding instance created successfully`);
             return ollamaEmbedding;
@@ -97,7 +98,7 @@ export function logEmbeddingProviderInfo(config: ContextMcpConfig, embedding: Op
             console.log(`[EMBEDDING] OpenRouter configuration - API Key: ${config.openrouterApiKey ? '✅ Provided' : '❌ Missing'}`);
             break;
         case 'Ollama':
-            console.log(`[EMBEDDING] Ollama configuration - Host: ${config.ollamaHost || 'http://127.0.0.1:11434'}, Model: ${config.embeddingModel}`);
+            console.log(`[EMBEDDING] Ollama configuration - Host: ${config.ollamaHost || 'http://127.0.0.1:11434'}, Model: ${config.embeddingModel}${config.ollamaDimension ? `, Dimension: ${config.ollamaDimension}` : ''}`);
             break;
     }
-} 
+}


### PR DESCRIPTION
## Summary

Fixes #235.

When the MCP server creates an Ollama embedding provider, it now reads an optional `EMBEDDING_DIMENSION` environment variable and passes it through to `OllamaEmbedding`. This lets users who already know their local Ollama model dimension skip runtime dimension detection, which can fail intermittently during background indexing.

Invalid `EMBEDDING_DIMENSION` values are ignored with a warning, so the default auto-detection behavior is preserved unless a valid positive integer is provided.

## Changes

- Add `ollamaDimension` to MCP config
- Parse `EMBEDDING_DIMENSION` as a positive integer
- Pass the parsed dimension into `new OllamaEmbedding(...)`
- Document the option in the MCP README and help output

## Validation

- `pnpm --filter @zilliz/claude-context-mcp typecheck`
- `pnpm --filter @zilliz/claude-context-mcp build`
- `pnpm --filter @zilliz/claude-context-core typecheck`
- Runtime smoke test: `EMBEDDING_PROVIDER=Ollama EMBEDDING_MODEL=nomic-embed-text EMBEDDING_DIMENSION=768 ... createEmbeddingInstance(...).getDimension()` returns `768`

Note: `pnpm --filter @zilliz/claude-context-mcp lint` currently fails before linting because ESLint 9 cannot find an `eslint.config.*` file in this repo.