### PR TITLE
feat(core): add Solidity file support

### DIFF
--- a/docs/dive-deep/file-inclusion-rules.md
+++ b/docs/dive-deep/file-inclusion-rules.md
@@ -28,7 +28,7 @@ All extension sources are combined together:
 
 ### 1. Default Extensions
 Built-in supported file extensions including:
-- Programming languages: `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.java`, `.cpp`, `.c`, `.h`, `.hpp`, `.cs`, `.go`, `.rs`, `.php`, `.rb`, `.swift`, `.kt`, `.scala`, `.m`, `.mm`
+- Programming languages: `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.java`, `.cpp`, `.c`, `.h`, `.hpp`, `.cs`, `.go`, `.rs`, `.php`, `.rb`, `.swift`, `.kt`, `.scala`, `.m`, `.mm`, `.dart`, `.sol`
 - Documentation: `.md`, `.markdown`, `.ipynb`
 
 For more details, see [DEFAULT_SUPPORTED_EXTENSIONS](../../packages/core/src/context.ts) in the context.ts file.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -141,6 +141,7 @@ interface ContextConfig {
   // Programming languages
   '.ts', '.tsx', '.js', '.jsx', '.py', '.java', '.cpp', '.c', '.h', '.hpp',
   '.cs', '.go', '.rs', '.php', '.rb', '.swift', '.kt', '.scala', '.m', '.mm',
+  '.dart', '.sol',
   // Text and markup files  
   '.md', '.markdown', '.ipynb'
 ]

--- a/packages/core/src/context.splitter.test.ts
+++ b/packages/core/src/context.splitter.test.ts
@@ -165,4 +165,31 @@ describe('Context request-scoped splitters', () => {
             await FileSynchronizer.deleteSnapshot(project);
         }
     });
+
+    it('indexes Solidity files by default and maps them to the solidity language', async () => {
+        const project = path.join(tempRoot, 'project');
+        await fs.mkdir(project);
+        await fs.writeFile(path.join(project, 'Token.sol'), 'contract Token {}');
+
+        const vectorDatabase = createVectorDatabase();
+        const splitter = new RecordingSplitter('context');
+        const context = new Context({
+            embedding: new TestEmbedding(),
+            vectorDatabase,
+            codeSplitter: splitter,
+        });
+
+        await context.indexCodebase(project);
+
+        expect(splitter.calls).toHaveLength(1);
+        expect(splitter.calls[0]).toMatchObject({
+            language: 'solidity',
+            filePath: path.join(project, 'Token.sol'),
+        });
+
+        const insertedDocuments = vectorDatabase.insert.mock.calls
+            .flatMap(([, documents]) => documents);
+        expect(insertedDocuments).toHaveLength(1);
+        expect(insertedDocuments[0].relativePath).toBe('Token.sol');
+    });
 });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -27,7 +27,7 @@ const DEFAULT_SUPPORTED_EXTENSIONS = [
     // Programming languages
     '.ts', '.tsx', '.js', '.jsx', '.py', '.java', '.cpp', '.c', '.h', '.hpp',
     '.cs', '.go', '.rs', '.php', '.rb', '.swift', '.kt', '.scala', '.m', '.mm',
-    '.dart',
+    '.dart', '.sol',
     // Text and markup files
     '.md', '.markdown', '.ipynb',
     // '.txt',  '.json', '.yaml', '.yml', '.xml', '.html', '.htm',
@@ -1024,6 +1024,7 @@ export class Context {
             '.m': 'objective-c',
             '.mm': 'objective-c',
             '.dart': 'dart',
+            '.sol': 'solidity',
             '.ipynb': 'jupyter'
         };
         return languageMap[ext] || 'text';


### PR DESCRIPTION
Summary
- include .sol in the default supported file extensions
- map .sol files to the solidity language so the existing LangChain splitter support is used
- add a regression test that indexes a Solidity file without custom extensions
- update default extension docs

Tests
- pnpm --filter @zilliz/claude-context-core test -- context.splitter.test.ts
- pnpm --filter @zilliz/claude-context-core test
- pnpm --filter @zilliz/claude-context-core typecheck
- pnpm --filter @zilliz/claude-context-core build
- git diff --check

Fixes #240