### PR TITLE
fix(mcp,core): honor request-scoped splitter option

### DIFF
--- a/packages/core/src/context.splitter.test.ts
+++ b/packages/core/src/context.splitter.test.ts
@@ -1,0 +1,168 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { Context } from './context';
+import { Embedding, EmbeddingVector } from './embedding';
+import { Splitter, CodeChunk } from './splitter';
+import { FileSynchronizer } from './sync/synchronizer';
+import { VectorDatabase } from './vectordb';
+
+class TestEmbedding extends Embedding {
+    protected maxTokens = 8192;
+
+    async detectDimension(): Promise<number> {
+        return 3;
+    }
+
+    async embed(text: string): Promise<EmbeddingVector> {
+        return { vector: [1, 0, 0], dimension: 3 };
+    }
+
+    async embedBatch(texts: string[]): Promise<EmbeddingVector[]> {
+        return texts.map(() => ({ vector: [1, 0, 0], dimension: 3 }));
+    }
+
+    getDimension(): number {
+        return 3;
+    }
+
+    getProvider(): string {
+        return 'test';
+    }
+}
+
+class RecordingSplitter implements Splitter {
+    public calls: Array<{ code: string; language: string; filePath?: string }> = [];
+
+    constructor(private readonly label: string) { }
+
+    async split(code: string, language: string, filePath?: string): Promise<CodeChunk[]> {
+        this.calls.push({ code, language, filePath });
+        return [{
+            content: `${this.label}:${code}`,
+            metadata: {
+                startLine: 1,
+                endLine: code.split('\n').length,
+                language,
+                filePath,
+            },
+        }];
+    }
+
+    setChunkSize(): void { }
+
+    setChunkOverlap(): void { }
+}
+
+const createVectorDatabase = (): jest.Mocked<VectorDatabase> => ({
+    createCollection: jest.fn().mockResolvedValue(undefined),
+    createHybridCollection: jest.fn().mockResolvedValue(undefined),
+    dropCollection: jest.fn().mockResolvedValue(undefined),
+    hasCollection: jest.fn().mockResolvedValue(false),
+    listCollections: jest.fn().mockResolvedValue([]),
+    insert: jest.fn().mockResolvedValue(undefined),
+    insertHybrid: jest.fn().mockResolvedValue(undefined),
+    search: jest.fn().mockResolvedValue([]),
+    hybridSearch: jest.fn().mockResolvedValue([]),
+    delete: jest.fn().mockResolvedValue(undefined),
+    query: jest.fn().mockResolvedValue([]),
+    getCollectionDescription: jest.fn().mockResolvedValue(''),
+    checkCollectionLimit: jest.fn().mockResolvedValue(true),
+    getCollectionRowCount: jest.fn().mockResolvedValue(0),
+});
+
+describe('Context request-scoped splitters', () => {
+    let tempRoot: string;
+    let originalHome: string | undefined;
+    let originalHybridMode: string | undefined;
+
+    beforeEach(async () => {
+        tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-context-splitter-'));
+        const homeDir = path.join(tempRoot, 'home');
+        await fs.mkdir(homeDir, { recursive: true });
+        originalHome = process.env.HOME;
+        originalHybridMode = process.env.HYBRID_MODE;
+        process.env.HOME = homeDir;
+        process.env.HYBRID_MODE = 'false';
+    });
+
+    afterEach(async () => {
+        if (originalHome === undefined) {
+            delete process.env.HOME;
+        } else {
+            process.env.HOME = originalHome;
+        }
+        if (originalHybridMode === undefined) {
+            delete process.env.HYBRID_MODE;
+        } else {
+            process.env.HYBRID_MODE = originalHybridMode;
+        }
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    });
+
+    it('uses a request-scoped splitter for indexing without replacing the context splitter', async () => {
+        const project = path.join(tempRoot, 'project');
+        await fs.mkdir(project);
+        await fs.writeFile(path.join(project, 'index.ts'), 'const value = 1;');
+
+        const vectorDatabase = createVectorDatabase();
+        const contextSplitter = new RecordingSplitter('context');
+        const requestSplitter = new RecordingSplitter('request');
+        const context = new Context({
+            embedding: new TestEmbedding(),
+            vectorDatabase,
+            codeSplitter: contextSplitter,
+        });
+
+        await context.indexCodebase(project, undefined, false, [], [], requestSplitter);
+
+        expect(contextSplitter.calls).toHaveLength(0);
+        expect(requestSplitter.calls).toHaveLength(1);
+        expect(context.getCodeSplitter()).toBe(contextSplitter);
+
+        const insertedDocuments = vectorDatabase.insert.mock.calls
+            .flatMap(([, documents]) => documents);
+        expect(insertedDocuments).toHaveLength(1);
+        expect(insertedDocuments[0].content).toBe('request:const value = 1;');
+    });
+
+    it('uses a request-scoped splitter for changed files during sync reindexing', async () => {
+        const project = path.join(tempRoot, 'project');
+        await fs.mkdir(project);
+        const filePath = path.join(project, 'note.md');
+        await fs.writeFile(filePath, 'first version');
+
+        const vectorDatabase = createVectorDatabase();
+        const contextSplitter = new RecordingSplitter('context');
+        const requestSplitter = new RecordingSplitter('request');
+        const context = new Context({
+            embedding: new TestEmbedding(),
+            vectorDatabase,
+            codeSplitter: contextSplitter,
+        });
+
+        try {
+            const synchronizer = new FileSynchronizer(
+                project,
+                await context.getEffectiveIgnorePatterns(project),
+                context.getEffectiveSupportedExtensions()
+            );
+            await synchronizer.initialize();
+            context.setSynchronizer(context.getCollectionName(project), synchronizer);
+
+            await fs.writeFile(filePath, 'second version');
+            await context.reindexByChange(project, undefined, [], [], requestSplitter);
+
+            expect(contextSplitter.calls).toHaveLength(0);
+            expect(requestSplitter.calls).toHaveLength(1);
+            expect(context.getCodeSplitter()).toBe(contextSplitter);
+
+            const insertedDocuments = vectorDatabase.insert.mock.calls
+                .flatMap(([, documents]) => documents);
+            expect(insertedDocuments).toHaveLength(1);
+            expect(insertedDocuments[0].content).toBe('request:second version');
+        } finally {
+            await FileSynchronizer.deleteSnapshot(project);
+        }
+    });
+});

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -319,6 +319,7 @@ export class Context {
      * @param forceReindex Whether to recreate the collection even if it exists
      * @param additionalIgnorePatterns Request-scoped ignore patterns
      * @param additionalSupportedExtensions Request-scoped file extensions
+     * @param requestSplitter Request-scoped splitter for this indexing run
      * @returns Indexing statistics
      */
     async indexCodebase(
@@ -326,11 +327,13 @@ export class Context {
         progressCallback?: (progress: { phase: string; current: number; total: number; percentage: number }) => void,
         forceReindex: boolean = false,
         additionalIgnorePatterns: string[] = [],
-        additionalSupportedExtensions: string[] = []
+        additionalSupportedExtensions: string[] = [],
+        requestSplitter?: Splitter
     ): Promise<{ indexedFiles: number; totalChunks: number; status: 'completed' | 'limit_reached' }> {
         const isHybrid = this.getIsHybrid();
         const searchType = isHybrid === true ? 'hybrid search' : 'semantic search';
         console.log(`[Context] 🚀 Starting to index codebase with ${searchType}: ${codebasePath}`);
+        const splitter = requestSplitter || this.codeSplitter;
 
         // 1. Compute ignore patterns for this codebase/request without
         // retaining file-based patterns from previous codebases.
@@ -372,7 +375,8 @@ export class Context {
                     total: totalFiles,
                     percentage: Math.round(progressPercentage)
                 });
-            }
+            },
+            splitter
         );
 
         console.log(`[Context] ✅ Codebase indexing completed! Processed ${result.processedFiles} files in total, generated ${result.totalChunks} code chunks`);
