### PR TITLE
fix(vscode): validate webview openFile paths

### DIFF
--- a/packages/vscode-extension/src/webview/pathUtils.ts
+++ b/packages/vscode-extension/src/webview/pathUtils.ts
@@ -1,0 +1,17 @@
+import * as path from 'path';
+
+export function resolveWorkspaceFilePath(workspaceRoot: string, relativePath: unknown): string | undefined {
+    if (!workspaceRoot || typeof relativePath !== 'string' || relativePath.length === 0 || path.isAbsolute(relativePath)) {
+        return undefined;
+    }
+
+    const rootPath = path.resolve(workspaceRoot);
+    const candidatePath = path.resolve(rootPath, relativePath);
+    const pathFromRoot = path.relative(rootPath, candidatePath);
+
+    if (pathFromRoot === '' || (!pathFromRoot.startsWith('..') && !path.isAbsolute(pathFromRoot))) {
+        return candidatePath;
+    }
+
+    return undefined;
+}

--- a/packages/vscode-extension/src/webview/semanticSearchProvider.ts
+++ b/packages/vscode-extension/src/webview/semanticSearchProvider.ts
@@ -4,7 +4,7 @@ import { SearchCommand } from '../commands/searchCommand';
 import { IndexCommand } from '../commands/indexCommand';
 import { SyncCommand } from '../commands/syncCommand';
 import { ConfigManager, EmbeddingProviderConfig } from '../config/configManager';
-import * as path from 'path';
+import { resolveWorkspaceFilePath } from './pathUtils';
 
 export class SemanticSearchViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'semanticSearchView';
@@ -130,7 +130,13 @@ export class SemanticSearchViewProvider implements vscode.WebviewViewProvider {
                         try {
                             const workspaceFolders = vscode.workspace.workspaceFolders;
                             const workspaceRoot = workspaceFolders ? workspaceFolders[0].uri.fsPath : '';
-                            const absPath = path.join(workspaceRoot, message.relativePath);
+                            const absPath = resolveWorkspaceFilePath(workspaceRoot, message.relativePath);
+
+                            if (!absPath) {
+                                vscode.window.showErrorMessage(`Cannot open file outside the workspace: ${message.relativePath || ''}`);
+                                return;
+                            }
+
                             const uri = vscode.Uri.file(absPath);
                             const document = await vscode.workspace.openTextDocument(uri);
                             const editor = await vscode.window.showTextDocument(document);


### PR DESCRIPTION
## Summary
- resolve semantic search webview `openFile` targets against the active workspace root before opening them
- reject empty, non-string, absolute, or `..` paths that would leave the workspace
- keep normal in-workspace search results opening as before

## Tests
- Built core declarations with `./node_modules/.bin/tsc -p packages/core/tsconfig.json`
- Ran `./node_modules/.bin/tsc -p packages/vscode-extension/tsconfig.json --noEmit`
- Ran a direct Node regression check for `resolveWorkspaceFilePath` covering normal paths, normalized in-workspace paths, `../` escapes, absolute paths, empty values, and non-string values

Note: local `pnpm install --frozen-lockfile` completed dependency extraction but exited on the local pnpm 11 ignored-build approval policy, so validation used the installed toolchain directly.
