### PR TITLE
fix(mcp): surface real error in collection validation catch

### DIFF
--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -7,6 +7,38 @@ import type { CodebaseIndexOptions, RequestSplitterType } from "./config.js";
 import { createRequestSplitter, isRequestSplitterType } from "./splitter.js";
 import { ensureAbsolutePath, truncateContent, trackCodebasePath } from "./utils.js";
 
+function formatValidationError(err: any): string {
+    const usableString = (value: unknown): string | null => {
+        if (typeof value !== "string") return null;
+
+        const trimmed = value.trim();
+        if (!trimmed || trimmed === "[object Object]") return null;
+
+        return trimmed;
+    };
+
+    const directMessage = usableString(err?.message);
+    if (directMessage) return directMessage;
+
+    const responseMessage = usableString(err?.response?.data?.message);
+    if (responseMessage) return responseMessage;
+
+    const responseDetail = usableString(err?.response?.data?.detail);
+    if (responseDetail) return responseDetail;
+
+    const statusText = usableString(err?.response?.statusText);
+    if (statusText) return statusText;
+
+    try {
+        const json = JSON.stringify(err);
+        if (json && json !== "{}" && json !== "null") return json;
+    } catch {
+        // Fall through to String(err) for circular or otherwise unserializable values.
+    }
+
+    return String(err);
+}
+
 export class ToolHandlers {
     private context: Context;
     private snapshotManager: SnapshotManager;
@@ -211,7 +243,7 @@ export class ToolHandlers {
                             }
                         }
                     } catch (descError: any) {
-                        console.warn(`[SYNC-CLOUD] ⚠️  Failed to get description for collection ${collectionName}:`, descError.message || descError);
+                        console.warn(`[SYNC-CLOUD] ⚠️  Failed to get description for collection ${collectionName}:`, formatValidationError(descError));
                     }
 
                     // Fallback: query document metadata for old collections without new description format
@@ -247,11 +279,11 @@ export class ToolHandlers {
                                 console.log(`[SYNC-CLOUD] ℹ️  Collection ${collectionName} is empty`);
                             }
                         } catch (queryError: any) {
-                            console.warn(`[SYNC-CLOUD] ⚠️  Fallback query failed for collection ${collectionName}:`, queryError.message || queryError);
+                            console.warn(`[SYNC-CLOUD] ⚠️  Fallback query failed for collection ${collectionName}:`, formatValidationError(queryError));
                         }
                     }
                 } catch (collectionError: any) {
-                    console.warn(`[SYNC-CLOUD] ⚠️  Error checking collection ${collectionName}:`, collectionError.message || collectionError);
+                    console.warn(`[SYNC-CLOUD] ⚠️  Error checking collection ${collectionName}:`, formatValidationError(collectionError));
                     // Continue with next collection
                 }
             }
@@ -281,7 +313,7 @@ export class ToolHandlers {
                     try {
                         await FileSynchronizer.deleteSnapshot(localCodebase);
                     } catch (error: any) {
-                        console.warn(`[SYNC-CLOUD] ⚠️  Failed to delete local merkle snapshot for removed codebase '${localCodebase}':`, error?.message || error);
+                        console.warn(`[SYNC-CLOUD] ⚠️  Failed to delete local merkle snapshot for removed codebase '${localCodebase}':`, formatValidationError(error));
                     }
 
                     console.log(`[SYNC-CLOUD] ➖ Removed local codebase (not in cloud): ${localCodebase}`);
@@ -316,7 +348,7 @@ export class ToolHandlers {
 
             console.log(`[SYNC-CLOUD] ✅ Cloud sync completed successfully`);
         } catch (error: any) {
-            console.error(`[SYNC-CLOUD] ❌ Error syncing codebases from cloud:`, error.message || error);
+            console.error(`[SYNC-CLOUD] ❌ Error syncing codebases from cloud:`, formatValidationError(error));
             // Don't throw - this is not critical for the main functionality
         }
     }
@@ -460,7 +492,7 @@ export class ToolHandlers {
                 return {
                     content: [{
                         type: "text",
-                        text: `Error validating collection creation: ${validationError.message || validationError}`
+                        text: `Error validating collection creation: ${formatValidationError(validationError)}`
                     }],
                     isError: true
                 };
@@ -533,7 +565,7 @@ export class ToolHandlers {
             return {
                 content: [{
                     type: "text",
-                    text: `Error starting indexing: ${error.message || error}`
+                    text: `Error starting indexing: ${formatValidationError(error)}`
                 }],
                 isError: true
             };
@@ -635,7 +667,7 @@ export class ToolHandlers {
             const lastProgress = this.snapshotManager.getIndexingProgress(absolutePath);
 
             // Set codebase to failed status with error information
-            const errorMessage = error.message || String(error);
+            const errorMessage = formatValidationError(error);
             this.snapshotManager.setCodebaseIndexFailed(absolutePath, errorMessage, lastProgress, indexOptions);
             this.snapshotManager.saveCodebaseSnapshot();
 
@@ -919,7 +951,7 @@ export class ToolHandlers {
                 } catch (waitError: any) {
                     // startBackgroundIndexing already logs and never re-throws,
                     // so this catch only guards against future refactors.
-                    console.warn(`[CLEAR] Background indexing wind-down reported: ${waitError?.message || waitError}`);
+                    console.warn(`[CLEAR] Background indexing wind-down reported: ${formatValidationError(waitError)}`);
                 }
                 this.indexingTasks.delete(absolutePath);
             }
@@ -1098,7 +1130,7 @@ export class ToolHandlers {
             return {
                 content: [{
                     type: "text",
-                    text: `Error getting indexing status: ${error.message || error}`
+                    text: `Error getting indexing status: ${formatValidationError(error)}`
                 }],
                 isError: true
             };


### PR DESCRIPTION
## Summary

Replace the `err.message || err` interpolation in the MCP catch blocks with a small `formatValidationError` helper so users see the actual error from Zilliz / Milvus instead of `[object Object]`.

## Why this matters

Issue #215 reports `Error validating collection creation: [object Object]` from `index_codebase`. Multiple users in the thread confirm the same opaque message (@DeadManPoe on Rust, @Wazabit on a NestJS TS codebase, @PeterSenyszyn, @mahmoudnaif, @KrustyHack). @PeterSenyszyn traced the root cause: Zilliz Cloud free tier caps collections at 5 per cluster, and the create call rejects past that.

The catch at `packages/mcp/src/handlers.ts:463` interpolated `${validationError.message || validationError}`. When `validationError` is a plain object without `.message`, the `||` fallback returns the object itself and template coercion produces `[object Object]`. The same antipattern repeats at four other catch sites in the file (cloud sync description, fallback query, snapshot delete, indexing dispatcher).

`formatValidationError` tries, in order:
- `err.message` (when it's a non-empty string and not literally `[object Object]`)
- `err.response.data.message`
- `err.response.data.detail`
- `err.response.statusText`
- `JSON.stringify(err)` (when the result is not `{}` or `null`)
- `String(err)` (final fallback)

This turns the Zilliz collection-limit error and similar response-bearing errors into a readable message at every existing catch site without changing the surrounding flow. `checkCollectionLimit` itself is not modified; this is purely a presentation fix.

## Testing

- `npx tsc --noEmit` on `packages/mcp` passes.
- No public API or schema changes; existing call sites unchanged.

Fixes #215
