### PR TITLE
fix(mcp): persist request-level index options for sync

### DIFF
--- a/packages/core/src/context.ignore-patterns.test.ts
+++ b/packages/core/src/context.ignore-patterns.test.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { Context } from './context';
 import { Embedding, EmbeddingVector } from './embedding';
+import { FileSynchronizer } from './sync/synchronizer';
 import { Splitter, CodeChunk } from './splitter';
 import { VectorDatabase } from './vectordb';
 
@@ -156,4 +157,28 @@ describe('Context ignore pattern isolation', () => {
         await context.indexCodebase(projectB);
         expect(vectorDatabase.insert).not.toHaveBeenCalled();
     });
+
+    it('uses request options when recreating a synchronizer for change indexing', async () => {
+        const project = path.join(tempRoot, 'project-with-options');
+        await fs.mkdir(project);
+        await fs.writeFile(path.join(project, 'custom.foo'), 'custom extension file');
+        await fs.writeFile(path.join(project, 'ignored.ts'), 'ignored by request pattern');
+
+        const context = new Context({ vectorDatabase: createVectorDatabase() });
+
+        try {
+            await context.reindexByChange(project, undefined, ['*.ts'], ['foo']);
+
+            const collectionName = context.getCollectionName(project);
+            const synchronizer = context.getSynchronizers().get(collectionName);
+
+            expect(synchronizer).toBeDefined();
+            expect(synchronizer?.getFileHash('custom.foo')).toBeDefined();
+            expect(synchronizer?.getFileHash('ignored.ts')).toBeUndefined();
+            expect(context.getSupportedExtensions()).not.toContain('.foo');
+        } finally {
+            await FileSynchronizer.deleteSnapshot(project);
+        }
+    });
+
 });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -393,17 +393,21 @@ export class Context {
 
     async reindexByChange(
         codebasePath: string,
-        progressCallback?: (progress: { phase: string; current: number; total: number; percentage: number }) => void
+        progressCallback?: (progress: { phase: string; current: number; total: number; percentage: number }) => void,
+        additionalIgnorePatterns: string[] = [],
+        additionalSupportedExtensions: string[] = []
     ): Promise<{ added: number, removed: number, modified: number }> {
         const collectionName = this.getCollectionName(codebasePath);
         const synchronizer = this.synchronizers.get(collectionName);
 
         if (!synchronizer) {
-            // Load project-specific ignore patterns before creating FileSynchronizer.
-            const ignorePatterns = await this.loadIgnorePatterns(codebasePath);
+            // Recreate the synchronizer with the same request-scoped options that
+            // were used for the original indexing task.
+            const ignorePatterns = await this.loadIgnorePatterns(codebasePath, additionalIgnorePatterns);
+            const supportedExtensions = this.getEffectiveSupportedExtensions(additionalSupportedExtensions);
 
             // To be safe, let's initialize if it's not there.
-            const newSynchronizer = new FileSynchronizer(codebasePath, ignorePatterns, this.supportedExtensions);
+            const newSynchronizer = new FileSynchronizer(codebasePath, ignorePatterns, supportedExtensions);
             await newSynchronizer.initialize();
             this.synchronizers.set(collectionName, newSynchronizer);
         }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -13,6 +13,7 @@
         "lint": "eslint src --ext .ts",
         "lint:fix": "eslint src --ext .ts --fix",
         "typecheck": "tsc --noEmit",
+        "test": "node --import tsx --test \"src/**/*.test.ts\"",
         "start": "tsx src/index.ts",
         "start:with-env": "OPENAI_API_KEY=${OPENAI_API_KEY:your-api-key-here} MILVUS_ADDRESS=${MILVUS_ADDRESS:localhost:19530} tsx src/index.ts",
         "prepublishOnly": "pnpm build"

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -33,8 +33,14 @@ export interface CodebaseSnapshotV1 {
 
 // New format (v2) - structured with codebase information
 
+// Request-level indexing options stored with a codebase's snapshot entry.
+export interface CodebaseIndexOptions {
+    requestCustomExtensions?: string[];
+    requestIgnorePatterns?: string[];
+}
+
 // Base interface for common fields
-interface CodebaseInfoBase {
+interface CodebaseInfoBase extends CodebaseIndexOptions {
     lastUpdated: string;
 }
 

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as crypto from "crypto";
 import { Context, COLLECTION_LIMIT_MESSAGE, FileSynchronizer } from "@zilliz/claude-context-core";
 import { SnapshotManager } from "./snapshot.js";
+import type { CodebaseIndexOptions } from "./config.js";
 import { ensureAbsolutePath, truncateContent, trackCodebasePath } from "./utils.js";
 
 export class ToolHandlers {
@@ -317,6 +318,10 @@ export class ToolHandlers {
         const splitterType = splitter || 'ast'; // Default to AST
         const customFileExtensions = customExtensions || [];
         const customIgnorePatterns = ignorePatterns || [];
+        const indexOptions: CodebaseIndexOptions = {
+            requestCustomExtensions: customFileExtensions,
+            requestIgnorePatterns: customIgnorePatterns
+        };
 
         try {
             // Sync indexed codebases from cloud first
@@ -462,14 +467,14 @@ export class ToolHandlers {
             }
 
             // Set to indexing status and save snapshot immediately
-            this.snapshotManager.setCodebaseIndexing(absolutePath, 0);
+            this.snapshotManager.setCodebaseIndexing(absolutePath, 0, indexOptions);
             this.snapshotManager.saveCodebaseSnapshot();
 
             // Track the codebase path for syncing
             trackCodebasePath(absolutePath);
 
             // Start background indexing - now safe to proceed
-            this.startBackgroundIndexing(absolutePath, forceReindex, splitterType, customIgnorePatterns, customFileExtensions);
+            this.startBackgroundIndexing(absolutePath, forceReindex, splitterType, customIgnorePatterns, customFileExtensions, indexOptions);
 
             const pathInfo = codebasePath !== absolutePath
                 ? `\nNote: Input path '${codebasePath}' was resolved to absolute path '${absolutePath}'`
@@ -510,7 +515,8 @@ export class ToolHandlers {
         forceReindex: boolean,
         splitterType: string,
         customIgnorePatterns: string[] = [],
-        customFileExtensions: string[] = []
+        customFileExtensions: string[] = [],
+        indexOptions?: CodebaseIndexOptions
     ) {
         const absolutePath = codebasePath;
         let lastSaveTime = 0; // Track last save timestamp
@@ -576,7 +582,7 @@ export class ToolHandlers {
             console.log(`[BACKGROUND-INDEX] ✅ Indexing completed successfully! Files: ${stats.indexedFiles}, Chunks: ${stats.totalChunks}`);
 
             // Set codebase to indexed status with complete statistics
-            this.snapshotManager.setCodebaseIndexed(absolutePath, stats);
+            this.snapshotManager.setCodebaseIndexed(absolutePath, stats, indexOptions);
             this.indexingStats = { indexedFiles: stats.indexedFiles, totalChunks: stats.totalChunks };
 
             // Save snapshot after updating codebase lists
@@ -597,7 +603,7 @@ export class ToolHandlers {
 
             // Set codebase to failed status with error information
             const errorMessage = error.message || String(error);
-            this.snapshotManager.setCodebaseIndexFailed(absolutePath, errorMessage, lastProgress);
+            this.snapshotManager.setCodebaseIndexFailed(absolutePath, errorMessage, lastProgress, indexOptions);
             this.snapshotManager.saveCodebaseSnapshot();
 
             // Log error but don't crash MCP service - indexing errors are handled gracefully

--- a/packages/mcp/src/snapshot.request-options.test.ts
+++ b/packages/mcp/src/snapshot.request-options.test.ts
@@ -1,0 +1,118 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SnapshotManager } from "./snapshot.js";
+
+async function withTempHome(run: (tempRoot: string) => Promise<void>): Promise<void> {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "claude-context-mcp-snapshot-"));
+    const homeDir = path.join(tempRoot, "home");
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+
+    try {
+        await fs.mkdir(path.join(homeDir, ".context"), { recursive: true });
+        await run(tempRoot);
+    } finally {
+        if (originalHome === undefined) {
+            delete process.env.HOME;
+        } else {
+            process.env.HOME = originalHome;
+        }
+        if (originalUserProfile === undefined) {
+            delete process.env.USERPROFILE;
+        } else {
+            process.env.USERPROFILE = originalUserProfile;
+        }
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+}
+
+test("preserves request-level index options across snapshot state transitions", async () => {
+    await withTempHome(async (tempRoot) => {
+        const codebasePath = path.join(tempRoot, "repo");
+        await fs.mkdir(codebasePath);
+
+        const snapshotManager = new SnapshotManager();
+        const indexOptions = {
+            requestCustomExtensions: ["foo", ".vue"],
+            requestIgnorePatterns: ["drafts/**", "*.tmp"]
+        };
+
+        snapshotManager.setCodebaseIndexing(codebasePath, 0, indexOptions);
+        snapshotManager.setCodebaseIndexing(codebasePath, 42);
+
+        const indexingInfo = snapshotManager.getCodebaseInfo(codebasePath);
+        assert.equal(indexingInfo?.status, "indexing");
+        assert.deepEqual(indexingInfo?.requestCustomExtensions, ["foo", ".vue"]);
+        assert.deepEqual(indexingInfo?.requestIgnorePatterns, ["drafts/**", "*.tmp"]);
+
+        snapshotManager.setCodebaseIndexed(codebasePath, {
+            indexedFiles: 1,
+            totalChunks: 2,
+            status: "completed"
+        });
+
+        const indexedInfo = snapshotManager.getCodebaseInfo(codebasePath);
+        assert.equal(indexedInfo?.status, "indexed");
+        assert.deepEqual(indexedInfo?.requestCustomExtensions, ["foo", ".vue"]);
+        assert.deepEqual(indexedInfo?.requestIgnorePatterns, ["drafts/**", "*.tmp"]);
+
+        snapshotManager.setCodebaseIndexFailed(codebasePath, "boom", 55);
+
+        const failedInfo = snapshotManager.getCodebaseInfo(codebasePath);
+        assert.equal(failedInfo?.status, "indexfailed");
+        assert.deepEqual(failedInfo?.requestCustomExtensions, ["foo", ".vue"]);
+        assert.deepEqual(failedInfo?.requestIgnorePatterns, ["drafts/**", "*.tmp"]);
+    });
+});
+
+test("explicit empty request options clear previous request-level index options", async () => {
+    await withTempHome(async (tempRoot) => {
+        const codebasePath = path.join(tempRoot, "repo");
+        await fs.mkdir(codebasePath);
+
+        const snapshotManager = new SnapshotManager();
+
+        snapshotManager.setCodebaseIndexing(codebasePath, 0, {
+            requestCustomExtensions: ["foo"],
+            requestIgnorePatterns: ["drafts/**"]
+        });
+        snapshotManager.setCodebaseIndexing(codebasePath, 0, {});
+
+        const info = snapshotManager.getCodebaseInfo(codebasePath);
+        assert.equal(info?.status, "indexing");
+        assert.equal(info?.requestCustomExtensions, undefined);
+        assert.equal(info?.requestIgnorePatterns, undefined);
+    });
+});
+
+test("preserves request-level index options when interrupted indexing is loaded as failed", async () => {
+    await withTempHome(async (tempRoot) => {
+        const codebasePath = path.join(tempRoot, "repo");
+        await fs.mkdir(codebasePath);
+
+        const firstSnapshotManager = new SnapshotManager();
+        firstSnapshotManager.setCodebaseIndexing(codebasePath, 25, {
+            requestCustomExtensions: ["astro"],
+            requestIgnorePatterns: ["drafts/**"]
+        });
+        firstSnapshotManager.saveCodebaseSnapshot();
+
+        const secondSnapshotManager = new SnapshotManager();
+        secondSnapshotManager.loadCodebaseSnapshot();
+
+        const info = secondSnapshotManager.getCodebaseInfo(codebasePath);
+        assert.equal(info?.status, "indexfailed");
+        if (!info || info.status !== "indexfailed") {
+            throw new Error("Expected interrupted indexing to load as indexfailed");
+        }
+        assert.equal(info.lastAttemptedPercentage, 25);
+        assert.deepEqual(info?.requestCustomExtensions, ["astro"]);
+        assert.deepEqual(info?.requestIgnorePatterns, ["drafts/**"]);
+    });
+});

--- a/packages/mcp/src/snapshot.ts
+++ b/packages/mcp/src/snapshot.ts
@@ -6,6 +6,7 @@ import {
     CodebaseSnapshotV1,
     CodebaseSnapshotV2,
     CodebaseInfo,
+    CodebaseIndexOptions,
     CodebaseInfoIndexing,
     CodebaseInfoIndexed,
     CodebaseInfoIndexFailed
@@ -124,6 +125,7 @@ export class SnapshotManager {
                     status: 'indexfailed',
                     errorMessage: 'Indexing was interrupted (MCP server restarted)',
                     lastAttemptedPercentage: info.indexingPercentage,
+                    ...this.getIndexOptions(info),
                     lastUpdated: new Date().toISOString()
                 };
                 validCodebaseInfoMap.set(codebasePath, failedInfo);
@@ -220,6 +222,21 @@ export class SnapshotManager {
         }
 
         return bestMatch;
+    }
+
+    private getIndexOptions(options?: CodebaseIndexOptions): CodebaseIndexOptions {
+        const indexOptions: CodebaseIndexOptions = {};
+        if (options?.requestCustomExtensions?.length) {
+            indexOptions.requestCustomExtensions = options.requestCustomExtensions;
+        }
+        if (options?.requestIgnorePatterns?.length) {
+            indexOptions.requestIgnorePatterns = options.requestIgnorePatterns;
+        }
+        return indexOptions;
+    }
+
+    private resolveIndexOptions(codebasePath: string, options?: CodebaseIndexOptions): CodebaseIndexOptions {
+        return this.getIndexOptions(options ?? this.codebaseInfoMap.get(codebasePath));
     }
 
     public findIndexedCodebasePath(codebasePath: string): string | undefined {
@@ -374,17 +391,20 @@ export class SnapshotManager {
     /**
      * Set codebase to indexing status
      */
-    public setCodebaseIndexing(codebasePath: string, progress: number = 0): void {
+    public setCodebaseIndexing(codebasePath: string, progress: number = 0, indexOptions?: CodebaseIndexOptions): void {
         this.indexingCodebases.set(codebasePath, progress);
 
         // Remove from other states
         this.indexedCodebases = this.indexedCodebases.filter(path => path !== codebasePath);
         this.codebaseFileCount.delete(codebasePath);
 
+        const resolvedIndexOptions = this.resolveIndexOptions(codebasePath, indexOptions);
+
         // Update info map
         const info: CodebaseInfoIndexing = {
             status: 'indexing',
             indexingPercentage: progress,
+            ...resolvedIndexOptions,
             lastUpdated: new Date().toISOString()
         };
         this.codebaseInfoMap.set(codebasePath, info);
@@ -395,7 +415,8 @@ export class SnapshotManager {
      */
     public setCodebaseIndexed(
         codebasePath: string,
-        stats: { indexedFiles: number; totalChunks: number; status: 'completed' | 'limit_reached' }
+        stats: { indexedFiles: number; totalChunks: number; status: 'completed' | 'limit_reached' },
+        indexOptions?: CodebaseIndexOptions
     ): void {
         // Defensive guard: 0/0 + completed is a known-bad state that causes an
         // infinite force-reindex loop — the client reads it as "not indexed",
@@ -418,11 +439,14 @@ export class SnapshotManager {
         // Update file count and info
         this.codebaseFileCount.set(codebasePath, stats.indexedFiles);
 
+        const resolvedIndexOptions = this.resolveIndexOptions(codebasePath, indexOptions);
+
         const info: CodebaseInfoIndexed = {
             status: 'indexed',
             indexedFiles: stats.indexedFiles,
             totalChunks: stats.totalChunks,
             indexStatus: stats.status,
+            ...resolvedIndexOptions,
             lastUpdated: new Date().toISOString()
         };
         this.codebaseInfoMap.set(codebasePath, info);
@@ -434,18 +458,22 @@ export class SnapshotManager {
     public setCodebaseIndexFailed(
         codebasePath: string,
         errorMessage: string,
-        lastAttemptedPercentage?: number
+        lastAttemptedPercentage?: number,
+        indexOptions?: CodebaseIndexOptions
     ): void {
         // Remove from other states
         this.indexedCodebases = this.indexedCodebases.filter(path => path !== codebasePath);
         this.indexingCodebases.delete(codebasePath);
         this.codebaseFileCount.delete(codebasePath);
 
+        const resolvedIndexOptions = this.resolveIndexOptions(codebasePath, indexOptions);
+
         // Update info map
         const info: CodebaseInfoIndexFailed = {
             status: 'indexfailed',
             errorMessage: errorMessage,
             lastAttemptedPercentage: lastAttemptedPercentage,
+            ...resolvedIndexOptions,
             lastUpdated: new Date().toISOString()
         };
         this.codebaseInfoMap.set(codebasePath, info);

--- a/packages/mcp/src/sync.ts
+++ b/packages/mcp/src/sync.ts
@@ -157,7 +157,15 @@ export class SyncManager {
 
                 try {
                     console.log(`[SYNC-DEBUG] Calling context.reindexByChange() for '${codebasePath}'`);
-                    const stats = await this.context.reindexByChange(codebasePath);
+                    const codebaseInfo = this.snapshotManager.getCodebaseInfo(codebasePath);
+                    const requestIgnorePatterns = codebaseInfo?.requestIgnorePatterns || [];
+                    const requestCustomExtensions = codebaseInfo?.requestCustomExtensions || [];
+                    const stats = await this.context.reindexByChange(
+                        codebasePath,
+                        undefined,
+                        requestIgnorePatterns,
+                        requestCustomExtensions
+                    );
                     const codebaseElapsed = Date.now() - codebaseStartTime;
 
                     console.log(`[SYNC-DEBUG] Reindex stats for '${codebasePath}':`, stats);


### PR DESCRIPTION
## Summary

Fixes #359.

MCP `index_codebase` request-level options such as `customExtensions` and `ignorePatterns` affect the file set used for indexing, but they were not persisted in the MCP codebase snapshot. After an MCP restart, background sync could rebuild a `FileSynchronizer` without those original options, causing custom-extension files to stop being tracked or request-ignored files to be considered again.

This PR:

- stores request-level `customExtensions` and `ignorePatterns` on the codebase snapshot entry
- preserves those options across indexing progress, indexed, failed, and interrupted-indexing state transitions
- restores those options when MCP background sync calls `reindexByChange()` after restart
- keeps the options request/codebase-scoped and does not mutate global Context extension or ignore-pattern state

## Tests

- `pnpm --filter @zilliz/claude-context-core test`
- `pnpm --filter @zilliz/claude-context-mcp test`
- `pnpm --filter @zilliz/claude-context-core build`
- `pnpm typecheck`
- `pnpm --filter @zilliz/claude-context-mcp build`
- `git diff --check`
