### PR TITLE
feat(vscode): add OpenRouter embedding provider

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -14,7 +14,7 @@ A code indexing and semantic search VSCode extension powered by [Claude Context]
 - 🔍 **Semantic Search**: Intelligent code search based on semantic understanding, not just keyword matching
 - 📁 **Codebase Indexing**: Automatically index entire codebase and build semantic vector database
 - 🎯 **Context Search**: Search related code by selecting code snippets
-- 🔧 **Multi-platform Support**: Support for OpenAI, VoyageAI, Gemini, and Ollama as embedding providers
+- 🔧 **Multi-platform Support**: Support for OpenAI, VoyageAI, Gemini, Ollama, and OpenRouter as embedding providers
 - 💾 **Vector Storage**: Integrated with Milvus vector database for efficient storage and retrieval
 
 ## Requirements
@@ -50,6 +50,7 @@ Configure your embedding provider to convert code into semantic vectors.
 - **Gemini**: Google's state-of-the-art embedding model with Matryoshka representation learning
 - **VoyageAI**: Alternative embedding provider with competitive performance  
 - **Ollama**: For local embedding models
+- **OpenRouter**: OpenAI-compatible embedding access through OpenRouter
 
 #### Code Splitter Configuration
 Configure how your code is split into chunks for indexing.
@@ -106,10 +107,10 @@ MILVUS_TOKEN=your-zilliz-cloud-api-key
 
 ## Configuration
 
-- `semanticCodeSearch.embeddingProvider.provider` - Embedding provider (OpenAI/VoyageAI/Gemini/Ollama)
+- `semanticCodeSearch.embeddingProvider.provider` - Embedding provider (OpenAI/VoyageAI/Gemini/Ollama/OpenRouter)
 - `semanticCodeSearch.embeddingProvider.model` - Embedding model to use
 - `semanticCodeSearch.embeddingProvider.apiKey` - API key for embedding provider
-- `semanticCodeSearch.embeddingProvider.baseURL` - Custom API endpoint URL (optional, for OpenAI and Gemini)
+- `semanticCodeSearch.embeddingProvider.baseURL` - Custom API endpoint URL (optional, for OpenAI and Gemini; OpenRouter uses https://openrouter.ai/api/v1)
 - `semanticCodeSearch.embeddingProvider.outputDimensionality` - Output dimension for Gemini (supports 3072, 1536, 768, 256)
 - `semanticCodeSearch.milvus.address` - Milvus server address
 
@@ -129,7 +130,7 @@ This VSCode extension is part of the Claude Context monorepo. Please see:
 - TypeScript
 - VSCode Extension API  
 - Milvus Vector Database
-- OpenAI/VoyageAI Embeddings
+- OpenAI/VoyageAI/Gemini/Ollama/OpenRouter Embeddings
 
 ## License
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -83,7 +83,8 @@
                         "OpenAI",
                         "VoyageAI",
                         "Ollama",
-                        "Gemini"
+                        "Gemini",
+                        "OpenRouter"
                     ],
                     "description": "Embedding service provider"
                 },

--- a/packages/vscode-extension/src/config/configManager.ts
+++ b/packages/vscode-extension/src/config/configManager.ts
@@ -19,6 +19,9 @@ export type EmbeddingProviderConfig = {
 } | {
     provider: 'Gemini';
     config: GeminiEmbeddingConfig;
+} | {
+    provider: 'OpenRouter';
+    config: OpenAIEmbeddingConfig;
 };
 
 export type SplitterProviderConfig = {
@@ -102,6 +105,25 @@ const EMBEDDING_PROVIDERS = {
         ] as FieldDefinition[],
         defaultConfig: {
             model: 'gemini-embedding-001'
+        }
+    },
+    'OpenRouter': {
+        name: 'OpenRouter',
+        class: OpenAIEmbedding,
+        requiredFields: [
+            { name: 'model', type: 'string', description: 'Model name to use', inputType: 'select-with-custom', required: true },
+            { name: 'apiKey', type: 'string', description: 'OpenRouter API key', inputType: 'password', required: true }
+        ] as FieldDefinition[],
+        optionalFields: [] as FieldDefinition[],
+        defaultConfig: {
+            model: 'openai/text-embedding-3-small',
+            baseURL: 'https://openrouter.ai/api/v1'
+        },
+        models: {
+            'openai/text-embedding-3-small': {
+                dimension: 1536,
+                description: 'OpenRouter-hosted OpenAI text embedding model (recommended)'
+            }
         }
     }
 } as const;
@@ -205,7 +227,7 @@ export class ConfigManager {
         if (!configObject) return undefined;
 
         return {
-            provider: provider as 'OpenAI' | 'VoyageAI' | 'Ollama' | 'Gemini',
+            provider: provider as 'OpenAI' | 'VoyageAI' | 'Ollama' | 'Gemini' | 'OpenRouter',
             config: configObject
         };
     }
@@ -274,8 +296,11 @@ export class ConfigManager {
         const result: any = {};
 
         for (const [providerKey, providerInfo] of Object.entries(EMBEDDING_PROVIDERS)) {
-            // Ollama doesn't have getSupportedModels since users input model names manually
-            const models = providerKey === 'Ollama' ? {} : (providerInfo.class as any).getSupportedModels();
+            // Ollama doesn't have getSupportedModels since users input model names manually.
+            // OpenRouter reuses OpenAIEmbedding internally, but its public model ids include the
+            // provider prefix, so expose the OpenRouter-specific default list when present.
+            const models = providerKey === 'Ollama' ? {} :
+                ('models' in providerInfo ? providerInfo.models : (providerInfo.class as any).getSupportedModels());
 
             result[providerKey] = {
                 name: providerInfo.name,

--- a/packages/vscode-extension/src/webview/scripts/semanticSearch.js
+++ b/packages/vscode-extension/src/webview/scripts/semanticSearch.js
@@ -184,7 +184,8 @@ class SemanticSearchController {
                 { value: 'OpenAI', text: 'OpenAI' },
                 { value: 'VoyageAI', text: 'VoyageAI' },
                 { value: 'Ollama', text: 'Ollama' },
-                { value: 'Gemini', text: 'Gemini' }
+                { value: 'Gemini', text: 'Gemini' },
+                { value: 'OpenRouter', text: 'OpenRouter' }
             ];
 
             defaultProviders.forEach(provider => {


### PR DESCRIPTION
## Summary

Add OpenRouter as a first-class embedding provider in the VSCode extension settings flow.

## Changes

- add `OpenRouter` to the VSCode extension configuration enum
- register an OpenRouter provider option that reuses `OpenAIEmbedding` with `https://openrouter.ai/api/v1`
- expose the OpenRouter fallback option in the webview provider dropdown
- document OpenRouter in the VSCode extension README

## Motivation

The MCP server already supports `EMBEDDING_PROVIDER=OpenRouter`, but the VSCode extension still only exposes OpenAI, VoyageAI, Ollama, and Gemini. This keeps the extension settings in sync with the existing OpenRouter support and gives users a direct OpenRouter option instead of requiring them to model it as generic OpenAI configuration.

Related: #81

## Validation

- `./node_modules/.bin/tsc -b packages/core/tsconfig.json`
- `./node_modules/.bin/tsc --noEmit -p packages/vscode-extension/tsconfig.json`
- `git diff --check origin/master...HEAD`
- `node -e "JSON.parse(require('fs').readFileSync('packages/vscode-extension/package.json','utf8')); console.log('package json ok')"`
