### PR TITLE
fix(mcp): scope customExtensions to index request

### DIFF
--- a/packages/core/src/context.ignore-patterns.test.ts
+++ b/packages/core/src/context.ignore-patterns.test.ts
@@ -2,35 +2,82 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { Context } from './context';
+import { Embedding, EmbeddingVector } from './embedding';
+import { Splitter, CodeChunk } from './splitter';
 import { VectorDatabase } from './vectordb';
 
-const createVectorDatabase = (): VectorDatabase => ({
-    createCollection: jest.fn(),
-    createHybridCollection: jest.fn(),
-    dropCollection: jest.fn(),
-    hasCollection: jest.fn(),
-    listCollections: jest.fn(),
-    insert: jest.fn(),
-    insertHybrid: jest.fn(),
-    search: jest.fn(),
-    hybridSearch: jest.fn(),
-    delete: jest.fn(),
-    query: jest.fn(),
-    getCollectionDescription: jest.fn(),
-    checkCollectionLimit: jest.fn(),
-    getCollectionRowCount: jest.fn(),
+class TestEmbedding extends Embedding {
+    protected maxTokens = 8192;
+
+    async detectDimension(): Promise<number> {
+        return 3;
+    }
+
+    async embed(text: string): Promise<EmbeddingVector> {
+        return { vector: [1, 0, 0], dimension: 3 };
+    }
+
+    async embedBatch(texts: string[]): Promise<EmbeddingVector[]> {
+        return texts.map(() => ({ vector: [1, 0, 0], dimension: 3 }));
+    }
+
+    getDimension(): number {
+        return 3;
+    }
+
+    getProvider(): string {
+        return 'test';
+    }
+}
+
+class TestSplitter implements Splitter {
+    async split(code: string, language: string, filePath?: string): Promise<CodeChunk[]> {
+        return [{
+            content: code,
+            metadata: {
+                startLine: 1,
+                endLine: 1,
+                language,
+                filePath,
+            },
+        }];
+    }
+
+    setChunkSize(): void { }
+
+    setChunkOverlap(): void { }
+}
+
+const createVectorDatabase = (): jest.Mocked<VectorDatabase> => ({
+    createCollection: jest.fn().mockResolvedValue(undefined),
+    createHybridCollection: jest.fn().mockResolvedValue(undefined),
+    dropCollection: jest.fn().mockResolvedValue(undefined),
+    hasCollection: jest.fn().mockResolvedValue(false),
+    listCollections: jest.fn().mockResolvedValue([]),
+    insert: jest.fn().mockResolvedValue(undefined),
+    insertHybrid: jest.fn().mockResolvedValue(undefined),
+    search: jest.fn().mockResolvedValue([]),
+    hybridSearch: jest.fn().mockResolvedValue([]),
+    delete: jest.fn().mockResolvedValue(undefined),
+    query: jest.fn().mockResolvedValue([]),
+    getCollectionDescription: jest.fn().mockResolvedValue(''),
+    checkCollectionLimit: jest.fn().mockResolvedValue(true),
+    getCollectionRowCount: jest.fn().mockResolvedValue(0),
 });
 
 describe('Context ignore pattern isolation', () => {
     let tempRoot: string;
     let originalHome: string | undefined;
+    let originalHybridMode: string | undefined;
 
     beforeEach(async () => {
         tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-context-ignore-'));
         const homeDir = path.join(tempRoot, 'home');
         await fs.mkdir(homeDir, { recursive: true });
         originalHome = process.env.HOME;
+        originalHybridMode = process.env.HYBRID_MODE;
         process.env.HOME = homeDir;
+        process.env.HYBRID_MODE = 'false';
     });
 
     afterEach(async () => {
@@ -38,6 +85,11 @@ describe('Context ignore pattern isolation', () => {
             delete process.env.HOME;
         } else {
             process.env.HOME = originalHome;
+        }
+        if (originalHybridMode === undefined) {
+            delete process.env.HYBRID_MODE;
+        } else {
+            process.env.HYBRID_MODE = originalHybridMode;
         }
         await fs.rm(tempRoot, { recursive: true, force: true });
     });
@@ -68,5 +120,40 @@ describe('Context ignore pattern isolation', () => {
 
         const withoutRequestIgnores = await context.getEffectiveIgnorePatterns(project);
         expect(withoutRequestIgnores).not.toContain('*.txt');
+    });
+
+    it('does not leak request custom extensions into persistent supported extensions', () => {
+        const context = new Context({ vectorDatabase: createVectorDatabase() });
+
+        const withRequestExtensions = context.getEffectiveSupportedExtensions(['foo']);
+        expect(withRequestExtensions).toContain('.foo');
+
+        const withoutRequestExtensions = context.getSupportedExtensions();
+        expect(withoutRequestExtensions).not.toContain('.foo');
+    });
+
+    it('does not leak request custom extensions between codebase indexes', async () => {
+        const projectA = path.join(tempRoot, 'project-a');
+        const projectB = path.join(tempRoot, 'project-b');
+        await fs.mkdir(projectA);
+        await fs.mkdir(projectB);
+        await fs.writeFile(path.join(projectA, 'a.foo'), 'project a custom file');
+        await fs.writeFile(path.join(projectB, 'b.foo'), 'project b custom file');
+
+        const vectorDatabase = createVectorDatabase();
+        const context = new Context({
+            embedding: new TestEmbedding(),
+            vectorDatabase,
+            codeSplitter: new TestSplitter(),
+        });
+
+        await context.indexCodebase(projectA, undefined, false, [], ['foo']);
+        expect(vectorDatabase.insert).toHaveBeenCalledTimes(1);
+        expect(vectorDatabase.insert.mock.calls[0][1][0].relativePath).toBe('a.foo');
+
+        vectorDatabase.insert.mockClear();
+
+        await context.indexCodebase(projectB);
+        expect(vectorDatabase.insert).not.toHaveBeenCalled();
     });
 });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -191,6 +191,15 @@ export class Context {
     }
 
     /**
+     * Get supported extensions for the current operation without mutating
+     * the Context's persistent extension list.
+     */
+    getEffectiveSupportedExtensions(additionalExtensions: string[] = []): string[] {
+        const normalizedExtensions = this.normalizeExtensions(additionalExtensions);
+        return [...new Set([...this.supportedExtensions, ...normalizedExtensions])];
+    }
+
+    /**
      * Get ignore patterns
      */
     getIgnorePatterns(): string[] {
@@ -308,13 +317,16 @@ export class Context {
      * @param codebasePath Codebase root path
      * @param progressCallback Optional progress callback function
      * @param forceReindex Whether to recreate the collection even if it exists
+     * @param additionalIgnorePatterns Request-scoped ignore patterns
+     * @param additionalSupportedExtensions Request-scoped file extensions
      * @returns Indexing statistics
      */
     async indexCodebase(
         codebasePath: string,
         progressCallback?: (progress: { phase: string; current: number; total: number; percentage: number }) => void,
         forceReindex: boolean = false,
-        additionalIgnorePatterns: string[] = []
+        additionalIgnorePatterns: string[] = [],
+        additionalSupportedExtensions: string[] = []
     ): Promise<{ indexedFiles: number; totalChunks: number; status: 'completed' | 'limit_reached' }> {
         const isHybrid = this.getIsHybrid();
         const searchType = isHybrid === true ? 'hybrid search' : 'semantic search';
@@ -331,7 +343,8 @@ export class Context {
 
         // 3. Recursively traverse codebase to get all supported files
         progressCallback?.({ phase: 'Scanning files...', current: 5, total: 100, percentage: 5 });
-        const codeFiles = await this.getCodeFiles(codebasePath, ignorePatterns);
+        const supportedExtensions = this.getEffectiveSupportedExtensions(additionalSupportedExtensions);
+        const codeFiles = await this.getCodeFiles(codebasePath, ignorePatterns, supportedExtensions);
         console.log(`[Context] 📁 Found ${codeFiles.length} code files`);
 
         if (codeFiles.length === 0) {
@@ -722,7 +735,11 @@ export class Context {
     /**
      * Recursively get all code files in the codebase
      */
-    private async getCodeFiles(codebasePath: string, ignorePatterns: string[] = this.ignorePatterns): Promise<string[]> {
+    private async getCodeFiles(
+        codebasePath: string,
+        ignorePatterns: string[] = this.ignorePatterns,
+        supportedExtensions: string[] = this.supportedExtensions
+    ): Promise<string[]> {
         const files: string[] = [];
 
         const traverseDirectory = async (currentPath: string) => {
@@ -740,7 +757,7 @@ export class Context {
                     await traverseDirectory(fullPath);
                 } else if (entry.isFile()) {
                     const ext = path.extname(entry.name);
-                    if (this.supportedExtensions.includes(ext)) {
+                    if (supportedExtensions.includes(ext)) {
                         files.push(fullPath);
                     }
                 }
@@ -1253,6 +1270,13 @@ export class Context {
         }
     }
 
+    private normalizeExtensions(extensions: string[]): string[] {
+        return extensions
+            .map(ext => ext.trim())
+            .filter(ext => ext.length > 0)
+            .map(ext => ext.startsWith('.') ? ext : `.${ext}`);
+    }
+
     /**
      * Add custom extensions (from MCP or other sources) without replacing existing ones
      * @param customExtensions Array of custom extensions to add
@@ -1260,10 +1284,7 @@ export class Context {
     addCustomExtensions(customExtensions: string[]): void {
         if (customExtensions.length === 0) return;
 
-        // Ensure extensions start with dot
-        const normalizedExtensions = customExtensions.map(ext =>
-            ext.startsWith('.') ? ext : `.${ext}`
-        );
+        const normalizedExtensions = this.normalizeExtensions(customExtensions);
 
         // Merge current extensions with new custom extensions, avoiding duplicates
         const mergedExtensions = [...this.supportedExtensions, ...normalizedExtensions];

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -443,10 +443,8 @@ export class ToolHandlers {
                 };
             }
 
-            // Add custom extensions if provided
             if (customFileExtensions.length > 0) {
-                console.log(`[CUSTOM-EXTENSIONS] Adding ${customFileExtensions.length} custom extensions: ${customFileExtensions.join(', ')}`);
-                this.context.addCustomExtensions(customFileExtensions);
+                console.log(`[CUSTOM-EXTENSIONS] Using ${customFileExtensions.length} request-scoped custom extensions: ${customFileExtensions.join(', ')}`);
             }
 
             // Check current status and log if retrying after failure
@@ -464,7 +462,7 @@ export class ToolHandlers {
             trackCodebasePath(absolutePath);
 
             // Start background indexing - now safe to proceed
-            this.startBackgroundIndexing(absolutePath, forceReindex, splitterType, customIgnorePatterns);
+            this.startBackgroundIndexing(absolutePath, forceReindex, splitterType, customIgnorePatterns, customFileExtensions);
 
             const pathInfo = codebasePath !== absolutePath
                 ? `\nNote: Input path '${codebasePath}' was resolved to absolute path '${absolutePath}'`
@@ -500,7 +498,13 @@ export class ToolHandlers {
         }
     }
 
-    private async startBackgroundIndexing(codebasePath: string, forceReindex: boolean, splitterType: string, customIgnorePatterns: string[] = []) {
+    private async startBackgroundIndexing(
+        codebasePath: string,
+        forceReindex: boolean,
+        splitterType: string,
+        customIgnorePatterns: string[] = [],
+        customFileExtensions: string[] = []
+    ) {
         const absolutePath = codebasePath;
         let lastSaveTime = 0; // Track last save timestamp
 
@@ -521,12 +525,16 @@ export class ToolHandlers {
             // Load ignore patterns from files first (including .ignore, .gitignore, etc.)
             // and merge them with this request's custom ignore patterns without
             // relying on shared Context state for this background indexing task.
-            const ignorePatterns = await this.context.getEffectiveIgnorePatterns(absolutePath, customIgnorePatterns);
+            const ignorePatterns = await contextForThisTask.getEffectiveIgnorePatterns(absolutePath, customIgnorePatterns);
+            const supportedExtensions = contextForThisTask.getEffectiveSupportedExtensions(customFileExtensions);
 
             // Initialize file synchronizer with proper ignore patterns (including project-specific patterns)
             const { FileSynchronizer } = await import("@zilliz/claude-context-core");
             console.log(`[BACKGROUND-INDEX] Using ignore patterns: ${ignorePatterns.join(', ')}`);
-            const synchronizer = new FileSynchronizer(absolutePath, ignorePatterns, this.context.getSupportedExtensions());
+            if (customFileExtensions.length > 0) {
+                console.log(`[BACKGROUND-INDEX] Using ${customFileExtensions.length} request-scoped custom extensions: ${customFileExtensions.join(', ')}`);
+            }
+            const synchronizer = new FileSynchronizer(absolutePath, ignorePatterns, supportedExtensions);
             await synchronizer.initialize();
 
             // Store synchronizer in the context (let context manage collection names)
@@ -558,7 +566,7 @@ export class ToolHandlers {
                 }
 
                 console.log(`[BACKGROUND-INDEX] Progress: ${progress.phase} - ${progress.percentage}% (${progress.current}/${progress.total})`);
-            }, false, customIgnorePatterns);
+            }, false, customIgnorePatterns, customFileExtensions);
             console.log(`[BACKGROUND-INDEX] ✅ Indexing completed successfully! Files: ${stats.indexedFiles}, Chunks: ${stats.totalChunks}`);
 
             // Set codebase to indexed status with complete statistics


### PR DESCRIPTION
## Summary

Fixes #356.

This makes MCP request-level `customExtensions` local to the current `index_codebase` request instead of mutating the shared long-lived `Context.supportedExtensions` state.

Previously, `handleIndexCodebase()` called `Context.addCustomExtensions(...)` for MCP request parameters. Since the MCP server reuses the same `Context` instance across indexing tasks, a custom extension requested for project A could remain enabled when indexing project B.

## Changes

- Add `Context.getEffectiveSupportedExtensions(...)` to compute per-operation supported extensions without mutating persistent Context state.
- Allow `Context.indexCodebase(...)` to receive request-scoped supported extensions as an optional final argument.
- Pass the same effective extension list into `FileSynchronizer` and `indexCodebase()` so initial indexing and change tracking use consistent file inclusion rules.
- Keep `Context.addCustomExtensions(...)` intact for explicit persistent core API usage.
- Add regression coverage for request-scoped custom extension isolation across sequential indexes on the same `Context`.

## Compatibility

Persistent extension configuration is unchanged:

- `CUSTOM_EXTENSIONS` still applies globally.
- `ContextConfig.customExtensions` still applies globally.
- Explicit `Context.addCustomExtensions(...)` calls still mutate the Context as before.

Only MCP request-level `customExtensions` are scoped to the current indexing task.

## Tests

- `pnpm --filter @zilliz/claude-context-core test`
- `pnpm --filter @zilliz/claude-context-core typecheck`
- `pnpm --filter @zilliz/claude-context-mcp typecheck`
- `pnpm --filter @zilliz/claude-context-core build`
- `pnpm --filter @zilliz/claude-context-mcp build`
- `git diff --check`
