### PR TITLE
fix(mcp): derive default version from package metadata

### DIFF
--- a/packages/mcp/src/config.test.ts
+++ b/packages/mcp/src/config.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createMcpConfig } from "./config.js";
+
+const mcpPackage = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8")
+) as { version: string };
+
+function withEnvOverride(name: string, value: string | undefined, run: () => void): void {
+    const originalValue = process.env[name];
+
+    if (value === undefined) {
+        delete process.env[name];
+    } else {
+        process.env[name] = value;
+    }
+
+    try {
+        run();
+    } finally {
+        if (originalValue === undefined) {
+            delete process.env[name];
+        } else {
+            process.env[name] = originalValue;
+        }
+    }
+}
+
+test("uses the MCP package version as the default server version", () => {
+    withEnvOverride("MCP_SERVER_VERSION", undefined, () => {
+        const config = createMcpConfig();
+
+        assert.equal(config.version, mcpPackage.version);
+    });
+});
+
+test("allows MCP_SERVER_VERSION to override the package default", () => {
+    withEnvOverride("MCP_SERVER_VERSION", "custom-test-version", () => {
+        const config = createMcpConfig();
+
+        assert.equal(config.version, "custom-test-version");
+    });
+});

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { envManager } from "@zilliz/claude-context-core";
 
 export interface ContextMcpConfig {
@@ -118,6 +119,22 @@ export function getEmbeddingModelForProvider(provider: string): string {
     }
 }
 
+function readMcpPackageVersion(): string {
+    try {
+        const packageJsonUrl = new URL("../package.json", import.meta.url);
+        const packageJson = JSON.parse(readFileSync(packageJsonUrl, "utf8")) as { version?: unknown };
+        if (typeof packageJson.version === "string" && packageJson.version.trim()) {
+            return packageJson.version;
+        }
+    } catch (error) {
+        console.warn(`[DEBUG] ⚠️  Unable to read MCP package version: ${error}`);
+    }
+
+    return "1.0.0";
+}
+
+const defaultMcpServerVersion = readMcpPackageVersion();
+
 function getPositiveIntegerFromEnv(name: string): number | undefined {
     const rawValue = envManager.get(name);
     if (!rawValue) {
@@ -148,7 +165,7 @@ export function createMcpConfig(): ContextMcpConfig {
 
     const config: ContextMcpConfig = {
         name: envManager.get('MCP_SERVER_NAME') || "Context MCP Server",
-        version: envManager.get('MCP_SERVER_VERSION') || "1.0.0",
+        version: envManager.get('MCP_SERVER_VERSION') || defaultMcpServerVersion,
         // Embedding provider configuration
         embeddingProvider: (envManager.get('EMBEDDING_PROVIDER') as 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama' | 'OpenRouter') || 'OpenAI',
         embeddingModel: getEmbeddingModelForProvider(envManager.get('EMBEDDING_PROVIDER') || 'OpenAI'),


### PR DESCRIPTION
## Summary
- derive the default MCP server version from `packages/mcp/package.json` instead of the stale hard-coded `1.0.0`
- preserve the `MCP_SERVER_VERSION` environment override
- add focused regression coverage for the package default and override paths

## Why
`createMcpConfig()` passes `config.version` into the MCP server metadata. The package is currently versioned as `0.1.13`, but a default install still reports `1.0.0` unless `MCP_SERVER_VERSION` is set.

## Tests
- `./node_modules/.bin/tsc --build packages/core --force`
- `cd packages/mcp && node --import tsx --test "src/config.test.ts"`
- `./node_modules/.bin/tsc --build packages/mcp --force`
- `git diff --check`

Note: `pnpm --filter @zilliz/claude-context-mcp test -- --test-name-pattern 'server version'` attempted to run through the local pnpm shim, but pnpm 11 aborted with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` before executing tests, so I used the package's underlying `node --import tsx --test` command directly.
