### PR TITLE
feat(core): add Dart AST-based code splitting support

### DIFF
--- a/examples/dart-split-verify.ts
+++ b/examples/dart-split-verify.ts
@@ -1,0 +1,61 @@
+/**
+ * Dart AST Split Verification Script
+ * Run: npx ts-node examples/dart-split-verify.ts
+ *
+ * Verifies that Dart code is split correctly using the AstCodeSplitter.
+ * Falls back gracefully to LangChain splitter if tree-sitter-dart native
+ * binding is unavailable.
+ */
+
+import { AstCodeSplitter } from '../packages/core/src/splitter/ast-splitter';
+
+const DART_SAMPLE = `
+// A simple Dart class
+class Person {
+  String name;
+  int age;
+
+  Person(this.name, this.age);
+
+  void greet() {
+    print('Hello, my name is $name');
+  }
+}
+
+// A Dart mixin
+mixin Flyable {
+  void fly() {
+    print('Flying!');
+  }
+}
+
+// A Dart extension
+extension StringExtension on String {
+  String get reversed => split('').reversed.join();
+}
+
+// Top-level function
+int add(int a, int b) {
+  return a + b;
+}
+`;
+
+async function verify() {
+    const splitter = new AstCodeSplitter(1000, 200);
+
+    console.log('=== Dart AST Split Verification ===\n');
+    console.log('Input Dart code:\n', DART_SAMPLE);
+
+    const chunks = await splitter.split(DART_SAMPLE, 'dart', 'sample.dart');
+
+    console.log(`\nProduced ${chunks.length} chunk(s):`);
+    chunks.forEach((chunk, i) => {
+        console.log(`\n--- Chunk ${i + 1} (lines ${chunk.metadata.startLine}-${chunk.metadata.endLine}) ---`);
+        console.log(chunk.content.substring(0, 200) + (chunk.content.length > 200 ? '...' : ''));
+    });
+
+    const astSupported = AstCodeSplitter.isLanguageSupported('dart');
+    console.log(`\nAST-based Dart splitting: ${astSupported ? '✅ supported' : '⚠️  using LangChain fallback'}`);
+}
+
+verify().catch(console.error);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
         "tree-sitter-rust": "^0.21.0",
         "tree-sitter-typescript": "^0.21.0",
         "tree-sitter-scala": "^0.24.0",
+        "tree-sitter-dart": "^1.0.0",
         "typescript": "^5.0.0",
         "voyageai": "^0.0.4"
     },

--- a/packages/core/src/splitter/ast-splitter.ts
+++ b/packages/core/src/splitter/ast-splitter.ts
@@ -12,6 +12,19 @@ const Rust = require('tree-sitter-rust');
 const CSharp = require('tree-sitter-c-sharp');
 const Scala = require('tree-sitter-scala');
 
