### PR TITLE
Respect .gitignore negation patterns during indexing

### DIFF
--- a/packages/core/src/context.ignore-patterns.test.ts
+++ b/packages/core/src/context.ignore-patterns.test.ts
@@ -211,6 +211,43 @@ describe('Context ignore pattern isolation', () => {
         ]);
     });
 
+    it('respects .gitignore negation patterns during initial indexing', async () => {
+        const project = path.join(tempRoot, 'project-gitignore-negation');
+        await fs.mkdir(path.join(project, 'wp-content', 'plugins', 'app'), { recursive: true });
+        await fs.mkdir(path.join(project, 'wp-content', 'plugins', 'backoffice'), { recursive: true });
+        await fs.mkdir(path.join(project, 'wp-content', 'plugins', 'vendor-plugin'), { recursive: true });
+
+        await fs.writeFile(path.join(project, '.gitignore'), [
+            'wp-content/plugins/*',
+            '!wp-content/plugins/app',
+            '!wp-content/plugins/backoffice',
+            '',
+        ].join('\n'));
+        await fs.writeFile(path.join(project, 'wp-content', 'plugins', 'app', 'main.ts'), 'app should be indexed');
+        await fs.writeFile(path.join(project, 'wp-content', 'plugins', 'backoffice', 'main.ts'), 'backoffice should be indexed');
+        await fs.writeFile(path.join(project, 'wp-content', 'plugins', 'vendor-plugin', 'main.ts'), 'vendor should stay ignored');
+
+        const vectorDatabase = createVectorDatabase();
+        const context = new Context({
+            embedding: new TestEmbedding(),
+            vectorDatabase,
+            codeSplitter: new TestSplitter(),
+        });
+
+        await context.indexCodebase(project);
+
+        const insertedDocuments = vectorDatabase.insert.mock.calls
+            .flatMap(([, documents]) => documents);
+        const indexedPaths = insertedDocuments
+            .map(document => document.relativePath.replace(/\\/g, '/'))
+            .sort();
+
+        expect(indexedPaths).toEqual([
+            'wp-content/plugins/app/main.ts',
+            'wp-content/plugins/backoffice/main.ts',
+        ]);
+    });
+
     it('skips dotfiles and dot directories during initial indexing', async () => {
         const project = path.join(tempRoot, 'project');
         await fs.mkdir(path.join(project, '.config'), { recursive: true });
@@ -283,5 +320,26 @@ describe('Context ignore pattern isolation', () => {
         expect(fileHashes.has(path.join('Library', 'generated.md'))).toBe(false);
         expect(fileHashes.has(path.join('src', 'Library', 'nested.md'))).toBe(true);
         expect(fileHashes.has(path.join('src', 'keep.md'))).toBe(true);
+    });
+
+    it('respects .gitignore negation patterns during sync hashing', async () => {
+        const project = path.join(tempRoot, 'project-sync-gitignore-negation');
+        await fs.mkdir(path.join(project, 'wp-content', 'plugins', 'app'), { recursive: true });
+        await fs.mkdir(path.join(project, 'wp-content', 'plugins', 'backoffice'), { recursive: true });
+        await fs.mkdir(path.join(project, 'wp-content', 'plugins', 'vendor-plugin'), { recursive: true });
+        await fs.writeFile(path.join(project, 'wp-content', 'plugins', 'app', 'main.ts'), 'app should be hashed');
+        await fs.writeFile(path.join(project, 'wp-content', 'plugins', 'backoffice', 'main.ts'), 'backoffice should be hashed');
+        await fs.writeFile(path.join(project, 'wp-content', 'plugins', 'vendor-plugin', 'main.ts'), 'vendor should stay ignored');
+
+        const synchronizer = new FileSynchronizer(project, [
+            'wp-content/plugins/*',
+            '!wp-content/plugins/app',
+            '!wp-content/plugins/backoffice',
+        ], ['.ts']);
+        const fileHashes = await (synchronizer as any).generateFileHashes(project) as Map<string, string>;
+
+        expect(fileHashes.has(path.join('wp-content', 'plugins', 'app', 'main.ts'))).toBe(true);
+        expect(fileHashes.has(path.join('wp-content', 'plugins', 'backoffice', 'main.ts'))).toBe(true);
+        expect(fileHashes.has(path.join('wp-content', 'plugins', 'vendor-plugin', 'main.ts'))).toBe(false);
     });
 });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1305,13 +1305,27 @@ export class Context {
 
         const normalizedPath = relativePath.replace(/\\/g, '/'); // Normalize path separators
 
-        for (const pattern of ignorePatterns) {
-            if (this.isPatternMatch(normalizedPath, pattern)) {
-                return true;
+        let ignored = false;
+
+        for (const rawPattern of ignorePatterns) {
+            const pattern = rawPattern.trim();
+            if (!pattern) {
+                continue;
+            }
+
+            const isNegation = pattern.startsWith('!');
+            const positivePattern = isNegation ? pattern.slice(1) : pattern;
+            if (!positivePattern) {
+                continue;
+            }
+
+            if (this.isPatternMatch(normalizedPath, positivePattern) ||
+                (isNegation && this.isDirectoryDescendantMatch(normalizedPath, positivePattern))) {
+                ignored = !isNegation;
             }
         }
 
-        return false;
+        return ignored;
     }
 
     /**
@@ -1368,6 +1382,17 @@ export class Context {
         }
 
         return false;
+    }
+
+    private isDirectoryDescendantMatch(filePath: string, pattern: string): boolean {
+        const cleanPath = filePath.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+        const cleanPattern = pattern.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+
+        if (!cleanPath || !cleanPattern || cleanPattern.includes('*')) {
+            return false;
+        }
+
+        return cleanPath.startsWith(`${cleanPattern}/`);
     }
 
     /**

--- a/packages/core/src/sync/synchronizer.ts
+++ b/packages/core/src/sync/synchronizer.ts
@@ -119,25 +119,37 @@ export class FileSynchronizer {
             return false; // Don't ignore root
         }
 
-        // Check direct pattern matches first
-        for (const pattern of this.ignorePatterns) {
-            if (this.matchPattern(normalizedPath, pattern)) {
-                return true;
-            }
-        }
+        let ignored = false;
 
-        // Check if any parent directory is ignored
+        const pathCandidates = [normalizedPath];
+
+        // Check if any parent directory is ignored. This preserves existing
+        // basename-only patterns such as `build`, while still allowing later
+        // negation patterns to re-include a directory subtree.
         const normalizedPathParts = normalizedPath.split('/');
         for (let i = 0; i < normalizedPathParts.length; i++) {
-            const partialPath = normalizedPathParts.slice(0, i + 1).join('/');
-            for (const pattern of this.ignorePatterns) {
-                if (this.matchPattern(partialPath, pattern)) {
-                    return true;
-                }
+            pathCandidates.push(normalizedPathParts.slice(0, i + 1).join('/'));
+        }
+
+        for (const rawPattern of this.ignorePatterns) {
+            const pattern = rawPattern.trim();
+            if (!pattern) {
+                continue;
+            }
+
+            const isNegation = pattern.startsWith('!');
+            const positivePattern = isNegation ? pattern.slice(1) : pattern;
+            if (!positivePattern) {
+                continue;
+            }
+
+            if (pathCandidates.some(candidate => this.matchPattern(candidate, positivePattern)) ||
+                (isNegation && this.isDirectoryDescendantMatch(normalizedPath, positivePattern))) {
+                ignored = !isNegation;
             }
         }
 
-        return false;
+        return ignored;
     }
 
     private matchPattern(filePath: string, pattern: string): boolean {
@@ -188,6 +200,17 @@ export class FileSynchronizer {
         }
 
         return false;
+    }
+
+    private isDirectoryDescendantMatch(filePath: string, pattern: string): boolean {
+        const cleanPath = filePath.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+        const cleanPattern = pattern.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+
+        if (!cleanPath || !cleanPattern || cleanPattern.includes('*')) {
+            return false;
+        }
+
+        return cleanPath.startsWith(`${cleanPattern}/`);
     }
 
     private simpleGlobMatch(text: string, pattern: string): boolean {


### PR DESCRIPTION
Fixes #397.

This makes file-based ignore matching honor `!` negation patterns instead of treating them as inert literal patterns. The bug in #397 can silently remove intentionally tracked/whitelisted directories from the index, which is especially risky for code-search agents because the user sees a completed index but the search universe is incomplete.

What changed:
- `Context.matchesIgnorePattern` now evaluates ignore rules in order and lets later `!pattern` rules re-include matching paths.
- `FileSynchronizer.shouldIgnore` uses the same ordered negation behavior so initial indexing and sync hashing stay aligned.
- Added regression coverage for the reported WordPress-style pattern:
  ```gitignore
  wp-content/plugins/*
  !wp-content/plugins/app
  !wp-content/plugins/backoffice
  ```
  covering both initial indexing and sync hashing.

Validation:
- `git diff --check`
- from `packages/core`: `./node_modules/.bin/jest src/context.ignore-patterns.test.ts --runInBand`
- from `packages/core`: `./node_modules/.bin/tsc --noEmit`

Note: I intentionally kept this narrow and did not replace the matcher with a full gitignore parser. The goal is to fix the silent exclusion case from #397 without changing unrelated ignore semantics.
