### PR TITLE
fix(mcp): show error when embedding model unavailable

### DIFF
--- a/packages/core/src/context.embedding-error.test.ts
+++ b/packages/core/src/context.embedding-error.test.ts
@@ -1,0 +1,170 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { Context, EmbeddingError } from './context';
+import { Embedding, EmbeddingVector } from './embedding';
+import { Splitter, CodeChunk } from './splitter';
+import { VectorDatabase } from './vectordb';
+
+type EmbeddingMode = 'throw' | 'empty' | 'short';
+
+class FailingEmbedding extends Embedding {
+    protected maxTokens = 8192;
+
+    constructor(private readonly mode: EmbeddingMode) {
+        super();
+    }
+
+    async detectDimension(): Promise<number> {
+        return 3;
+    }
+
+    async embed(_text: string): Promise<EmbeddingVector> {
+        return { vector: [1, 0, 0], dimension: 3 };
+    }
+
+    async embedBatch(texts: string[]): Promise<EmbeddingVector[]> {
+        if (this.mode === 'throw') {
+            throw new Error('quota exhausted');
+        }
+
+        if (this.mode === 'empty') {
+            return [];
+        }
+
+        return texts.slice(0, Math.max(0, texts.length - 1)).map(() => ({
+            vector: [1, 0, 0],
+            dimension: 3,
+        }));
+    }
+
+    getDimension(): number {
+        return 3;
+    }
+
+    getProvider(): string {
+        return 'test';
+    }
+}
+
+class OneChunkSplitter implements Splitter {
+    async split(code: string, language: string, filePath?: string): Promise<CodeChunk[]> {
+        return [{
+            content: code,
+            metadata: {
+                startLine: 1,
+                endLine: 1,
+                language,
+                filePath,
+            },
+        }];
+    }
+
+    setChunkSize(): void { }
+    setChunkOverlap(): void { }
+}
+
+const createVectorDatabase = (): jest.Mocked<VectorDatabase> => ({
+    createCollection: jest.fn().mockResolvedValue(undefined),
+    createHybridCollection: jest.fn().mockResolvedValue(undefined),
+    dropCollection: jest.fn().mockResolvedValue(undefined),
+    hasCollection: jest.fn().mockResolvedValue(false),
+    listCollections: jest.fn().mockResolvedValue([]),
+    insert: jest.fn().mockResolvedValue(undefined),
+    insertHybrid: jest.fn().mockResolvedValue(undefined),
+    search: jest.fn().mockResolvedValue([]),
+    hybridSearch: jest.fn().mockResolvedValue([]),
+    delete: jest.fn().mockResolvedValue(undefined),
+    query: jest.fn().mockResolvedValue([]),
+    getCollectionDescription: jest.fn().mockResolvedValue(''),
+    checkCollectionLimit: jest.fn().mockResolvedValue(true),
+    getCollectionRowCount: jest.fn().mockResolvedValue(0),
+});
+
+describe('Context embedding failure handling', () => {
+    let tempRoot: string;
+    let originalHome: string | undefined;
+    let originalHybridMode: string | undefined;
+    let originalEmbeddingBatchSize: string | undefined;
+
+    beforeEach(async () => {
+        tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-context-embedding-error-'));
+        const homeDir = path.join(tempRoot, 'home');
+        await fs.mkdir(homeDir, { recursive: true });
+        originalHome = process.env.HOME;
+        originalHybridMode = process.env.HYBRID_MODE;
+        originalEmbeddingBatchSize = process.env.EMBEDDING_BATCH_SIZE;
+        process.env.HOME = homeDir;
+        process.env.HYBRID_MODE = 'false';
+    });
+
+    afterEach(async () => {
+        if (originalHome === undefined) {
+            delete process.env.HOME;
+        } else {
+            process.env.HOME = originalHome;
+        }
+        if (originalHybridMode === undefined) {
+            delete process.env.HYBRID_MODE;
+        } else {
+            process.env.HYBRID_MODE = originalHybridMode;
+        }
+        if (originalEmbeddingBatchSize === undefined) {
+            delete process.env.EMBEDDING_BATCH_SIZE;
+        } else {
+            process.env.EMBEDDING_BATCH_SIZE = originalEmbeddingBatchSize;
+        }
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    });
+
+    async function createProject(): Promise<string> {
+        const project = path.join(tempRoot, 'project');
+        await fs.mkdir(project);
+        await fs.writeFile(path.join(project, 'one.ts'), 'const one = 1;');
+        await fs.writeFile(path.join(project, 'two.ts'), 'const two = 2;');
+        return project;
+    }
+
+    it('propagates embedding API errors instead of treating them as file skips', async () => {
+        process.env.EMBEDDING_BATCH_SIZE = '1';
+        const project = await createProject();
+        const vectorDatabase = createVectorDatabase();
+        const context = new Context({
+            embedding: new FailingEmbedding('throw'),
+            vectorDatabase,
+            codeSplitter: new OneChunkSplitter(),
+        });
+
+        await expect(context.indexCodebase(project)).rejects.toThrow(EmbeddingError);
+        expect(vectorDatabase.insert).not.toHaveBeenCalled();
+        expect(vectorDatabase.insertHybrid).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty embedding batches before inserting documents', async () => {
+        const project = await createProject();
+        const vectorDatabase = createVectorDatabase();
+        const context = new Context({
+            embedding: new FailingEmbedding('empty'),
+            vectorDatabase,
+            codeSplitter: new OneChunkSplitter(),
+        });
+
+        await expect(context.indexCodebase(project)).rejects.toThrow('Embedding API returned 0 embeddings for 2 chunks');
+        expect(vectorDatabase.insert).not.toHaveBeenCalled();
+        expect(vectorDatabase.insertHybrid).not.toHaveBeenCalled();
+    });
+
+    it('rejects embedding batches that do not match the chunk count', async () => {
+        const project = await createProject();
+        const vectorDatabase = createVectorDatabase();
+        const context = new Context({
+            embedding: new FailingEmbedding('short'),
+            vectorDatabase,
+            codeSplitter: new OneChunkSplitter(),
+        });
+
+        await expect(context.indexCodebase(project)).rejects.toThrow('Embedding API returned 1 embeddings for 2 chunks');
+        expect(vectorDatabase.insert).not.toHaveBeenCalled();
+        expect(vectorDatabase.insertHybrid).not.toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -35,6 +35,23 @@ export class IndexAbortError extends Error {
     }
 }
 
+/**
+ * Thrown when the embedding API fails (quota exhausted, auth failure,
+ * network error, etc.). Propagates through processFileList so callers
+ * can distinguish a critical embedding failure from a per-file skip.
+ *
+ * Unlike a per-file read/parse error (which is logged and skipped),
+ * an EmbeddingError is always re-thrown so that the entire indexing
+ * pipeline stops. This prevents silent partial indexing: Milvus would
+ * otherwise receive zero vectors while the snapshot marks files as done.
+ */
+export class EmbeddingError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'EmbeddingError';
+    }
+}
+
 const DEFAULT_SUPPORTED_EXTENSIONS = [
     // Programming languages
     '.ts', '.tsx', '.js', '.jsx', '.py', '.java', '.cpp', '.c', '.h', '.hpp',
@@ -877,6 +894,10 @@ export class Context {
                         try {
                             await this.processChunkBuffer(chunkBuffer);
                         } catch (error) {
+                            // Embedding errors (such as API having no quota) halt the entire indexing process and propagate upwards.
+                            if (error instanceof EmbeddingError) {
+                                throw error;
+                            }
                             const searchType = isHybrid === true ? 'hybrid' : 'regular';
                             console.error(`[Context] ❌ Failed to process chunk batch for ${searchType}:`, error);
                             if (error instanceof Error) {
@@ -903,6 +924,9 @@ export class Context {
                 }
 
             } catch (error) {
+                if (error instanceof EmbeddingError) {
+                    throw error;
+                }
                 console.warn(`[Context] ⚠️  Skipping file ${filePath}: ${error}`);
             }
         }
@@ -914,6 +938,9 @@ export class Context {
             try {
                 await this.processChunkBuffer(chunkBuffer);
             } catch (error) {
+                if (error instanceof EmbeddingError) {
+                    throw error;
+                }
                 console.error(`[Context] ❌ Failed to process final chunk batch for ${searchType}:`, error);
                 if (error instanceof Error) {
                     console.error('[Context] Stack trace:', error.stack);
@@ -959,7 +986,18 @@ export class Context {
 
         // Generate embedding vectors
         const chunkContents = chunks.map(chunk => chunk.content);
-        const embeddings = await this.embedding.embedBatch(chunkContents);
+
+        let embeddings: EmbeddingVector[];
+        try {
+            embeddings = await this.embedding.embedBatch(chunkContents);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            // Include batch size in the log/error message so operators can
+            // identify how many chunks were lost when the API call failed.
+            console.error(`[Context] ❌ Embedding API failed (batch size: ${chunkContents.length}): ${errorMessage}`);
+            throw new EmbeddingError(`Embedding API error (batch size: ${chunkContents.length}): ${errorMessage}`);
+        }
+        this.validateEmbeddings(embeddings, chunks.length);
 
         if (isHybrid === true) {
             // Create hybrid vector documents
@@ -1022,6 +1060,39 @@ export class Context {
             // Store to vector database
             await this.vectorDatabase.insert(this.getCollectionName(codebasePath), documents);
         }
+    }
+
+    /**
+     * Validate that the embedding batch response is well-formed before writing
+     * any vectors to Milvus. Throwing EmbeddingError here aborts the entire
+     * indexing run so that no partial / empty vectors are persisted.
+     *
+     * @param embeddings   - Array of embedding vectors returned by the API.
+     * @param expectedCount - Number of chunks submitted in the batch request.
+     * @throws EmbeddingError if the response is missing, mismatched, or contains
+     *         any empty vector.
+     * @returns void
+     */
+    private validateEmbeddings(embeddings: EmbeddingVector[], expectedCount: number): void {
+        // Guard against non-array return values (e.g. API returning null or an
+        // error object instead of throwing).
+        if (!Array.isArray(embeddings)) {
+            throw new EmbeddingError('Embedding API returned invalid embedding batch response');
+        }
+
+        // A partial response would silently mis-align embeddings[i] with chunks[i],
+        // producing wrong vectors in Milvus — treat it as a hard failure.
+        if (embeddings.length !== expectedCount) {
+            throw new EmbeddingError(`Embedding API returned ${embeddings.length} embeddings for ${expectedCount} chunks`);
+        }
+
+        // Check each vector; an empty vector inserted into Milvus
+        // would corrupt search results for that chunk's file.
+        embeddings.forEach((embedding, index) => {
+            if (!embedding || !Array.isArray(embedding.vector) || embedding.vector.length === 0) {
+                throw new EmbeddingError(`Embedding API returned empty embedding vector at index ${index}`);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Description:                                                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                  Summary                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  Fixes a bug where the context indexing pipeline silently skips files and submits empty/incomplete vectors to Milvus when the embedding API is unavailable (quota exhausted, auth failure, network error, etc.). Previously, embedding API errors were swallowed, resulting in partially indexed snapshots with empty data.                                                       
   
  Changes                                                                                                                                                                                                                                                                                                                                                                                                                        
                  
  - New EmbeddingError exception class: Distinguishes critical embedding failures from per-file read/parse skips. An EmbeddingError aborts the entire indexing run rather than silently continuing.                                                                                                                                                                                                                              
  - New validateEmbeddings method: Validates embedding batch responses before writing to Milvus, checking for:
    - Valid array return value                                                                                                                                                                                                                                                                                                                                                                                                   
    - Embedding count matching chunk count                                                                                                                                                                                                                                                                                                                                                                                       
    - Non-empty vectors                                                                                                                                                                                                                                                                                                                                                                                                          
  - Propagate EmbeddingError through processChunkBuffer and processFileList: Ensures the error propagates upward and indexing stops immediately when the embedding API fails.                                                                                                                                                                                                                                                    
  - Comprehensive test coverage (context.embedding-error.test.ts): Covers three failure scenarios:                                                                                                                                                                                                                                                                                                                               
    - API throws an exception (e.g., quota exhausted)                                                                                                                                                                                                                                                                                                                                                                            
    - API returns an empty array                                                                                                                                                                                                                                                                                                                                                                                                 
    - API returns mismatched vector count                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  Test plan                                                                                                                                                                                                                                                                                                                                                                                                                      
                  
  - Unit tests pass — all three failure scenarios covered (exception, empty batch, mismatched count)                                                                                                                                                                                                                                                                                                                             
  - Verified that MCP correctly displays an error message when the embedding model is unavailable, instead of silently skipping

Now


<img width="937" height="612" alt="image" src="https://github.com/user-attachments/assets/afcb4b02-6912-4b33-89a3-c65de89220bb" />
<img width="937" height="612" alt="image" src="https://github.com/user-attachments/assets/6eda0725-4177-4cd8-a2a1-3ae131cc1b1f" />