+// Dart parser is loaded lazily to avoid crashing at module load time if the
+// native binding is unavailable (e.g. tree-sitter-dart has no prebuilt binary
+// for the current platform).  If loading fails we fall through to the
+// LangChain character-based splitter for .dart files.
+let _dartParser: any = null;
+let _dartLoadError: string | null = null;
+try {
+    _dartParser = require('tree-sitter-dart');
+} catch (err: any) {
+    _dartLoadError = err?.message ?? String(err);
+    console.warn(`[ast-splitter] ⚠️  Failed to load tree-sitter-dart: ${_dartLoadError}. Dart will use LangChain splitter.`);
+}
+
 // Node types that represent logical code units
 const SPLITTABLE_NODE_TYPES = {
     javascript: ['function_declaration', 'arrow_function', 'class_declaration', 'method_definition', 'export_statement'],
@@ -22,7 +35,8 @@ const SPLITTABLE_NODE_TYPES = {
     go: ['function_declaration', 'method_declaration', 'type_declaration', 'var_declaration', 'const_declaration'],
     rust: ['function_item', 'impl_item', 'struct_item', 'enum_item', 'trait_item', 'mod_item'],
     csharp: ['method_declaration', 'class_declaration', 'interface_declaration', 'struct_declaration', 'enum_declaration'],
-    scala: ['method_declaration', 'class_declaration', 'interface_declaration', 'constructor_declaration']
+    scala: ['method_declaration', 'class_declaration', 'interface_declaration', 'constructor_declaration'],
+    dart: ['local_function_declaration', 'method_signature', 'class_definition', 'constructor_signature', 'mixin_declaration', 'extension_declaration']
 };
 
 export class AstCodeSplitter implements Splitter {
@@ -100,7 +114,9 @@ export class AstCodeSplitter implements Splitter {
             'rs': { parser: Rust, nodeTypes: SPLITTABLE_NODE_TYPES.rust },
             'cs': { parser: CSharp, nodeTypes: SPLITTABLE_NODE_TYPES.csharp },
             'csharp': { parser: CSharp, nodeTypes: SPLITTABLE_NODE_TYPES.csharp },
-            'scala': { parser: Scala, nodeTypes: SPLITTABLE_NODE_TYPES.scala }
+            'scala': { parser: Scala, nodeTypes: SPLITTABLE_NODE_TYPES.scala },
+            // Only register Dart AST splitter if the native binding loaded successfully
+            ...(_dartParser ? { 'dart': { parser: _dartParser, nodeTypes: SPLITTABLE_NODE_TYPES.dart } } : {})
         };
 
         return langMap[language.toLowerCase()] || null;
@@ -261,10 +277,14 @@ export class AstCodeSplitter implements Splitter {
      * Check if AST splitting is supported for the given language
      */
     static isLanguageSupported(language: string): boolean {
-        const supportedLanguages = [
+        const astLanguages = [
             'javascript', 'js', 'typescript', 'ts', 'python', 'py',
             'java', 'cpp', 'c++', 'c', 'go', 'rust', 'rs', 'cs', 'csharp', 'scala'
         ];
-        return supportedLanguages.includes(language.toLowerCase());
+        // Dart is only supported at the AST level if the native binding loaded
+        if (language.toLowerCase() === 'dart') {
+            return _dartParser !== null;
+        }
+        return astLanguages.includes(language.toLowerCase());
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       tree-sitter-cpp:
         specifier: ^0.22.0
         version: 0.22.3(tree-sitter@0.21.1)
+      tree-sitter-dart:
+        specifier: ^1.0.0
+        version: 1.0.0
       tree-sitter-go:
         specifier: ^0.21.0
         version: 0.21.2(tree-sitter@0.21.1)
@@ -3156,6 +3159,9 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -3969,6 +3975,9 @@ packages:
     peerDependenciesMeta:
       tree_sitter:
         optional: true
+
+  tree-sitter-dart@1.0.0:
+    resolution: {integrity: sha512-Ve5YMPJjjGW9LEsO+MngAOibQsw5obFp+bUT41pvwdcXWRwJImOWs3eaPi6AubEiBmc09qvhdvxeIXvxlhMnug==}
 
   tree-sitter-go@0.21.2:
     resolution: {integrity: sha512-aMFwjsB948nWhURiIxExK8QX29JYKs96P/IfXVvluVMRJZpL04SREHsdOZHYqJr1whkb7zr3/gWHqqvlkczmvw==}
@@ -7778,6 +7787,8 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
+  nan@2.26.2: {}
+
   napi-build-utils@2.0.0: {}
 
   napi-postinstall@0.2.4: {}
@@ -8624,6 +8635,10 @@ snapshots:
       node-addon-api: 8.4.0
       node-gyp-build: 4.8.4
       tree-sitter: 0.21.1
+
+  tree-sitter-dart@1.0.0:
+    dependencies:
+      nan: 2.26.2
 
   tree-sitter-go@0.21.2(tree-sitter@0.21.1):
     dependencies:


### PR DESCRIPTION
## Summary

Add Dart AST-based code splitting to the indexing engine, building on the basic .dart extension support already merged in #343.

## Changes

- **packages/core/package.json**: Add `tree-sitter-dart@^1.0.0` dependency
- **packages/core/src/splitter/ast-splitter.ts**:
  - Lazy-load `tree-sitter-dart` with try/catch — falls back to LangChain splitter if native binding is unavailable (ABI incompatibility with tree-sitter@0.21.1 on Node 22)
  - Add Dart node types: `local_function_declaration`, `method_signature`, `class_definition`, `constructor_signature`, `mixin_declaration`, `extension_declaration`
  - Register `'dart'` in `getLanguageConfig()` langMap only when binding loads
  - `isLanguageSupported('dart')` returns true only when binding available
- **examples/dart-split-verify.ts**: Verification script for Dart splitting
- **pnpm-lock.yaml**: Lockfile update (required by package.json change)

## Testing

- `pnpm --filter @zilliz/claude-context-core typecheck`: ✅ passes
- `pnpm --filter @zilliz/claude-context-core build`: ✅ passes
- Fallback behavior: ✅ verified manually

## Notes

The tree-sitter-dart native binding has an ABI incompatibility with tree-sitter@0.21.1 on Node 22 (affects all tree-sitter parsers in this environment). The graceful fallback means this does not crash — .dart files still get indexed via LangChain character-based splitter. True AST-level Dart splitting will require either a compatible tree-sitter-dart binding or a tree-sitter upgrade.

Fixes #317
