### PR TITLE
feat(core): add Elixir language support

### DIFF
--- a/packages/core/src/context.splitter.test.ts
+++ b/packages/core/src/context.splitter.test.ts
@@ -192,4 +192,31 @@ describe('Context request-scoped splitters', () => {
         expect(insertedDocuments).toHaveLength(1);
         expect(insertedDocuments[0].relativePath).toBe('Token.sol');
     });
+
+    it('indexes Elixir files by default and maps them to the elixir language', async () => {
+        const project = path.join(tempRoot, 'project');
+        await fs.mkdir(project);
+        await fs.writeFile(path.join(project, 'greeter.ex'), 'defmodule Greeter do\n  def hello, do: :world\nend');
+
+        const vectorDatabase = createVectorDatabase();
+        const splitter = new RecordingSplitter('context');
+        const context = new Context({
+            embedding: new TestEmbedding(),
+            vectorDatabase,
+            codeSplitter: splitter,
+        });
+
+        await context.indexCodebase(project);
+
+        expect(splitter.calls).toHaveLength(1);
+        expect(splitter.calls[0]).toMatchObject({
+            language: 'elixir',
+            filePath: path.join(project, 'greeter.ex'),
+        });
+
+        const insertedDocuments = vectorDatabase.insert.mock.calls
+            .flatMap(([, documents]) => documents);
+        expect(insertedDocuments).toHaveLength(1);
+        expect(insertedDocuments[0].relativePath).toBe('greeter.ex');
+    });
 });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -26,7 +26,7 @@ import { FileSynchronizer } from './sync/synchronizer';
 const DEFAULT_SUPPORTED_EXTENSIONS = [
     // Programming languages
     '.ts', '.tsx', '.js', '.jsx', '.py', '.java', '.cpp', '.c', '.h', '.hpp',
-    '.cs', '.go', '.rs', '.php', '.rb', '.swift', '.kt', '.scala', '.m', '.mm',
+    '.cs', '.go', '.rs', '.php', '.rb', '.swift', '.kt', '.scala', '.ex', '.exs', '.m', '.mm',
     '.dart', '.sol',
     // Text and markup files
     '.md', '.markdown', '.ipynb',
@@ -1021,6 +1021,8 @@ export class Context {
             '.swift': 'swift',
             '.kt': 'kotlin',
             '.scala': 'scala',
+            '.ex': 'elixir',
+            '.exs': 'elixir',
             '.m': 'objective-c',
             '.mm': 'objective-c',
             '.dart': 'dart',


### PR DESCRIPTION
## Summary

Adds default Elixir file support to the core indexer.

- include `.ex` and `.exs` in the default supported extension list
- map both extensions to the `elixir` language before splitting
- add a focused indexing test for Elixir files

Fixes #315

## Validation

- `pnpm --filter @zilliz/claude-context-core test -- context.splitter.test.ts`
- `pnpm --filter @zilliz/claude-context-core build`
- `git diff --check`
