### PR TITLE
fix(core): auto-fallback to dense collection when Milvus lacks SparseFloatVector

### DIFF
--- a/packages/core/src/context.hybrid-fallback.test.ts
+++ b/packages/core/src/context.hybrid-fallback.test.ts
@@ -1,0 +1,135 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { Context } from './context';
+import { Embedding, EmbeddingVector } from './embedding';
+import { VectorDatabase, MilvusUnsupportedSparseVectorError } from './vectordb';
+
+class StubEmbedding extends Embedding {
+    protected maxTokens = 8192;
+    async detectDimension(): Promise<number> { return 3; }
+    async embed(): Promise<EmbeddingVector> { return { vector: [1, 0, 0], dimension: 3 }; }
+    async embedBatch(texts: string[]): Promise<EmbeddingVector[]> {
+        return texts.map(() => ({ vector: [1, 0, 0], dimension: 3 }));
+    }
+    getDimension(): number { return 3; }
+    getProvider(): string { return 'stub'; }
+}
+
+const makeVectorDb = (overrides: Partial<jest.Mocked<VectorDatabase>> = {}): jest.Mocked<VectorDatabase> => ({
+    createCollection: jest.fn().mockResolvedValue(undefined),
+    createHybridCollection: jest.fn().mockResolvedValue(undefined),
+    dropCollection: jest.fn().mockResolvedValue(undefined),
+    hasCollection: jest.fn().mockResolvedValue(false),
+    listCollections: jest.fn().mockResolvedValue([]),
+    insert: jest.fn().mockResolvedValue(undefined),
+    insertHybrid: jest.fn().mockResolvedValue(undefined),
+    search: jest.fn().mockResolvedValue([]),
+    hybridSearch: jest.fn().mockResolvedValue([]),
+    delete: jest.fn().mockResolvedValue(undefined),
+    query: jest.fn().mockResolvedValue([]),
+    getCollectionDescription: jest.fn().mockResolvedValue(''),
+    checkCollectionLimit: jest.fn().mockResolvedValue(true),
+    getCollectionRowCount: jest.fn().mockResolvedValue(0),
+    ...overrides,
+});
+
+describe('Context hybrid SparseFloatVector fallback', () => {
+    let tempRoot: string;
+    let codebasePath: string;
+    let originalHome: string | undefined;
+    let originalHybridMode: string | undefined;
+
+    beforeEach(async () => {
+        tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-context-hybrid-'));
+        const homeDir = path.join(tempRoot, 'home');
+        await fs.mkdir(homeDir, { recursive: true });
+        codebasePath = path.join(tempRoot, 'project');
+        await fs.mkdir(codebasePath);
+        originalHome = process.env.HOME;
+        originalHybridMode = process.env.HYBRID_MODE;
+        process.env.HOME = homeDir;
+        delete process.env.HYBRID_MODE;
+    });
+
+    afterEach(async () => {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalHybridMode === undefined) delete process.env.HYBRID_MODE;
+        else process.env.HYBRID_MODE = originalHybridMode;
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    });
+
+    it('falls back to dense collection when HYBRID_MODE is unspecified and Milvus rejects type 104', async () => {
+        const vectorDatabase = makeVectorDb({
+            createHybridCollection: jest.fn().mockRejectedValue(
+                new MilvusUnsupportedSparseVectorError('field data type: 104 is not supported')
+            ),
+        });
+        const context = new Context({
+            embedding: new StubEmbedding(),
+            vectorDatabase,
+        });
+
+        await context.getPreparedCollection(codebasePath);
+
+        expect(vectorDatabase.createHybridCollection).toHaveBeenCalledTimes(1);
+        expect(vectorDatabase.createCollection).toHaveBeenCalledTimes(1);
+
+        const denseCallName = vectorDatabase.createCollection.mock.calls[0][0];
+        expect(denseCallName).toMatch(/^code_chunks_/);
+        expect(denseCallName).not.toMatch(/^hybrid_code_chunks_/);
+
+        // After fallback, getCollectionName should reflect the dense override.
+        expect(context.getCollectionName(codebasePath)).toBe(denseCallName);
+    });
+
+    it('reuses an existing dense collection on the fallback path', async () => {
+        const hasCollection = jest.fn()
+            .mockResolvedValueOnce(false)  // hybrid name lookup before failure
+            .mockResolvedValueOnce(true);  // dense name lookup after fallback
+        const vectorDatabase = makeVectorDb({
+            hasCollection,
+            createHybridCollection: jest.fn().mockRejectedValue(
+                new MilvusUnsupportedSparseVectorError('data type 104 not supported')
+            ),
+        });
+        const context = new Context({
+            embedding: new StubEmbedding(),
+            vectorDatabase,
+        });
+
+        await context.getPreparedCollection(codebasePath);
+
+        expect(vectorDatabase.createCollection).not.toHaveBeenCalled();
+    });
+
+    it('rethrows with guidance when HYBRID_MODE is explicitly true', async () => {
+        process.env.HYBRID_MODE = 'true';
+        const vectorDatabase = makeVectorDb({
+            createHybridCollection: jest.fn().mockRejectedValue(
+                new MilvusUnsupportedSparseVectorError('field data type: 104 is not supported')
+            ),
+        });
+        const context = new Context({
+            embedding: new StubEmbedding(),
+            vectorDatabase,
+        });
+
+        await expect(context.getPreparedCollection(codebasePath)).rejects.toThrow(/HYBRID_MODE=true/);
+        expect(vectorDatabase.createCollection).not.toHaveBeenCalled();
+    });
+
+    it('does not catch unrelated errors from createHybridCollection', async () => {
+        const vectorDatabase = makeVectorDb({
+            createHybridCollection: jest.fn().mockRejectedValue(new Error('connection refused')),
+        });
+        const context = new Context({
+            embedding: new StubEmbedding(),
+            vectorDatabase,
+        });
+
+        await expect(context.getPreparedCollection(codebasePath)).rejects.toThrow(/connection refused/);
+        expect(vectorDatabase.createCollection).not.toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -14,7 +14,8 @@ import {
     VectorSearchResult,
     HybridSearchRequest,
     HybridSearchOptions,
-    HybridSearchResult
+    HybridSearchResult,
+    MilvusUnsupportedSparseVectorError
 } from './vectordb';
 import { SemanticSearchResult } from './types';
 import { envManager } from './utils/env-manager';
@@ -110,6 +111,8 @@ export class Context {
     private collectionNameOverride?: string;
     private warnedOverrideSanitization = new Set<string>();
     private synchronizers = new Map<string, FileSynchronizer>();
+    private hybridModeOverride?: boolean;
+    private hybridFallbackWarned = false;
 
     constructor(config: ContextConfig = {}) {
         // Initialize services
@@ -243,14 +246,27 @@ export class Context {
     }
 
     /**
-     * Get isHybrid setting from environment variable with default true
+     * Get isHybrid setting. An instance-level override (set when the server
+     * lacks SparseFloatVector support) takes precedence over the env var.
      */
     private getIsHybrid(): boolean {
+        if (this.hybridModeOverride !== undefined) {
+            return this.hybridModeOverride;
+        }
         const isHybridEnv = envManager.get('HYBRID_MODE');
         if (isHybridEnv === undefined || isHybridEnv === null) {
             return true; // Default to true
         }
         return isHybridEnv.toLowerCase() === 'true';
+    }
+
+    /**
+     * Whether the user explicitly opted into hybrid mode via HYBRID_MODE=true.
+     * Used to decide whether falling back to non-hybrid is safe.
+     */
+    private isHybridModeExplicitlyEnabled(): boolean {
+        const isHybridEnv = envManager.get('HYBRID_MODE');
+        return typeof isHybridEnv === 'string' && isHybridEnv.toLowerCase() === 'true';
     }
 
     /**
@@ -756,12 +772,64 @@ export class Context {
         const dirName = path.basename(codebasePath);
 
         if (isHybrid === true) {
-            await this.vectorDatabase.createHybridCollection(collectionName, dimension, `codebasePath:${codebasePath}`);
+            try {
+                await this.vectorDatabase.createHybridCollection(collectionName, dimension, `codebasePath:${codebasePath}`);
+            } catch (error) {
+                if (error instanceof MilvusUnsupportedSparseVectorError) {
+                    if (this.isHybridModeExplicitlyEnabled()) {
+                        // User explicitly opted in — don't silently downgrade.
+                        throw new Error(
+                            `HYBRID_MODE=true is set but the Milvus server does not support SparseFloatVector. ` +
+                            `Upgrade Milvus to a version with SparseFloatVector support, or set HYBRID_MODE=false ` +
+                            `to use dense-only collections. Underlying error: ${error.milvusReason}`
+                        );
+                    }
+                    await this.fallbackToDenseCollection(codebasePath, dimension, forceReindex, error);
+                    return;
+                }
+                throw error;
+            }
         } else {
             await this.vectorDatabase.createCollection(collectionName, dimension, `codebasePath:${codebasePath}`);
         }
 
         console.log(`[Context] ✅ Collection ${collectionName} created successfully (dimension: ${dimension})`);
+    }
+
+    /**
+     * Recover from a server that lacks SparseFloatVector support by switching
+     * this Context to dense-only mode and creating (or reusing) a dense
+     * collection. Only invoked when hybrid mode was the implicit default.
+     */
+    private async fallbackToDenseCollection(
+        codebasePath: string,
+        dimension: number,
+        forceReindex: boolean,
+        cause: MilvusUnsupportedSparseVectorError
+    ): Promise<void> {
+        if (!this.hybridFallbackWarned) {
+            console.warn(
+                `[Context] ⚠️  Milvus server does not support SparseFloatVector; ` +
+                `falling back to dense-only collections for this session. ` +
+                `Set HYBRID_MODE=false to silence this warning, or upgrade Milvus to enable hybrid search. ` +
+                `Reason: ${cause.milvusReason}`
+            );
+            this.hybridFallbackWarned = true;
+        }
+        this.hybridModeOverride = false;
+        const denseName = this.getCollectionName(codebasePath);
+
+        const denseExists = await this.vectorDatabase.hasCollection(denseName);
+        if (denseExists && !forceReindex) {
+            console.log(`📋 Dense collection ${denseName} already exists, skipping creation`);
+            return;
+        }
+        if (denseExists && forceReindex) {
+            console.log(`[Context] 🗑️  Dropping existing dense collection ${denseName} for force reindex...`);
+            await this.vectorDatabase.dropCollection(denseName);
+        }
+        await this.vectorDatabase.createCollection(denseName, dimension, `codebasePath:${codebasePath}`);
+        console.log(`[Context] ✅ Dense collection ${denseName} created successfully (dimension: ${dimension})`);
     }
 
     /**

--- a/packages/core/src/vectordb/index.ts
+++ b/packages/core/src/vectordb/index.ts
@@ -13,7 +13,7 @@ export {
 
 // Implementation class exports
 export { MilvusRestfulVectorDatabase, MilvusRestfulConfig } from './milvus-restful-vectordb';
-export { MilvusVectorDatabase, MilvusConfig } from './milvus-vectordb';
+export { MilvusVectorDatabase, MilvusConfig, MilvusUnsupportedSparseVectorError } from './milvus-vectordb';
 export {
     ClusterManager,
     ZillizConfig,

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -18,6 +18,44 @@ export interface MilvusConfig {
     ssl?: boolean;
 }
 
+/**
+ * Thrown when a Milvus server rejects SparseFloatVector (data type 104) during
+ * hybrid collection creation. Older self-hosted Milvus releases (and some
+ * embedded deployments such as `MILVUS_LITE`) do not implement this type.
+ *
+ * Callers can catch this to fall back to a dense-only collection.
+ */
+export class MilvusUnsupportedSparseVectorError extends Error {
+    public readonly milvusReason: string;
+    constructor(milvusReason: string) {
+        super(
+            `Milvus server does not support SparseFloatVector (data type 104). ` +
+            `This usually means the server version is too old for hybrid search. ` +
+            `Reason: ${milvusReason}`
+        );
+        this.name = 'MilvusUnsupportedSparseVectorError';
+        this.milvusReason = milvusReason;
+        Object.setPrototypeOf(this, MilvusUnsupportedSparseVectorError.prototype);
+    }
+}
+
+function extractMilvusErrorMessage(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    if (err && typeof err === 'object') {
+        const anyErr = err as Record<string, unknown>;
+        if (typeof anyErr.reason === 'string' && anyErr.reason.length > 0) return anyErr.reason as string;
+        if (typeof anyErr.message === 'string' && anyErr.message.length > 0) return anyErr.message as string;
+        try { return JSON.stringify(err); } catch { /* ignore */ }
+    }
+    return String(err);
+}
+
+function isSparseFloatVectorUnsupported(text: string): boolean {
+    if (!text) return false;
+    const lower = text.toLowerCase();
+    // Milvus surfaces this as "field data type: 104 is not supported" on older servers.
+    return lower.includes('data type: 104') || lower.includes('data type 104');
+}
 
 
 export class MilvusVectorDatabase implements VectorDatabase {
@@ -558,7 +596,27 @@ export class MilvusVectorDatabase implements VectorDatabase {
             throw new Error('MilvusClient is not initialized. Call ensureInitialized() first.');
         }
 
-        await this.client.createCollection(createCollectionParams);
+        let createResult: any;
+        try {
+            createResult = await this.client.createCollection(createCollectionParams);
+        } catch (err) {
+            const message = extractMilvusErrorMessage(err);
+            if (isSparseFloatVectorUnsupported(message)) {
+                throw new MilvusUnsupportedSparseVectorError(message);
+            }
+            throw new Error(`Failed to create hybrid collection '${collectionName}': ${message}`);
+        }
+
+        // Some SDK versions do not throw on server-side errors and instead return a
+        // ResStatus object. Surface that explicitly so the caller sees a real error
+        // instead of a stringified `[object Object]` later in the pipeline.
+        if (createResult && typeof createResult === 'object' && 'error_code' in createResult && createResult.error_code !== 'Success') {
+            const reason = extractMilvusErrorMessage(createResult);
+            if (isSparseFloatVectorUnsupported(reason)) {
+                throw new MilvusUnsupportedSparseVectorError(reason);
+            }
+            throw new Error(`Failed to create hybrid collection '${collectionName}': ${reason}`);
+        }
 
         // Create indexes for both vector fields
         // Index for dense vector


### PR DESCRIPTION
## Summary

Closes #259.

When indexing a codebase against a Milvus server (or embedded `MILVUS_LITE` deployment) that does not implement `SparseFloatVector`, the server rejects hybrid collection creation with `field data type: 104 is not supported`. Today this surfaces to the user as a stringified `[object Object]` because the SDK returns a `ResStatus` rather than throwing a real `Error`, and the failure aborts indexing without any actionable message.

This PR makes that capability mismatch self-healing for the default case while still giving explicit opt-ins a clear, fixable error.

### What changed

- `packages/core/src/vectordb/milvus-vectordb.ts`
  - New exported `MilvusUnsupportedSparseVectorError` so callers can recognize the type-104 rejection programmatically.
  - `createHybridCollection` now wraps the Milvus SDK call, surfaces both thrown errors and non-`Success` `ResStatus` responses (fixing the original `[object Object]`), and converts the type-104 case into the typed error.
- `packages/core/src/context.ts`
  - `prepareCollection` catches `MilvusUnsupportedSparseVectorError` and:
    - when `HYBRID_MODE` was the implicit default, logs a one-time warning, flips a per-instance hybrid override to `false`, and falls back to creating a dense collection (or reuses an existing one);
    - when the user explicitly set `HYBRID_MODE=true`, re-throws with guidance to upgrade Milvus or set `HYBRID_MODE=false`, rather than silently downgrading.
  - `getIsHybrid()` consults the instance override first, so all downstream insert/search paths in the same session route to the dense collection that was actually created.

### Why not just improve the error message

A previous fork-only patch ([Somebi/claude-context@886a459](https://github.com/Somebi/claude-context/commit/886a459e26dd6a6e7b195ddfccba6598dbcafd43)) replaced `[object Object]` with the real Milvus reason, but left the user stuck: hybrid is the default, so a perfectly serviceable Milvus server still cannot index anything until the user discovers `HYBRID_MODE=false`. This PR keeps the better error message *and* lets the index complete on its own.

### Tradeoffs considered

- The fallback is intentionally **session-scoped**, not persisted. We don't write env files or override the user's configuration on disk; on restart the same fallback kicks in idempotently (the dense collection already exists, so `prepareCollection` short-circuits).
- The fallback is **not** taken when the user explicitly opts into hybrid mode. Silently downgrading an explicit `HYBRID_MODE=true` would mask a server-version problem the user cares about.
- Detection is by error message substring (`data type: 104`). The Milvus error code for this rejection isn't versioned reliably, but the substring has been stable across releases that emit it.

## Test plan

- [x] `pnpm install` && `pnpm build:core` — clean
- [x] `pnpm --filter @zilliz/claude-context-core typecheck` — clean
- [x] `pnpm --filter @zilliz/claude-context-mcp typecheck` — clean (no downstream breakage)
- [x] `pnpm --filter @zilliz/claude-context-core test` — 11/11 passing, including 4 new tests in `context.hybrid-fallback.test.ts`:
  - falls back to dense collection when `HYBRID_MODE` is unspecified and Milvus rejects type 104
  - reuses an existing dense collection on the fallback path
  - rethrows with guidance when `HYBRID_MODE=true` is explicit
  - does not catch unrelated errors from `createHybridCollection`
- [ ] Manual end-to-end against a Milvus instance that lacks SparseFloatVector — not run locally; relies on the typed-error contract verified by the unit tests. Maintainers with access to such a deployment can confirm.