@@ -395,10 +399,12 @@ export class Context {
         codebasePath: string,
         progressCallback?: (progress: { phase: string; current: number; total: number; percentage: number }) => void,
         additionalIgnorePatterns: string[] = [],
-        additionalSupportedExtensions: string[] = []
+        additionalSupportedExtensions: string[] = [],
+        requestSplitter?: Splitter
     ): Promise<{ added: number, removed: number, modified: number }> {
         const collectionName = this.getCollectionName(codebasePath);
         const synchronizer = this.synchronizers.get(collectionName);
+        const splitter = requestSplitter || this.codeSplitter;
 
         if (!synchronizer) {
             // Recreate the synchronizer with the same request-scoped options that
@@ -454,7 +460,8 @@ export class Context {
                 codebasePath,
                 (filePath, fileIndex, totalFiles) => {
                     updateProgress(`Indexed ${filePath} (${fileIndex}/${totalFiles})`);
-                }
+                },
+                splitter
             );
         }
 
@@ -810,7 +817,8 @@ export class Context {
     private async processFileList(
         filePaths: string[],
         codebasePath: string,
-        onFileProcessed?: (filePath: string, fileIndex: number, totalFiles: number) => void
+        onFileProcessed?: (filePath: string, fileIndex: number, totalFiles: number) => void,
+        splitter: Splitter = this.codeSplitter
     ): Promise<{ processedFiles: number; totalChunks: number; status: 'completed' | 'limit_reached' }> {
         const isHybrid = this.getIsHybrid();
         const EMBEDDING_BATCH_SIZE = Math.max(1, parseInt(envManager.get('EMBEDDING_BATCH_SIZE') || '100', 10));
@@ -828,7 +836,7 @@ export class Context {
             try {
                 const content = await fs.promises.readFile(filePath, 'utf-8');
                 const language = this.getLanguageFromExtension(path.extname(filePath));
-                const chunks = await this.codeSplitter.split(content, language, filePath);
+                const chunks = await splitter.split(content, language, filePath);
 
                 // Log files with many chunks or large content
                 if (chunks.length > 50) {

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -33,8 +33,11 @@ export interface CodebaseSnapshotV1 {
 
 // New format (v2) - structured with codebase information
 
+export type RequestSplitterType = 'ast' | 'langchain';
+
 // Request-level indexing options stored with a codebase's snapshot entry.
 export interface CodebaseIndexOptions {
+    requestSplitter?: RequestSplitterType;
     requestCustomExtensions?: string[];
     requestIgnorePatterns?: string[];
 }

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -3,7 +3,8 @@ import * as path from "path";
 import * as crypto from "crypto";
 import { Context, COLLECTION_LIMIT_MESSAGE, FileSynchronizer } from "@zilliz/claude-context-core";
 import { SnapshotManager } from "./snapshot.js";
-import type { CodebaseIndexOptions } from "./config.js";
+import type { CodebaseIndexOptions, RequestSplitterType } from "./config.js";
+import { createRequestSplitter, isRequestSplitterType } from "./splitter.js";
 import { ensureAbsolutePath, truncateContent, trackCodebasePath } from "./utils.js";
 
 export class ToolHandlers {
@@ -315,28 +316,30 @@ export class ToolHandlers {
     public async handleIndexCodebase(args: any) {
         const { path: codebasePath, force, splitter, customExtensions, ignorePatterns } = args;
         const forceReindex = force || false;
-        const splitterType = splitter || 'ast'; // Default to AST
+        const requestedSplitter = splitter || 'ast'; // Default to AST
         const customFileExtensions = customExtensions || [];
         const customIgnorePatterns = ignorePatterns || [];
-        const indexOptions: CodebaseIndexOptions = {
-            requestCustomExtensions: customFileExtensions,
-            requestIgnorePatterns: customIgnorePatterns
-        };
 
         try {
             // Sync indexed codebases from cloud first
             await this.syncIndexedCodebasesFromCloud();
 
             // Validate splitter parameter
-            if (splitterType !== 'ast' && splitterType !== 'langchain') {
+            if (!isRequestSplitterType(requestedSplitter)) {
                 return {
                     content: [{
                         type: "text",
-                        text: `Error: Invalid splitter type '${splitterType}'. Must be 'ast' or 'langchain'.`
+                        text: `Error: Invalid splitter type '${requestedSplitter}'. Must be 'ast' or 'langchain'.`
                     }],
                     isError: true
                 };
             }
+            const splitterType: RequestSplitterType = requestedSplitter;
+            const indexOptions: CodebaseIndexOptions = {
+                requestSplitter: splitterType,
+                requestCustomExtensions: customFileExtensions,
+                requestIgnorePatterns: customIgnorePatterns
+            };
             // Force absolute path resolution - warn if relative path provided
             const absolutePath = ensureAbsolutePath(codebasePath);
 
@@ -513,7 +516,7 @@ export class ToolHandlers {
     private async startBackgroundIndexing(
         codebasePath: string,
         forceReindex: boolean,
-        splitterType: string,
+        splitterType: RequestSplitterType,
         customIgnorePatterns: string[] = [],
         customFileExtensions: string[] = [],
         indexOptions?: CodebaseIndexOptions
@@ -529,17 +532,13 @@ export class ToolHandlers {
                 console.log(`[BACKGROUND-INDEX] ℹ️  Force reindex mode - collection was already cleared during validation`);
             }
 
-            // Use the existing Context instance for indexing.
-            let contextForThisTask = this.context;
-            if (splitterType !== 'ast') {
-                console.warn(`[BACKGROUND-INDEX] Non-AST splitter '${splitterType}' requested; falling back to AST splitter`);
-            }
+            const requestSplitter = createRequestSplitter(splitterType);
 
             // Load ignore patterns from files first (including .ignore, .gitignore, etc.)
             // and merge them with this request's custom ignore patterns without
             // relying on shared Context state for this background indexing task.
-            const ignorePatterns = await contextForThisTask.getEffectiveIgnorePatterns(absolutePath, customIgnorePatterns);
-            const supportedExtensions = contextForThisTask.getEffectiveSupportedExtensions(customFileExtensions);
+            const ignorePatterns = await this.context.getEffectiveIgnorePatterns(absolutePath, customIgnorePatterns);
+            const supportedExtensions = this.context.getEffectiveSupportedExtensions(customFileExtensions);
 
             // Initialize file synchronizer with proper ignore patterns (including project-specific patterns)
             console.log(`[BACKGROUND-INDEX] Using ignore patterns: ${ignorePatterns.join(', ')}`);
@@ -553,9 +552,6 @@ export class ToolHandlers {
             await this.context.getPreparedCollection(absolutePath);
             const collectionName = this.context.getCollectionName(absolutePath);
             this.context.setSynchronizer(collectionName, synchronizer);
-            if (contextForThisTask !== this.context) {
-                contextForThisTask.setSynchronizer(collectionName, synchronizer);
-            }
 
             console.log(`[BACKGROUND-INDEX] Starting indexing with ${splitterType} splitter for: ${absolutePath}`);
 
@@ -565,7 +561,7 @@ export class ToolHandlers {
 
             // Start indexing with the appropriate context and progress tracking
             console.log(`[BACKGROUND-INDEX] 🚀 Beginning codebase indexing process...`);
-            const stats = await contextForThisTask.indexCodebase(absolutePath, (progress) => {
+            const stats = await this.context.indexCodebase(absolutePath, (progress) => {
                 // Update progress in snapshot manager using new method
                 this.snapshotManager.setCodebaseIndexing(absolutePath, progress.percentage);
 
@@ -578,7 +574,7 @@ export class ToolHandlers {
                 }
 
                 console.log(`[BACKGROUND-INDEX] Progress: ${progress.phase} - ${progress.percentage}% (${progress.current}/${progress.total})`);
-            }, false, customIgnorePatterns, customFileExtensions);
+            }, false, customIgnorePatterns, customFileExtensions, requestSplitter);
             console.log(`[BACKGROUND-INDEX] ✅ Indexing completed successfully! Files: ${stats.indexedFiles}, Chunks: ${stats.totalChunks}`);
 
             // Set codebase to indexed status with complete statistics

--- a/packages/mcp/src/snapshot.request-options.test.ts
+++ b/packages/mcp/src/snapshot.request-options.test.ts
@@ -39,6 +39,7 @@ test("preserves request-level index options across snapshot state transitions", 
 
         const snapshotManager = new SnapshotManager();
         const indexOptions = {
+            requestSplitter: "langchain" as const,
             requestCustomExtensions: ["foo", ".vue"],
             requestIgnorePatterns: ["drafts/**", "*.tmp"]
         };
@@ -48,6 +49,7 @@ test("preserves request-level index options across snapshot state transitions", 
 
         const indexingInfo = snapshotManager.getCodebaseInfo(codebasePath);
         assert.equal(indexingInfo?.status, "indexing");
+        assert.equal(indexingInfo?.requestSplitter, "langchain");
         assert.deepEqual(indexingInfo?.requestCustomExtensions, ["foo", ".vue"]);
         assert.deepEqual(indexingInfo?.requestIgnorePatterns, ["drafts/**", "*.tmp"]);
 
@@ -59,6 +61,7 @@ test("preserves request-level index options across snapshot state transitions", 
 
         const indexedInfo = snapshotManager.getCodebaseInfo(codebasePath);
         assert.equal(indexedInfo?.status, "indexed");
+        assert.equal(indexedInfo?.requestSplitter, "langchain");
         assert.deepEqual(indexedInfo?.requestCustomExtensions, ["foo", ".vue"]);
         assert.deepEqual(indexedInfo?.requestIgnorePatterns, ["drafts/**", "*.tmp"]);
 
@@ -66,6 +69,7 @@ test("preserves request-level index options across snapshot state transitions", 
 
         const failedInfo = snapshotManager.getCodebaseInfo(codebasePath);
         assert.equal(failedInfo?.status, "indexfailed");
+        assert.equal(failedInfo?.requestSplitter, "langchain");
         assert.deepEqual(failedInfo?.requestCustomExtensions, ["foo", ".vue"]);
         assert.deepEqual(failedInfo?.requestIgnorePatterns, ["drafts/**", "*.tmp"]);
     });
@@ -79,6 +83,7 @@ test("explicit empty request options clear previous request-level index options"
         const snapshotManager = new SnapshotManager();
 
         snapshotManager.setCodebaseIndexing(codebasePath, 0, {
+            requestSplitter: "langchain",
             requestCustomExtensions: ["foo"],
             requestIgnorePatterns: ["drafts/**"]
         });
@@ -86,6 +91,7 @@ test("explicit empty request options clear previous request-level index options"
 
         const info = snapshotManager.getCodebaseInfo(codebasePath);
         assert.equal(info?.status, "indexing");
+        assert.equal(info?.requestSplitter, undefined);
         assert.equal(info?.requestCustomExtensions, undefined);
         assert.equal(info?.requestIgnorePatterns, undefined);
     });
@@ -98,6 +104,7 @@ test("preserves request-level index options when interrupted indexing is loaded 
 
         const firstSnapshotManager = new SnapshotManager();
         firstSnapshotManager.setCodebaseIndexing(codebasePath, 25, {
+            requestSplitter: "langchain",
             requestCustomExtensions: ["astro"],
             requestIgnorePatterns: ["drafts/**"]
         });
@@ -112,6 +119,7 @@ test("preserves request-level index options when interrupted indexing is loaded 
             throw new Error("Expected interrupted indexing to load as indexfailed");
         }
         assert.equal(info.lastAttemptedPercentage, 25);
+        assert.equal(info?.requestSplitter, "langchain");
         assert.deepEqual(info?.requestCustomExtensions, ["astro"]);
         assert.deepEqual(info?.requestIgnorePatterns, ["drafts/**"]);
     });

--- a/packages/mcp/src/snapshot.ts
+++ b/packages/mcp/src/snapshot.ts
@@ -226,6 +226,9 @@ export class SnapshotManager {
 
     private getIndexOptions(options?: CodebaseIndexOptions): CodebaseIndexOptions {
         const indexOptions: CodebaseIndexOptions = {};
+        if (options?.requestSplitter === 'ast' || options?.requestSplitter === 'langchain') {
+            indexOptions.requestSplitter = options.requestSplitter;
+        }
         if (options?.requestCustomExtensions?.length) {
             indexOptions.requestCustomExtensions = options.requestCustomExtensions;
         }

--- a/packages/mcp/src/splitter.ts
+++ b/packages/mcp/src/splitter.ts
@@ -1,0 +1,20 @@
+import { AstCodeSplitter, LangChainCodeSplitter } from "@zilliz/claude-context-core";
+import type { Splitter } from "@zilliz/claude-context-core";
+import type { RequestSplitterType } from "./config.js";
+
+export function isRequestSplitterType(splitterType: unknown): splitterType is RequestSplitterType {
+    return splitterType === "ast" || splitterType === "langchain";
+}
+
+export function resolveRequestSplitterType(splitterType: unknown): RequestSplitterType {
+    return isRequestSplitterType(splitterType) ? splitterType : "ast";
+}
+
+export function createRequestSplitter(splitterType: RequestSplitterType): Splitter {
+    switch (splitterType) {
+        case "langchain":
+            return new LangChainCodeSplitter(1000, 200);
+        case "ast":
+            return new AstCodeSplitter(2500, 300);
+    }
+}

--- a/packages/mcp/src/sync.ts
+++ b/packages/mcp/src/sync.ts
@@ -3,6 +3,8 @@ import * as os from "os";
 import * as path from "path";
 import { Context, FileSynchronizer, envManager } from "@zilliz/claude-context-core";
 import { SnapshotManager } from "./snapshot.js";
+import type { RequestSplitterType } from "./config.js";
+import { createRequestSplitter, resolveRequestSplitterType } from "./splitter.js";
 
 const DEFAULT_SYNC_LOCK_STALE_MS = 10 * 60 * 1000;
 const SYNC_LOCK_STALE_ENV = "CLAUDE_CONTEXT_SYNC_LOCK_STALE_MS";
@@ -158,13 +160,15 @@ export class SyncManager {
                 try {
                     console.log(`[SYNC-DEBUG] Calling context.reindexByChange() for '${codebasePath}'`);
                     const codebaseInfo = this.snapshotManager.getCodebaseInfo(codebasePath);
+                    const requestSplitterType: RequestSplitterType = resolveRequestSplitterType(codebaseInfo?.requestSplitter);
                     const requestIgnorePatterns = codebaseInfo?.requestIgnorePatterns || [];
                     const requestCustomExtensions = codebaseInfo?.requestCustomExtensions || [];
                     const stats = await this.context.reindexByChange(
                         codebasePath,
                         undefined,
                         requestIgnorePatterns,
-                        requestCustomExtensions
+                        requestCustomExtensions,
+                        createRequestSplitter(requestSplitterType)
                     );
                     const codebaseElapsed = Date.now() - codebaseStartTime;
 


### PR DESCRIPTION
Summary

- honor the MCP `splitter` option by passing a request-scoped splitter into core indexing
- avoid mutating the long-lived shared `Context` splitter when `splitter: "langchain"` is requested
- persist the selected splitter in the codebase snapshot so sync/reindex uses the same splitter later
- add regression coverage for request-scoped index/reindex splitter behavior and snapshot option preservation

Tests

- `pnpm --filter @zilliz/claude-context-core test`
- `pnpm --filter @zilliz/claude-context-mcp test`
- `pnpm --filter @zilliz/claude-context-core build`
- `pnpm --filter @zilliz/claude-context-core typecheck`
- `pnpm --filter @zilliz/claude-context-mcp typecheck`
- `pnpm --filter @zilliz/claude-context-mcp build`
- `pnpm typecheck`
- `git diff --check`

Fixes #362
