### PR TITLE
fix(core): only load .gitignore and .contextignore from codebase root

### DIFF
--- a/docs/dive-deep/file-inclusion-rules.md
+++ b/docs/dive-deep/file-inclusion-rules.md
@@ -14,7 +14,7 @@ Final Files = (All Supported Extensions) - (All Ignore Patterns)
 
 Where:
 - **All Supported Extensions** = Default + MCP Custom + Environment Variable Extensions
-- **All Ignore Patterns** = Default + MCP Custom + Environment Variable + .gitignore + .xxxignore + Global .contextignore
+- **All Ignore Patterns** = Default + MCP Custom + Environment Variable + .gitignore + .contextignore + Global .contextignore
 
 ## File Inclusion Flow
 
@@ -91,12 +91,16 @@ See [Environment Variables](../getting-started/environment-variables.md) for mor
 ### 4. .gitignore Files
 Standard Git ignore patterns in codebase root.
 
-### 5. .xxxignore Files
-Any file in codebase root matching pattern `.xxxignore`:
-- `.cursorignore`
-- `.codeiumignore` 
-- `.contextignore`
-- etc.
+### 5. .contextignore File
+Project-local patterns in `<codebase>/.contextignore`.
+
+Only `.gitignore` and `.contextignore` are read from the codebase root.
+Tool-specific ignore files (`.prettierignore`, `.dockerignore`,
+`.eslintignore`, `.cursorignore`, …) are intentionally skipped: their
+contents follow tool-defined semantics (e.g. prettier's allowlist idiom
+`*` + `!path`) that the indexer's flat exclude-list loader cannot
+faithfully interpret, and historically caused entire codebases to be
+silently excluded. Use `.contextignore` for any indexer-specific patterns.
 
 ### 6. Global .contextignore
 User-wide patterns in `~/.context/.contextignore`.

--- a/packages/core/src/context.ignore-patterns.test.ts
+++ b/packages/core/src/context.ignore-patterns.test.ts
@@ -181,6 +181,36 @@ describe('Context ignore pattern isolation', () => {
         }
     });
 
+    it('does not load tool-specific ignore files such as .prettierignore', async () => {
+        const project = path.join(tempRoot, 'project-with-prettierignore');
+        await fs.mkdir(project);
+        // prettier's allowlist idiom: deny everything, then re-allow specific paths via `!`.
+        // Loading this as a flat exclude list (without negation support) would ignore the
+        // entire codebase, so the indexer must skip `.prettierignore` entirely.
+        await fs.writeFile(path.join(project, '.prettierignore'), '*\n!app/**\n');
+        await fs.writeFile(path.join(project, 'a.ts'), 'export const a = 1;');
+
+        const context = new Context({ vectorDatabase: createVectorDatabase() });
+
+        const patterns = await context.getEffectiveIgnorePatterns(project);
+        expect(patterns).not.toContain('*');
+        expect(patterns).not.toContain('!app/**');
+
+        const files = await (context as any).getCodeFiles(project, patterns, ['.ts']);
+        expect(files.map((p: string) => path.relative(project, p))).toEqual(['a.ts']);
+    });
+
+    it('still loads .contextignore from the codebase root', async () => {
+        const project = path.join(tempRoot, 'project-with-contextignore');
+        await fs.mkdir(project);
+        await fs.writeFile(path.join(project, '.contextignore'), '*.md\n');
+
+        const context = new Context({ vectorDatabase: createVectorDatabase() });
+
+        const patterns = await context.getEffectiveIgnorePatterns(project);
+        expect(patterns).toContain('*.md');
+    });
+
     it('treats leading-slash directory ignore patterns as root-anchored and recursive during indexing', async () => {
         const project = path.join(tempRoot, 'project');
         await fs.mkdir(path.join(project, 'Library'), { recursive: true });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1140,19 +1140,28 @@ export class Context {
     }
 
     /**
-     * Find all .xxxignore files in the codebase directory
+     * Find supported ignore files in the codebase root.
+     *
+     * Only `.gitignore` and `.contextignore` are loaded. Other tool-specific
+     * ignore files (`.prettierignore`, `.dockerignore`, `.eslintignore`, …)
+     * are intentionally skipped because their semantics are tool-defined and
+     * not reliably interpretable as a flat list of exclude patterns. In
+     * particular, prettier-style allowlists that begin with a bare `*` and
+     * use `!`-negations would otherwise cause every file to be ignored, since
+     * this loader does not implement gitignore negation. Projects that need
+     * extra patterns for indexing should put them in `.contextignore`.
+     *
      * @param codebasePath Path to the codebase
      * @returns Array of ignore file paths
      */
     private async findIgnoreFiles(codebasePath: string): Promise<string[]> {
+        const SUPPORTED_IGNORE_FILES = ['.gitignore', '.contextignore'];
         try {
             const entries = await fs.promises.readdir(codebasePath, { withFileTypes: true });
             const ignoreFiles: string[] = [];
 
             for (const entry of entries) {
-                if (entry.isFile() &&
-                    entry.name.startsWith('.') &&
-                    entry.name.endsWith('ignore')) {
+                if (entry.isFile() && SUPPORTED_IGNORE_FILES.includes(entry.name)) {
                     ignoreFiles.push(path.join(codebasePath, entry.name));
                 }
             }


### PR DESCRIPTION
Fixes #222 and very likely #195, #145 too.

## TL;DR;

When I run indexing, I get response that indexing succeeded but no files where actually indexed. This happened for me because claude-context was looking at .prettierignore which has nothing to do with the claude-context not to mention that it parsed incorrectly. This PR tries to solve the issue by explicitly listing which ignore files we should look at.

## Technicalities

Previously `findIgnoreFiles` loaded every `.<name>ignore` file in the codebase root — `.prettierignore`, `.dockerignore`, `.eslintignore`, `.cursorignore`, etc. — and concatenated their lines into the indexer's flat exclude list. The loader has no per-file semantics and no support for `!` negations.

Tool-specific files often use the prettier-style allowlist idiom (a bare `*` followed by `!path` re-includes). With the existing flat loader, the bare `*` is converted to regex `^.*$` and matches every relative path. The walker returns 0 files, the indexer reports 100% completion, and the Milvus collection ends up empty — no error surfaced to the user. This is the symptom #222 describes from the user side ("Claude-context automatically ignores files which have the key information for agents to look for").

This PR narrows the discovery to `.gitignore` and `.contextignore` only. Tool-specific ignore files are intentionally skipped because their semantics are tool-defined and not reliably interpretable as a flat exclude list. Projects that need extra patterns specifically for the indexer can put them in `.contextignore` (already documented).

A previous attempt to fix this more broadly (#293, closed) replaced the custom matcher with the `ignore` npm package to support `!` negations and gitignore semantics across the board. This PR is deliberately narrower: no new dependency, no behavior change for `.gitignore` users, only the surface area where the bug fires.

## Changes
- `packages/core/src/context.ts`: `findIgnoreFiles` now matches a fixed allowlist (`.gitignore`, `.contextignore`) instead of every `.*ignore` file.
- `packages/core/src/context.ignore-patterns.test.ts`: regression tests — `.prettierignore` no longer poisons the pattern set, and `.contextignore` continues to load.
- `docs/dive-deep/file-inclusion-rules.md`: replaces the "any .xxxignore" section with the narrowed rule and rationale.

## Test plan
- [x] `pnpm --filter @zilliz/claude-context-core test` — 21/21 pass
- [x] `pnpm build` — all packages compile clean