### PR TITLE
fix(core): make Merkle root hashing deterministic

### DIFF
--- a/packages/core/src/sync/synchronizer.test.ts
+++ b/packages/core/src/sync/synchronizer.test.ts
@@ -1,0 +1,28 @@
+import { FileSynchronizer } from './synchronizer';
+
+type TestableFileSynchronizer = {
+    buildMerkleDAG(fileHashes: Map<string, string>): {
+        rootIds: string[];
+    };
+};
+
+describe('FileSynchronizer Merkle DAG', () => {
+    it('uses stable root ids for identical file hashes inserted in different orders', () => {
+        const synchronizer = new FileSynchronizer('/tmp/project') as unknown as TestableFileSynchronizer;
+        const firstOrder = new Map([
+            ['src/a.ts', 'hash-a'],
+            ['src/b.ts', 'hash-b'],
+            ['README.md', 'hash-readme'],
+        ]);
+        const secondOrder = new Map([
+            ['README.md', 'hash-readme'],
+            ['src/b.ts', 'hash-b'],
+            ['src/a.ts', 'hash-a'],
+        ]);
+
+        const firstDag = synchronizer.buildMerkleDAG(firstOrder);
+        const secondDag = synchronizer.buildMerkleDAG(secondOrder);
+
+        expect(firstDag.rootIds).toEqual(secondDag.rootIds);
+    });
+});

--- a/packages/core/src/sync/synchronizer.ts
+++ b/packages/core/src/sync/synchronizer.ts
@@ -209,7 +209,7 @@ export class FileSynchronizer {
 
         // Create a root node for the entire directory
         let valuesString = "";
-        keys.forEach(key => {
+        sortedPaths.forEach(key => {
             valuesString += fileHashes.get(key);
         });
         const rootNodeData = "root:" + valuesString;


### PR DESCRIPTION
## Summary
- build the Merkle DAG root hash from sorted file paths instead of Map insertion order
- add a regression test that builds identical file-hash maps in different insertion orders and checks the root id stays stable

## Why
`buildMerkleDAG()` already adds child nodes in `sortedPaths` order, but the root node data was still built from the unsorted `Map` key order. When the same file hashes are inserted in a different traversal order, the root id can change even though the files did not.

`MerkleDAG.compare()` treats changed node ids as added/removed, so an insertion-order-only root change can make the synchronizer do unnecessary file-state comparisons and snapshot writes.

## Tests
- `cd packages/core && node_modules/.bin/jest src/sync/synchronizer.test.ts --runInBand`
- `./node_modules/.bin/tsc --build packages/core --force`
- `git diff --check`
