### PR TITLE
feat(vscode): index custom subfolders with multi-folder search and excludes

### DIFF
--- a/packages/core/src/context.default-ignore.test.ts
+++ b/packages/core/src/context.default-ignore.test.ts
@@ -1,0 +1,14 @@
+import { DEFAULT_IGNORE_PATTERNS } from './context';
+
+describe('DEFAULT_IGNORE_PATTERNS', () => {
+    it('ignores Python virtualenv folders', () => {
+        expect(DEFAULT_IGNORE_PATTERNS).toContain('venv/**');
+        expect(DEFAULT_IGNORE_PATTERNS).toContain('.venv/**');
+        expect(DEFAULT_IGNORE_PATTERNS).toContain('venv');
+        expect(DEFAULT_IGNORE_PATTERNS).toContain('.venv');
+    });
+
+    it('still ignores node_modules', () => {
+        expect(DEFAULT_IGNORE_PATTERNS).toContain('node_modules');
+    });
+});

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -63,7 +63,7 @@ const DEFAULT_SUPPORTED_EXTENSIONS = [
     // '.css', '.scss', '.less', '.sql', '.sh', '.bash', '.env'
 ];
 
-const DEFAULT_IGNORE_PATTERNS = [
+export const DEFAULT_IGNORE_PATTERNS = [
     // Common build output and dependency directories
     'node_modules/**',
     'dist/**',
@@ -89,6 +89,10 @@ const DEFAULT_IGNORE_PATTERNS = [
     '__pycache__/**',
     '.pytest_cache/**',
 
+    // Python virtual environments
+    'venv/**',
+    '.venv/**',
+
     // Logs and temporary files
     'logs/**',
     'tmp/**',
@@ -113,7 +117,7 @@ const DEFAULT_IGNORE_PATTERNS = [
     '*.map', // source map files
     'node_modules', '.git', '.svn', '.hg', 'build', 'dist', 'out',
     'target', '.vscode', '.idea', '__pycache__', '.pytest_cache',
-    'coverage', '.nyc_output', 'logs', 'tmp', 'temp'
+    'coverage', '.nyc_output', 'logs', 'tmp', 'temp', 'venv', '.venv'
 ];
 
 export interface ContextConfig {

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -94,9 +94,20 @@ MILVUS_TOKEN=your-zilliz-cloud-api-key
    - Open Command Palette (Ctrl+Shift+P or Cmd+Shift+P on Mac)
    - Run "Semantic Code Search: Index Codebase"
 
+   Or use the panel for finer control:
+   - **Folder(s) to index**: leave empty to index the whole workspace, or
+     enter one or more paths (comma- or newline-separated) relative to the
+     workspace root to index only those subfolders — for example `backend, frontend/src`.
+     Each folder is indexed into its own collection, and search fans out across
+     all of them.
+   - **Exclude folders**: glob patterns to skip inside the indexed folders,
+     for example `dist, **/*.test.ts`. `node_modules`, `venv`, and `.venv`
+     are ignored by default.
+
 3. **Start Searching**:
    - Open Semantic Code Search panel in sidebar
    - Enter search query or right-click on selected code to search
+   - Results are tagged with the folder they came from
 
 ## Commands
 

--- a/packages/vscode-extension/jest.config.cjs
+++ b/packages/vscode-extension/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    testMatch: ['<rootDir>/src/**/*.test.ts'],
+};

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -171,6 +171,7 @@
         "lint": "eslint src",
         "lint:fix": "eslint src --fix",
         "typecheck": "tsc --noEmit",
+        "test": "jest --runInBand",
         "package": "vsce package --no-dependencies",
         "release": "vsce publish --no-dependencies"
     },
@@ -179,6 +180,7 @@
         "web-tree-sitter": "^0.25.6"
     },
     "devDependencies": {
+        "@types/jest": "^30.0.0",
         "@types/node": "20.x",
         "@types/vscode": "^1.74.0",
         "@typescript-eslint/eslint-plugin": "^8.31.1",
@@ -186,7 +188,9 @@
         "@vscode/vsce": "^3.4.0",
         "copy-webpack-plugin": "^12.0.2",
         "eslint": "^9.25.1",
+        "jest": "^30.0.0",
         "source-map-loader": "^5.0.0",
+        "ts-jest": "^29.4.0",
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.3",
         "webpack": "^5.99.9",

--- a/packages/vscode-extension/src/commands/indexCommand.ts
+++ b/packages/vscode-extension/src/commands/indexCommand.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { Context } from '@zilliz/claude-context-core';
 import * as path from 'path';
+import * as fs from 'fs';
 
 export class IndexCommand {
     private context: Context;
@@ -133,6 +134,85 @@ export class IndexCommand {
                 vscode.window.showErrorMessage(`❌ Indexing failed: ${errorString}`);
             }
         }
+    }
+
+    /**
+     * Index a single absolute folder path with the given extra ignore patterns.
+     * Clears any existing index for that folder first.
+     */
+    private async indexOneFolder(
+        folderPath: string,
+        excludePatterns: string[],
+        progress: vscode.Progress<{ increment?: number; message?: string }>,
+        label: string
+    ): Promise<{ indexedFiles: number; totalChunks: number; status: 'completed' | 'limit_reached' }> {
+        let lastPercentage = 0;
+
+        await this.context.clearIndex(folderPath, (info) => {
+            progress.report({ increment: 0, message: `${label} ${info.phase}` });
+        });
+
+        const { FileSynchronizer } = await import('@zilliz/claude-context-core');
+        const ignorePatterns = [...(this.context.getIgnorePatterns() || []), ...excludePatterns];
+        const synchronizer = new FileSynchronizer(
+            folderPath,
+            ignorePatterns,
+            this.context.getSupportedExtensions() || []
+        );
+        await synchronizer.initialize();
+        await this.context.getPreparedCollection(folderPath);
+        const collectionName = this.context.getCollectionName(folderPath);
+        this.context.setSynchronizer(collectionName, synchronizer);
+
+        return this.context.indexCodebase(
+            folderPath,
+            (info) => {
+                const increment = info.percentage - lastPercentage;
+                lastPercentage = info.percentage;
+                progress.report({ increment, message: `${label} ${info.phase}` });
+            },
+            false,
+            excludePatterns
+        );
+    }
+
+    /**
+     * Index a list of absolute folder paths (webview entry point).
+     * @param folders absolute folder paths (already validated/resolved by the caller)
+     * @param excludePatterns extra ignore patterns applied to every folder
+     * @returns the folders that were successfully indexed, plus aggregate stats
+     */
+    async executeForWebview(
+        folders: string[],
+        excludePatterns: string[]
+    ): Promise<{ indexedPaths: string[]; indexedFiles: number; totalChunks: number }> {
+        // Validate every folder exists and is a directory before doing any work.
+        for (const folder of folders) {
+            if (!fs.existsSync(folder) || !fs.statSync(folder).isDirectory()) {
+                throw new Error(`Not a folder: ${folder}`);
+            }
+        }
+
+        const indexedPaths: string[] = [];
+        let indexedFiles = 0;
+        let totalChunks = 0;
+
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Indexing Codebase',
+            cancellable: false
+        }, async (progress) => {
+            for (let i = 0; i < folders.length; i++) {
+                const folder = folders[i];
+                const label = folders.length > 1 ? `(${i + 1}/${folders.length} ${path.basename(folder)})` : '';
+                const stats = await this.indexOneFolder(folder, excludePatterns, progress, label);
+                indexedPaths.push(folder);
+                indexedFiles += stats.indexedFiles;
+                totalChunks += stats.totalChunks;
+            }
+        });
+
+        return { indexedPaths, indexedFiles, totalChunks };
     }
 
     async clearIndex(): Promise<void> {

--- a/packages/vscode-extension/src/commands/searchCommand.ts
+++ b/packages/vscode-extension/src/commands/searchCommand.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { Context, SearchQuery, SemanticSearchResult } from '@zilliz/claude-context-core';
 import * as path from 'path';
+import { TaggedResult, mergeAndSortResults } from '../utils/pathUtils';
 
 export class SearchCommand {
     private context: Context;
@@ -164,25 +165,29 @@ export class SearchCommand {
     }
 
     /**
-     * Execute search for webview (without UI prompts)
+     * Execute search across one or more indexed folders (webview entry point).
+     * @param searchTerm query string
+     * @param limit max merged results
+     * @param fileExtensions optional extension filter (e.g. ['.ts'])
+     * @param indexedPaths absolute folder paths to search; empty => workspace root
      */
-    async executeForWebview(searchTerm: string, limit: number = 50, fileExtensions: string[] = []): Promise<SemanticSearchResult[]> {
-        // Get workspace root for codebase path
-        const workspaceFolders = vscode.workspace.workspaceFolders;
-        if (!workspaceFolders || workspaceFolders.length === 0) {
-            throw new Error('No workspace folder found. Please open a folder first.');
+    async executeForWebview(
+        searchTerm: string,
+        limit: number = 50,
+        fileExtensions: string[] = [],
+        indexedPaths: string[] = []
+    ): Promise<TaggedResult[]> {
+        // Determine which folders to search. Fall back to the workspace root.
+        let folders = indexedPaths.filter(Boolean);
+        if (folders.length === 0) {
+            const workspaceFolders = vscode.workspace.workspaceFolders;
+            if (!workspaceFolders || workspaceFolders.length === 0) {
+                throw new Error('No workspace folder found. Please open a folder first.');
+            }
+            folders = [workspaceFolders[0].uri.fsPath];
         }
-        const codebasePath = workspaceFolders[0].uri.fsPath;
 
-        // Check if index exists
-        const hasIndex = await this.context.hasIndex(codebasePath);
-        if (!hasIndex) {
-            throw new Error('Index not found. Please index the codebase first.');
-        }
-
-        console.log('🔍 Using semantic search for webview...');
-
-        // Validate extensions strictly and build filter expression
+        // Build the extension filter expression (unchanged validation rules).
         let filterExpr: string | undefined = undefined;
         if (fileExtensions && fileExtensions.length > 0) {
             const invalid = fileExtensions.filter(e => !(typeof e === 'string' && e.startsWith('.') && e.length > 1 && !/\s/.test(e)));
@@ -193,14 +198,35 @@ export class SearchCommand {
             filterExpr = `fileExtension in [${quoted}]`;
         }
 
-        let results = await this.context.semanticSearch(
-            codebasePath,
-            searchTerm,
-            limit,
-            0.3, // similarity threshold
-            filterExpr
+        // Only search folders that actually have an index. Skip the rest.
+        const indexedOnly: string[] = [];
+        for (const folder of folders) {
+            if (await this.context.hasIndex(folder)) {
+                indexedOnly.push(folder);
+            } else {
+                console.warn(`[Search] Skipping folder without an index: ${folder}`);
+            }
+        }
+        if (indexedOnly.length === 0) {
+            throw new Error('Index not found. Please index the codebase first.');
+        }
+
+        // Fan out: one semantic search per folder, in parallel.
+        const perFolder: TaggedResult[][] = await Promise.all(
+            indexedOnly.map(async folder => {
+                const results = await this.context.semanticSearch(folder, searchTerm, limit, 0.3, filterExpr);
+                return results.map(r => this.tagResult(r, folder));
+            })
         );
-        return results;
+
+        return mergeAndSortResults(perFolder, limit);
+    }
+
+    /** Attach origin folder + absolute path to a raw search result. */
+    private tagResult(result: SemanticSearchResult, folder: string): TaggedResult {
+        const isAbsolute = result.relativePath.startsWith('/') || result.relativePath.includes(':');
+        const absolutePath = isAbsolute ? result.relativePath : path.join(folder, result.relativePath);
+        return { ...result, searchFolder: folder, absolutePath };
     }
 
     /**

--- a/packages/vscode-extension/src/commands/syncCommand.ts
+++ b/packages/vscode-extension/src/commands/syncCommand.ts
@@ -1,13 +1,41 @@
 import * as vscode from 'vscode';
 import { Context } from '@zilliz/claude-context-core';
 import * as fs from 'fs';
+import { parseListInput } from '../utils/pathUtils';
+import { STATE_INDEXED_PATHS, STATE_EXCLUDE_INPUT } from '../utils/stateKeys';
 
 export class SyncCommand {
     private context: Context;
     private isSyncing: boolean = false;
+    private extensionContext: vscode.ExtensionContext;
 
-    constructor(context: Context) {
+    constructor(context: Context, extensionContext: vscode.ExtensionContext) {
         this.context = context;
+        this.extensionContext = extensionContext;
+    }
+
+    /**
+     * Resolve the folders auto-sync/sync should operate on.
+     * Uses the indexed-folder list when present; otherwise falls back to the
+     * first workspace folder (the pre-subfolder behavior). Only existing folders
+     * are returned. Also returns the saved exclude patterns to reapply.
+     */
+    private getSyncTargets(): { folders: string[]; excludes: string[] } {
+        const excludes = parseListInput(
+            this.extensionContext.workspaceState.get<string>(STATE_EXCLUDE_INPUT, '')
+        );
+
+        const indexedPaths = this.extensionContext.workspaceState.get<string[]>(STATE_INDEXED_PATHS, []);
+        let folders = indexedPaths.filter(Boolean);
+        if (folders.length === 0) {
+            const workspaceFolders = vscode.workspace.workspaceFolders;
+            folders = workspaceFolders && workspaceFolders.length > 0
+                ? [workspaceFolders[0].uri.fsPath]
+                : [];
+        }
+
+        folders = folders.filter(p => fs.existsSync(p));
+        return { folders, excludes };
     }
 
     /**
@@ -32,59 +60,56 @@ export class SyncCommand {
             return;
         }
 
-        // Use the first workspace folder as target
-        const targetFolder = workspaceFolders[0];
-        const codebasePath = targetFolder.uri.fsPath;
-
-        // Check if the workspace folder exists
-        if (!fs.existsSync(codebasePath)) {
-            vscode.window.showErrorMessage(`Workspace folder '${codebasePath}' does not exist.`);
+        const { folders, excludes } = this.getSyncTargets();
+        if (folders.length === 0) {
+            vscode.window.showErrorMessage('No indexed folder found to sync.');
             return;
         }
 
-        console.log(`[SYNC] Starting sync for current workspace: ${codebasePath}`);
+        console.log(`[SYNC] Starting sync for ${folders.length} folder(s): ${folders.join(', ')}`);
 
         this.isSyncing = true;
 
         try {
-            let syncStats: { added: number; removed: number; modified: number } | undefined;
+            let added = 0, removed = 0, modified = 0;
 
             await vscode.window.withProgress({
                 location: vscode.ProgressLocation.Notification,
                 title: 'Syncing Workspace Index',
                 cancellable: false
             }, async (progress) => {
-                progress.report({ increment: 0, message: 'Checking for file changes...' });
-
-                try {
-                    syncStats = await this.context.reindexByChange(
-                        codebasePath,
-                        (progressInfo) => {
-                            const increment = progressInfo.percentage;
-                            progress.report({
-                                increment: increment,
-                                message: progressInfo.phase
-                            });
-                        }
-                    );
-                } catch (error: any) {
-                    console.error(`[SYNC] Error syncing workspace '${codebasePath}':`, error);
-                    throw error;
+                for (const codebasePath of folders) {
+                    progress.report({ increment: 0, message: `Checking ${codebasePath}...` });
+                    try {
+                        const stats = await this.context.reindexByChange(
+                            codebasePath,
+                            (progressInfo) => {
+                                progress.report({
+                                    increment: progressInfo.percentage,
+                                    message: progressInfo.phase
+                                });
+                            },
+                            excludes
+                        );
+                        added += stats.added;
+                        removed += stats.removed;
+                        modified += stats.modified;
+                    } catch (error: any) {
+                        console.error(`[SYNC] Error syncing '${codebasePath}':`, error);
+                        throw error;
+                    }
                 }
             });
 
-            if (syncStats) {
-                const totalChanges = syncStats.added + syncStats.removed + syncStats.modified;
-
-                if (totalChanges > 0) {
-                    vscode.window.showInformationMessage(
-                        `✅ Sync complete!\n\nAdded: ${syncStats.added}, Removed: ${syncStats.removed}, Modified: ${syncStats.modified} files.`
-                    );
-                    console.log(`[SYNC] Sync complete for '${codebasePath}'. Added: ${syncStats.added}, Removed: ${syncStats.removed}, Modified: ${syncStats.modified}`);
-                } else {
-                    vscode.window.showInformationMessage('✅ Sync complete! No changes detected.');
-                    console.log(`[SYNC] No changes detected for '${codebasePath}'`);
-                }
+            const totalChanges = added + removed + modified;
+            if (totalChanges > 0) {
+                vscode.window.showInformationMessage(
+                    `✅ Sync complete!\n\nAdded: ${added}, Removed: ${removed}, Modified: ${modified} files.`
+                );
+                console.log(`[SYNC] Sync complete. Added: ${added}, Removed: ${removed}, Modified: ${modified}`);
+            } else {
+                vscode.window.showInformationMessage('✅ Sync complete! No changes detected.');
+                console.log('[SYNC] No changes detected');
             }
 
         } catch (error: any) {
@@ -92,7 +117,7 @@ export class SyncCommand {
             vscode.window.showErrorMessage(`❌ Sync failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
         } finally {
             this.isSyncing = false;
-            console.log(`[SYNC] Sync process finished for workspace: ${codebasePath}`);
+            console.log('[SYNC] Sync process finished');
         }
     }
 
@@ -125,43 +150,44 @@ export class SyncCommand {
      * Silent sync - runs without progress notifications, used for auto-sync
      */
     async executeSilent(): Promise<void> {
-        const workspaceFolders = vscode.workspace.workspaceFolders;
-        if (!workspaceFolders || workspaceFolders.length === 0) {
-            return;
-        }
-
         if (this.isSyncing) {
             console.log('[AUTO-SYNC] Sync already in progress, skipping...');
             return;
         }
 
-        const targetFolder = workspaceFolders[0];
-        const codebasePath = targetFolder.uri.fsPath;
-
-        if (!fs.existsSync(codebasePath)) {
-            console.warn(`[AUTO-SYNC] Workspace folder '${codebasePath}' does not exist`);
+        const { folders, excludes } = this.getSyncTargets();
+        if (folders.length === 0) {
             return;
         }
 
-        console.log(`[AUTO-SYNC] Starting silent sync for: ${codebasePath}`);
+        console.log(`[AUTO-SYNC] Starting silent sync for ${folders.length} folder(s)`);
 
         this.isSyncing = true;
 
         try {
-            const syncStats = await this.context.reindexByChange(codebasePath);
+            let added = 0, removed = 0, modified = 0;
+            for (const codebasePath of folders) {
+                // Skip folders that were never indexed (no collection yet) so we
+                // don't attempt to insert into a non-existent collection.
+                if (!(await this.context.hasIndex(codebasePath))) {
+                    console.log(`[AUTO-SYNC] Skipping un-indexed folder: ${codebasePath}`);
+                    continue;
+                }
+                const stats = await this.context.reindexByChange(codebasePath, undefined, excludes);
+                added += stats.added;
+                removed += stats.removed;
+                modified += stats.modified;
+            }
 
-            const totalChanges = syncStats.added + syncStats.removed + syncStats.modified;
-
+            const totalChanges = added + removed + modified;
             if (totalChanges > 0) {
-                console.log(`[AUTO-SYNC] Silent sync complete for '${codebasePath}'. Added: ${syncStats.added}, Removed: ${syncStats.removed}, Modified: ${syncStats.modified}`);
-
-                // Show a subtle notification for auto-sync changes
+                console.log(`[AUTO-SYNC] Silent sync complete. Added: ${added}, Removed: ${removed}, Modified: ${modified}`);
                 vscode.window.showInformationMessage(
                     `🔄 Index auto-updated: ${totalChanges} file changes detected`,
                     { modal: false }
                 );
             } else {
-                console.log(`[AUTO-SYNC] No changes detected for '${codebasePath}'`);
+                console.log('[AUTO-SYNC] No changes detected');
             }
 
         } catch (error: any) {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -28,7 +28,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Initialize providers and commands
     searchCommand = new SearchCommand(codeContext);
     indexCommand = new IndexCommand(codeContext);
-    syncCommand = new SyncCommand(codeContext);
+    syncCommand = new SyncCommand(codeContext, context);
     semanticSearchProvider = new SemanticSearchViewProvider(context.extensionUri, searchCommand, indexCommand, syncCommand, configManager, context);
 
     // Register command handlers

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -29,7 +29,7 @@ export async function activate(context: vscode.ExtensionContext) {
     searchCommand = new SearchCommand(codeContext);
     indexCommand = new IndexCommand(codeContext);
     syncCommand = new SyncCommand(codeContext);
-    semanticSearchProvider = new SemanticSearchViewProvider(context.extensionUri, searchCommand, indexCommand, syncCommand, configManager);
+    semanticSearchProvider = new SemanticSearchViewProvider(context.extensionUri, searchCommand, indexCommand, syncCommand, configManager, context);
 
     // Register command handlers
     const disposables = [

--- a/packages/vscode-extension/src/utils/pathUtils.test.ts
+++ b/packages/vscode-extension/src/utils/pathUtils.test.ts
@@ -1,0 +1,66 @@
+import * as path from 'path';
+import {
+    parseListInput,
+    resolveIndexFolders,
+    mergeAndSortResults,
+    TaggedResult,
+} from './pathUtils';
+
+describe('parseListInput', () => {
+    it('splits on commas and newlines, trims, drops empties, dedupes', () => {
+        expect(parseListInput('a, b\nc,,a\n  ')).toEqual(['a', 'b', 'c']);
+    });
+    it('returns [] for empty/whitespace', () => {
+        expect(parseListInput('   ')).toEqual([]);
+        expect(parseListInput('')).toEqual([]);
+    });
+});
+
+describe('resolveIndexFolders', () => {
+    const root = path.resolve('/work/main');
+
+    it('resolves relative subfolders against the workspace root', () => {
+        const r = resolveIndexFolders('sub1, sub2', root);
+        expect(r.errors).toEqual([]);
+        expect(r.resolved).toEqual([path.join(root, 'sub1'), path.join(root, 'sub2')]);
+    });
+
+    it('falls back to [root] when input is empty', () => {
+        const r = resolveIndexFolders('', root);
+        expect(r.resolved).toEqual([root]);
+        expect(r.errors).toEqual([]);
+    });
+
+    it('treats the root itself as valid', () => {
+        const r = resolveIndexFolders('.', root);
+        expect(r.resolved).toEqual([root]);
+    });
+
+    it('rejects paths that escape the workspace root', () => {
+        const r = resolveIndexFolders('../outside', root);
+        expect(r.resolved).toEqual([]);
+        expect(r.errors.length).toBe(1);
+        expect(r.errors[0]).toContain('../outside');
+    });
+
+    it('accepts an absolute path inside the workspace', () => {
+        const inside = path.join(root, 'sub1');
+        const r = resolveIndexFolders(inside, root);
+        expect(r.resolved).toEqual([inside]);
+        expect(r.errors).toEqual([]);
+    });
+});
+
+describe('mergeAndSortResults', () => {
+    it('flattens, sorts by score desc, and applies the limit', () => {
+        const a: TaggedResult[] = [
+            { relativePath: 'x', score: 0.4, searchFolder: '/f1', absolutePath: '/f1/x' } as TaggedResult,
+        ];
+        const b: TaggedResult[] = [
+            { relativePath: 'y', score: 0.9, searchFolder: '/f2', absolutePath: '/f2/y' } as TaggedResult,
+            { relativePath: 'z', score: 0.7, searchFolder: '/f2', absolutePath: '/f2/z' } as TaggedResult,
+        ];
+        const merged = mergeAndSortResults([a, b], 2);
+        expect(merged.map(r => r.relativePath)).toEqual(['y', 'z']);
+    });
+});

--- a/packages/vscode-extension/src/utils/pathUtils.ts
+++ b/packages/vscode-extension/src/utils/pathUtils.ts
@@ -1,0 +1,73 @@
+import * as path from 'path';
+import { SemanticSearchResult } from '@zilliz/claude-context-core';
+
+/** A search result tagged with the folder (codebasePath) it came from. */
+export interface TaggedResult extends SemanticSearchResult {
+    /** The indexed folder (absolute codebasePath) this result was found in. */
+    searchFolder: string;
+    /** Absolute path to the file on disk. */
+    absolutePath: string;
+}
+
+/** Split a comma/newline separated string into a trimmed, de-duplicated, non-empty list. */
+export function parseListInput(raw: string): string[] {
+    if (!raw) {
+        return [];
+    }
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const part of raw.split(/[\n,]/)) {
+        const trimmed = part.trim();
+        if (trimmed.length > 0 && !seen.has(trimmed)) {
+            seen.add(trimmed);
+            out.push(trimmed);
+        }
+    }
+    return out;
+}
+
+/**
+ * Resolve folder-input entries to absolute paths inside the workspace root.
+ * Empty input falls back to [workspaceRoot]. Entries that escape the root are
+ * reported as errors and excluded from `resolved`.
+ */
+export function resolveIndexFolders(
+    raw: string,
+    workspaceRoot: string
+): { resolved: string[]; errors: string[] } {
+    const root = path.resolve(workspaceRoot);
+    const entries = parseListInput(raw);
+    if (entries.length === 0) {
+        return { resolved: [root], errors: [] };
+    }
+
+    const resolved: string[] = [];
+    const errors: string[] = [];
+    const seen = new Set<string>();
+
+    for (const entry of entries) {
+        const abs = path.isAbsolute(entry) ? path.resolve(entry) : path.resolve(root, entry);
+        const rel = path.relative(root, abs);
+        const escapes = rel.startsWith('..') || path.isAbsolute(rel);
+        if (escapes) {
+            errors.push(`Folder is outside the workspace: ${entry}`);
+            continue;
+        }
+        if (!seen.has(abs)) {
+            seen.add(abs);
+            resolved.push(abs);
+        }
+    }
+
+    return { resolved, errors };
+}
+
+/** Flatten per-folder result arrays, sort by score descending, take top `limit`. */
+export function mergeAndSortResults(perFolder: TaggedResult[][], limit: number): TaggedResult[] {
+    const all: TaggedResult[] = [];
+    for (const group of perFolder) {
+        all.push(...group);
+    }
+    all.sort((a, b) => b.score - a.score);
+    return all.slice(0, limit);
+}

--- a/packages/vscode-extension/src/utils/stateKeys.ts
+++ b/packages/vscode-extension/src/utils/stateKeys.ts
@@ -1,0 +1,7 @@
+/**
+ * workspaceState keys shared across the extension.
+ * Centralized so the provider (writer) and SyncCommand (reader) stay in sync.
+ */
+export const STATE_INDEXED_PATHS = 'semanticCodeSearch.indexedPaths';
+export const STATE_FOLDER_INPUT = 'semanticCodeSearch.folderInput';
+export const STATE_EXCLUDE_INPUT = 'semanticCodeSearch.excludeInput';

--- a/packages/vscode-extension/src/webview/scripts/semanticSearch.js
+++ b/packages/vscode-extension/src/webview/scripts/semanticSearch.js
@@ -23,6 +23,8 @@ class SemanticSearchController {
         // Search view elements
         this.searchInput = document.getElementById('searchInput');
         this.extFilterInput = document.getElementById('extFilterInput');
+        this.folderInput = document.getElementById('folderInput');
+        this.excludeInput = document.getElementById('excludeInput');
         this.searchButton = document.getElementById('searchButton');
         this.indexButton = document.getElementById('indexButton');
         this.settingsButton = document.getElementById('settingsButton');
@@ -82,7 +84,8 @@ class SemanticSearchController {
                     item.dataset.path,
                     Number(item.dataset.line),
                     Number(item.dataset.startLine),
-                    Number(item.dataset.endLine)
+                    Number(item.dataset.endLine),
+                    item.dataset.abspath
                 );
             }
         });
@@ -126,7 +129,9 @@ class SemanticSearchController {
         this.indexButton.textContent = 'Indexing...';
         this.indexButton.disabled = true;
         this.vscode.postMessage({
-            command: 'index'
+            command: 'index',
+            folderInput: (this.folderInput && this.folderInput.value) || '',
+            excludeInput: (this.excludeInput && this.excludeInput.value) || ''
         });
     }
 
@@ -245,6 +250,7 @@ class SemanticSearchController {
         return `
             <div class="result-item"
                  data-path="${this.escapeHtml(result.relativePath)}"
+                 data-abspath="${this.escapeHtml(result.absolutePath || '')}"
                  data-line="${Number(result.line) || 0}"
                  data-start-line="${Number(startLine) || 0}"
                  data-end-line="${Number(endLine) || 0}">
@@ -266,10 +272,11 @@ class SemanticSearchController {
      * @param {number} startLine - Start line
      * @param {number} endLine - End line
      */
-    openFile(relativePath, line, startLine, endLine) {
+    openFile(relativePath, line, startLine, endLine, absolutePath) {
         this.vscode.postMessage({
             command: 'openFile',
             relativePath: relativePath,
+            absolutePath: absolutePath || '',
             line: line,
             startLine: startLine,
             endLine: endLine
@@ -289,8 +296,13 @@ class SemanticSearchController {
                 break;
 
             case 'indexComplete':
-                this.indexButton.textContent = 'Index Current Codebase';
+                this.indexButton.textContent = 'Index Folder(s)';
                 this.indexButton.disabled = false;
+                break;
+
+            case 'indexConfigData':
+                if (this.folderInput) { this.folderInput.value = message.folderInput || ''; }
+                if (this.excludeInput) { this.excludeInput.value = message.excludeInput || ''; }
                 break;
 
             case 'updateIndexStatus':

--- a/packages/vscode-extension/src/webview/semanticSearchProvider.ts
+++ b/packages/vscode-extension/src/webview/semanticSearchProvider.ts
@@ -5,6 +5,11 @@ import { IndexCommand } from '../commands/indexCommand';
 import { SyncCommand } from '../commands/syncCommand';
 import { ConfigManager, EmbeddingProviderConfig } from '../config/configManager';
 import * as path from 'path';
+import { resolveIndexFolders, parseListInput } from '../utils/pathUtils';
+
+const STATE_INDEXED_PATHS = 'semanticCodeSearch.indexedPaths';
+const STATE_FOLDER_INPUT = 'semanticCodeSearch.folderInput';
+const STATE_EXCLUDE_INPUT = 'semanticCodeSearch.excludeInput';
 
 export class SemanticSearchViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'semanticSearchView';
@@ -13,7 +18,14 @@ export class SemanticSearchViewProvider implements vscode.WebviewViewProvider {
     private syncCommand: SyncCommand;
     private configManager: ConfigManager;
 
-    constructor(private readonly _extensionUri: vscode.Uri, searchCommand: SearchCommand, indexCommand: IndexCommand, syncCommand: SyncCommand, configManager: ConfigManager) {
+    constructor(
+        private readonly _extensionUri: vscode.Uri,
+        searchCommand: SearchCommand,
+        indexCommand: IndexCommand,
+        syncCommand: SyncCommand,
+        configManager: ConfigManager,
+        private readonly _extensionContext: vscode.ExtensionContext
+    ) {
         this.searchCommand = searchCommand;
         this.indexCommand = indexCommand;
         this.syncCommand = syncCommand;
@@ -53,6 +65,9 @@ export class SemanticSearchViewProvider implements vscode.WebviewViewProvider {
         // Send initial configuration data to webview
         this.sendCurrentConfig(webviewView.webview);
 
+        // Send saved folder/exclude inputs to prefill the panel
+        this.sendIndexConfig(webviewView.webview);
+
         // Handle messages from webview
         webviewView.webview.onDidReceiveMessage(
             async message => {
@@ -76,11 +91,13 @@ export class SemanticSearchViewProvider implements vscode.WebviewViewProvider {
 
                     case 'search':
                         try {
-                            // Use search command
+                            // Use search command across all indexed folders
+                            const indexedPaths = this._extensionContext.workspaceState.get<string[]>(STATE_INDEXED_PATHS, []);
                             const searchResults = await this.searchCommand.executeForWebview(
                                 message.text,
                                 50,
-                                Array.isArray(message.fileExtensions) ? message.fileExtensions : []
+                                Array.isArray(message.fileExtensions) ? message.fileExtensions : [],
+                                indexedPaths
                             );
 
                             // Convert SemanticSearchResult[] to webview format
@@ -107,30 +124,54 @@ export class SemanticSearchViewProvider implements vscode.WebviewViewProvider {
                         return;
 
                     case 'index':
-                        // Handle index command
                         try {
-                            await this.indexCommand.execute();
-                            // Notify webview that indexing is complete and check index status
-                            webviewView.webview.postMessage({
-                                command: 'indexComplete'
-                            });
-                            // Update index status after completion
-                            await this.checkIndexStatusAndUpdateWebview(webviewView.webview);
+                            const workspaceFolders = vscode.workspace.workspaceFolders;
+                            if (!workspaceFolders || workspaceFolders.length === 0) {
+                                throw new Error('No workspace folder found. Please open a folder first.');
+                            }
+                            const workspaceRoot = workspaceFolders[0].uri.fsPath;
+
+                            const folderInput: string = message.folderInput || '';
+                            const excludeInput: string = message.excludeInput || '';
+
+                            // Persist raw inputs for prefill.
+                            await this._extensionContext.workspaceState.update(STATE_FOLDER_INPUT, folderInput);
+                            await this._extensionContext.workspaceState.update(STATE_EXCLUDE_INPUT, excludeInput);
+
+                            const { resolved, errors } = resolveIndexFolders(folderInput, workspaceRoot);
+                            if (errors.length > 0) {
+                                throw new Error(errors.join('\n'));
+                            }
+                            const excludes = parseListInput(excludeInput);
+
+                            const { indexedPaths, indexedFiles, totalChunks } =
+                                await this.indexCommand.executeForWebview(resolved, excludes);
+
+                            // Persist the authoritative indexed-path list for search.
+                            await this._extensionContext.workspaceState.update(STATE_INDEXED_PATHS, indexedPaths);
+
+                            vscode.window.showInformationMessage(
+                                `✅ Indexed ${indexedFiles} files (${totalChunks} chunks) across ${indexedPaths.length} folder(s).`
+                            );
                         } catch (error) {
                             console.error('Indexing error:', error);
-                            // Still notify webview to reset button state
-                            webviewView.webview.postMessage({
-                                command: 'indexComplete'
-                            });
+                            vscode.window.showErrorMessage(`❌ Indexing failed: ${error instanceof Error ? error.message : error}`);
+                        } finally {
+                            webviewView.webview.postMessage({ command: 'indexComplete' });
+                            await this.checkIndexStatusAndUpdateWebview(webviewView.webview);
                         }
                         return;
 
                     case 'openFile':
                         // Handle file opening
                         try {
-                            const workspaceFolders = vscode.workspace.workspaceFolders;
-                            const workspaceRoot = workspaceFolders ? workspaceFolders[0].uri.fsPath : '';
-                            const absPath = path.join(workspaceRoot, message.relativePath);
+                            // Prefer the absolute path carried from the search result.
+                            let absPath: string = message.absolutePath;
+                            if (!absPath) {
+                                const workspaceFolders = vscode.workspace.workspaceFolders;
+                                const workspaceRoot = workspaceFolders ? workspaceFolders[0].uri.fsPath : '';
+                                absPath = path.join(workspaceRoot, message.relativePath);
+                            }
                             const uri = vscode.Uri.file(absPath);
                             const document = await vscode.workspace.openTextDocument(uri);
                             const editor = await vscode.window.showTextDocument(document);
@@ -149,7 +190,7 @@ export class SemanticSearchViewProvider implements vscode.WebviewViewProvider {
                                 editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
                             }
                         } catch (error) {
-                            vscode.window.showErrorMessage(`Failed to open file: ${message.relativePath}`);
+                            vscode.window.showErrorMessage(`Failed to open file: ${message.absolutePath || message.relativePath}`);
                         }
                         return;
                 }
@@ -160,32 +201,25 @@ export class SemanticSearchViewProvider implements vscode.WebviewViewProvider {
     }
 
     /**
-     * Convert SemanticSearchResult[] from core to webview format
+     * Convert TaggedResult[] from the search command to webview display format.
      */
     private convertSearchResultsToWebviewFormat(searchResults: any[]): any[] {
-        const workspaceFolders = vscode.workspace.workspaceFolders;
-        const baseWorkspacePath = workspaceFolders ? workspaceFolders[0].uri.fsPath : '/tmp';
-
         return searchResults.map(result => {
-            let filePath = result.relativePath;
-            if (result.relativePath && !result.relativePath.startsWith('/') && !result.relativePath.includes(':')) {
-                filePath = `${baseWorkspacePath}/${result.relativePath}`;
-            }
+            const folderName = result.searchFolder ? path.basename(result.searchFolder) : '';
+            const displayPath = folderName ? `${folderName}/${result.relativePath}` : result.relativePath;
 
-            let displayPath = result.relativePath;
-
-            // Truncate content for display
             const truncatedContent = result.content && result.content.length <= 150
                 ? result.content
                 : (result.content || '').substring(0, 150) + '...';
 
             return {
                 file: displayPath,
-                filePath: filePath,
+                absolutePath: result.absolutePath,
                 relativePath: result.relativePath,
+                folder: folderName,
                 line: result.startLine,
                 preview: truncatedContent,
-                context: `1 match in ${displayPath}`,
+                context: folderName ? `match in ${folderName}` : `match in ${displayPath}`,
                 score: result.score,
                 startLine: result.startLine,
                 endLine: result.endLine
@@ -198,29 +232,34 @@ export class SemanticSearchViewProvider implements vscode.WebviewViewProvider {
      */
     private async checkIndexStatusAndUpdateWebview(webview: vscode.Webview): Promise<void> {
         try {
-            const workspaceFolders = vscode.workspace.workspaceFolders;
-            if (!workspaceFolders || workspaceFolders.length === 0) {
-                webview.postMessage({
-                    command: 'updateIndexStatus',
-                    hasIndex: false
-                });
-                return;
+            const indexedPaths = this._extensionContext.workspaceState.get<string[]>(STATE_INDEXED_PATHS, []);
+            const candidates = indexedPaths.length > 0
+                ? indexedPaths
+                : (vscode.workspace.workspaceFolders || []).map(f => f.uri.fsPath);
+
+            let hasIndex = false;
+            for (const p of candidates) {
+                if (await this.searchCommand.hasIndex(p)) {
+                    hasIndex = true;
+                    break;
+                }
             }
 
-            const codebasePath = workspaceFolders[0].uri.fsPath;
-            const hasIndex = await this.searchCommand.hasIndex(codebasePath);
-
-            webview.postMessage({
-                command: 'updateIndexStatus',
-                hasIndex: hasIndex
-            });
+            webview.postMessage({ command: 'updateIndexStatus', hasIndex });
         } catch (error) {
             console.error('Failed to check index status:', error);
-            webview.postMessage({
-                command: 'updateIndexStatus',
-                hasIndex: false
-            });
+            webview.postMessage({ command: 'updateIndexStatus', hasIndex: false });
         }
+    }
+
+    private sendIndexConfig(webview: vscode.Webview) {
+        const folderInput = this._extensionContext.workspaceState.get<string>(STATE_FOLDER_INPUT, '');
+        const excludeInput = this._extensionContext.workspaceState.get<string>(STATE_EXCLUDE_INPUT, '');
+        webview.postMessage({
+            command: 'indexConfigData',
+            folderInput,
+            excludeInput
+        });
     }
 
     private sendCurrentConfig(webview: vscode.Webview) {

--- a/packages/vscode-extension/src/webview/semanticSearchProvider.ts
+++ b/packages/vscode-extension/src/webview/semanticSearchProvider.ts
@@ -6,10 +6,7 @@ import { SyncCommand } from '../commands/syncCommand';
 import { ConfigManager, EmbeddingProviderConfig } from '../config/configManager';
 import * as path from 'path';
 import { resolveIndexFolders, parseListInput } from '../utils/pathUtils';
-
-const STATE_INDEXED_PATHS = 'semanticCodeSearch.indexedPaths';
-const STATE_FOLDER_INPUT = 'semanticCodeSearch.folderInput';
-const STATE_EXCLUDE_INPUT = 'semanticCodeSearch.excludeInput';
+import { STATE_INDEXED_PATHS, STATE_FOLDER_INPUT, STATE_EXCLUDE_INPUT } from '../utils/stateKeys';
 
 export class SemanticSearchViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'semanticSearchView';

--- a/packages/vscode-extension/src/webview/templates/semanticSearch.html
+++ b/packages/vscode-extension/src/webview/templates/semanticSearch.html
@@ -37,9 +37,18 @@
             <input type="text" id="extFilterInput" class="search-input" style="margin-top: 6px;"
                 placeholder="e.g. .ts,.py,.java" />
             <button id="searchButton" class="search-button">Search</button>
+
+            <label for="folderInput" class="input-label" style="margin-top: 10px; display: block;">Folder(s) to index (optional, relative to workspace; blank = whole workspace)</label>
+            <textarea id="folderInput" class="search-input" style="margin-top: 6px; min-height: 48px; resize: vertical;"
+                placeholder="e.g. sub1, sub2 (comma or newline separated)"></textarea>
+
+            <label for="excludeInput" class="input-label" style="margin-top: 10px; display: block;">Exclude folders (optional)</label>
+            <input type="text" id="excludeInput" class="search-input" style="margin-top: 6px;"
+                placeholder="e.g. venv, .venv, build" />
+
             <button id="indexButton" class="search-button"
-                style="margin-top: 4px; background-color: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground);">
-                Index Current Codebase
+                style="margin-top: 8px; background-color: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground);">
+                Index Folder(s)
             </button>
         </div>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
         specifier: ^0.25.6
         version: 0.25.6
     devDependencies:
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/node':
         specifier: 20.x
         version: 20.19.0
@@ -274,9 +277,15 @@ importers:
       eslint:
         specifier: ^9.25.1
         version: 9.28.0
+      jest:
+        specifier: ^30.0.0
+        version: 30.0.1(@types/node@20.19.0)
       source-map-loader:
         specifier: ^5.0.0
         version: 5.0.0(webpack@5.99.9)
+      ts-jest:
+        specifier: ^29.4.0
+        version: 29.4.0(@babel/core@7.27.4)(@jest/transform@30.0.1)(@jest/types@30.0.1)(babel-jest@30.0.1(@babel/core@7.27.4))(jest-util@30.0.1)(jest@30.0.1(@types/node@20.19.0))(typescript@5.8.3)
       ts-loader:
         specifier: ^9.5.2
         version: 9.5.2(typescript@5.8.3)(webpack@5.99.9)


### PR DESCRIPTION
## Summary

Adds three capabilities to the VSCode extension's Semantic Code Search panel so you can index specific subfolders of an open workspace rather than the whole root:

- **Custom index path(s):** Open VSCode at a parent folder but index only the subfolder(s) you name. Retrieval comes from the same scope.
- **Multiple subpaths:** Index several subfolders at once (e.g. `backend, frontend/src`). Search fans out across all indexed folders in parallel and merges results by score.
- **Exclude folders:** Glob patterns to skip nested directories inside indexed folders.

Two new panel fields drive this:
- **Folder(s) to index** — comma/newline-separated paths relative to the workspace root. Empty = whole workspace (unchanged default behavior).
- **Exclude folders** — glob patterns applied on top of the defaults.

`node_modules` was already ignored by default; this PR also adds `venv` and `.venv` to the core default ignore list.

## Design

- **One collection per indexed folder.** Each folder is indexed independently (its own collection keyed by resolved path), so adding/removing a folder doesn't rebuild the others. Search runs one query per folder in parallel (`Promise.all`) and merges by score. Auto-sync is scoped to the indexed folders, not the workspace root.
- Folder inputs and the resolved indexed-path list are persisted in `workspaceState`, so the panel prefills and search/sync know what to target across reloads.
- Path resolution rejects any path that escapes the workspace root.
- Search results are tagged with their source folder and carry an absolute path, fixing file-open for results outside the workspace root.

## Testing

- `packages/core`: build clean, 28 unit tests pass (incl. new default-ignore test).
- `packages/vscode-extension`: `tsc --noEmit` clean; 8 new unit tests for path/result helpers pass.
- Full `pnpm build` passes.
- Manually verified end-to-end against a local Milvus + Ollama setup: indexed two subfolders, confirmed `node_modules`/`venv` and unlisted folders are skipped, search results are folder-tagged, and clicking a result opens the correct file and line.

## Screenshot
<img width="994" height="957" alt="image" src="https://github.com/user-attachments/assets/9b08b4c7-eb8d-4625-ac6f-bd04d40bef17" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
