### PR TITLE
test(core): cover VoyageAI variable dimensions

### DIFF
--- a/packages/core/src/embedding/voyageai-embedding.test.ts
+++ b/packages/core/src/embedding/voyageai-embedding.test.ts
@@ -1,0 +1,53 @@
+import { VoyageAIClient } from 'voyageai';
+import { VoyageAIEmbedding } from './voyageai-embedding';
+
+const mockEmbed = jest.fn();
+
+jest.mock('voyageai', () => ({
+    VoyageAIClient: jest.fn().mockImplementation(() => ({
+        embed: mockEmbed,
+    })),
+}));
+
+describe('VoyageAIEmbedding', () => {
+    beforeEach(() => {
+        mockEmbed.mockReset();
+        (VoyageAIClient as unknown as jest.Mock).mockClear();
+    });
+
+    it('keeps voyage-4-nano metadata aligned with its default dimension', async () => {
+        const supportedModels = VoyageAIEmbedding.getSupportedModels();
+
+        expect(supportedModels['voyage-4-nano']).toMatchObject({
+            dimension: '1024 (default), 256, 512, 2048',
+            contextLength: 32000,
+        });
+
+        const embedding = new VoyageAIEmbedding({
+            apiKey: 'test-api-key',
+            model: 'voyage-4-nano',
+        });
+
+        expect(embedding.getDimension()).toBe(1024);
+        await expect(embedding.detectDimension()).resolves.toBe(1024);
+    });
+
+    it('parses the leading default dimension from variable-dimension model metadata', () => {
+        const defaultDimensionModels = [
+            'voyage-4-large',
+            'voyage-4',
+            'voyage-4-lite',
+            'voyage-4-nano',
+            'voyage-code-3',
+        ];
+
+        for (const model of defaultDimensionModels) {
+            const embedding = new VoyageAIEmbedding({
+                apiKey: 'test-api-key',
+                model,
+            });
+
+            expect(embedding.getDimension()).toBe(1024);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Add focused VoyageAI embedding regression coverage for variable-dimension model metadata
- Assert `voyage-4-nano` keeps the current `1024 (default), 256, 512, 2048` metadata and resolves its default dimension to 1024
- Cover the same leading-default parser path for the Voyage 4 family and `voyage-code-3`

## Why

`VoyageAIEmbedding` parses the leading number from string-form dimension metadata and exposes it through `getDimension()` / `detectDimension()`, which downstream indexing uses for vector collection dimensions. PR #307 fixed this parser path, and current `master` has the corrected `voyage-4-nano` metadata, but there was no VoyageAI embedding test guarding the default-dimension contract.

## Test plan

- [x] `./packages/core/node_modules/.bin/jest --runInBand --config packages/core/jest.config.cjs packages/core/src/embedding/voyageai-embedding.test.ts`
- [x] `./node_modules/.bin/tsc --build packages/core/tsconfig.json --force`
- [x] `git diff --check`
