### PR TITLE
fix(mcp): allow clearing tracked index after path removal

### DIFF
--- a/packages/mcp/src/handlers.clear-index.test.ts
+++ b/packages/mcp/src/handlers.clear-index.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ToolHandlers } from "./handlers.js";
+import { SnapshotManager } from "./snapshot.js";
+
+async function withTempHome(run: (tempRoot: string) => Promise<void>): Promise<void> {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "claude-context-mcp-clear-"));
+    const homeDir = path.join(tempRoot, "home");
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+
+    try {
+        await fs.mkdir(path.join(homeDir, ".context"), { recursive: true });
+        await run(tempRoot);
+    } finally {
+        if (originalHome === undefined) {
+            delete process.env.HOME;
+        } else {
+            process.env.HOME = originalHome;
+        }
+        if (originalUserProfile === undefined) {
+            delete process.env.USERPROFILE;
+        } else {
+            process.env.USERPROFILE = originalUserProfile;
+        }
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+}
+
+function createContextMock() {
+    return {
+        clearIndex: test.mock.fn(async (_path: string) => undefined),
+    };
+}
+
+test("clear_index clears a tracked index even when the local codebase directory no longer exists", async () => {
+    await withTempHome(async (tempRoot) => {
+        const deletedCodebasePath = path.join(tempRoot, "deleted-project");
+        const context = createContextMock();
+        const snapshotManager = new SnapshotManager();
+        snapshotManager.setCodebaseIndexed(deletedCodebasePath, {
+            indexedFiles: 1,
+            totalChunks: 2,
+            status: "completed"
+        });
+        snapshotManager.saveCodebaseSnapshot();
+
+        const handlers = new ToolHandlers(context as any, snapshotManager);
+
+        const result = await handlers.handleClearIndex({ path: deletedCodebasePath });
+
+        assert.equal(result.isError, undefined);
+        assert.match(result.content[0].text, /Successfully cleared codebase/);
+        assert.equal(context.clearIndex.mock.callCount(), 1);
+        assert.equal(context.clearIndex.mock.calls[0].arguments[0], deletedCodebasePath);
+        assert.equal(snapshotManager.getIndexedCodebases().includes(deletedCodebasePath), false);
+    });
+});
+
+test("clear_index still rejects a missing local path when it is not tracked in the snapshot", async () => {
+    await withTempHome(async (tempRoot) => {
+        const missingUntrackedPath = path.join(tempRoot, "missing-untracked-project");
+        const otherIndexedPath = path.join(tempRoot, "other-project");
+        const context = createContextMock();
+        const snapshotManager = new SnapshotManager();
+        snapshotManager.setCodebaseIndexed(otherIndexedPath, {
+            indexedFiles: 1,
+            totalChunks: 2,
+            status: "completed"
+        });
+        snapshotManager.saveCodebaseSnapshot();
+
+        const handlers = new ToolHandlers(context as any, snapshotManager);
+
+        const result = await handlers.handleClearIndex({ path: missingUntrackedPath });
+
+        assert.equal(result.isError, true);
+        assert.match(result.content[0].text, /not indexed or being indexed/);
+        assert.equal(context.clearIndex.mock.callCount(), 0);
+    });
+});

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -867,29 +867,6 @@ export class ToolHandlers {
             // Force absolute path resolution - warn if relative path provided
             const absolutePath = ensureAbsolutePath(codebasePath);
 
-            // Validate path exists
-            if (!fs.existsSync(absolutePath)) {
-                return {
-                    content: [{
-                        type: "text",
-                        text: `Error: Path '${absolutePath}' does not exist. Original input: '${codebasePath}'`
-                    }],
-                    isError: true
-                };
-            }
-
-            // Check if it's a directory
-            const stat = fs.statSync(absolutePath);
-            if (!stat.isDirectory()) {
-                return {
-                    content: [{
-                        type: "text",
-                        text: `Error: Path '${absolutePath}' is not a directory`
-                    }],
-                    isError: true
-                };
-            }
-
             // Check if this codebase is indexed or being indexed
             const isIndexed = this.snapshotManager.getIndexedCodebases().includes(absolutePath);
             const isIndexing = this.snapshotManager.getIndexingCodebases().includes(absolutePath);


### PR DESCRIPTION
Summary

- allow `clear_index` to clear an index whose original local directory no longer exists
- keep the existing exact snapshot guard, so only indexed or indexing codebases can be cleared
- leave local filesystem validation unchanged for tools that need to read from disk
- add regression coverage for both tracked-deleted and missing-untracked paths

Tests

- `pnpm --filter @zilliz/claude-context-mcp test`
- `pnpm --filter @zilliz/claude-context-mcp typecheck`
- `pnpm --filter @zilliz/claude-context-mcp build`
- `git diff --check`

Fixes #375