### PR TITLE
fix(mcp): allow clear_index to drop orphaned collections without local path

### DIFF
--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -867,28 +867,10 @@ export class ToolHandlers {
             // Force absolute path resolution - warn if relative path provided
             const absolutePath = ensureAbsolutePath(codebasePath);
 
-            // Validate path exists
-            if (!fs.existsSync(absolutePath)) {
-                return {
-                    content: [{
-                        type: "text",
-                        text: `Error: Path '${absolutePath}' does not exist. Original input: '${codebasePath}'`
-                    }],
-                    isError: true
-                };
-            }
-
-            // Check if it's a directory
-            const stat = fs.statSync(absolutePath);
-            if (!stat.isDirectory()) {
-                return {
-                    content: [{
-                        type: "text",
-                        text: `Error: Path '${absolutePath}' is not a directory`
-                    }],
-                    isError: true
-                };
-            }
+            // clear_index is a cloud-side teardown keyed by the absolute path,
+            // so the local folder does not need to exist on disk (issue #375).
+            // The isIndexed/isIndexing check below establishes that there is a
+            // collection to drop; the path is only used as the identifier.
 
             // Check if this codebase is indexed or being indexed
             const isIndexed = this.snapshotManager.getIndexedCodebases().includes(absolutePath);


### PR DESCRIPTION
## What

`clear_index` validated that the codebase path exists on disk before dropping its Milvus collection:

```ts
if (!fs.existsSync(absolutePath)) { ... "does not exist" ... }
const stat = fs.statSync(absolutePath);
if (!stat.isDirectory()) { ... "is not a directory" ... }
```

But the path is only used as the collection identifier. If a codebase is moved or deleted on disk, its collection is left orphaned with no way to clear it, since the existence check fails before any Milvus call runs.

## Change

Remove the `fs.existsSync` and `fs.statSync` directory checks from `handleClearIndex`. The existing `isIndexed`/`isIndexing` check already proves there is a collection to drop, and the path serves only as the key. Index and search handlers, which genuinely need a local directory, are untouched.

## Testing

- `tsc --noEmit` clean for the mcp package
- `pnpm --filter @zilliz/claude-context-mcp test` passes (4/4)
- core package builds

Fixes #375