### PR TITLE
Add privacy-preserving search retrieval receipts

### DIFF
--- a/packages/mcp/src/handlers.search-receipt.test.ts
+++ b/packages/mcp/src/handlers.search-receipt.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { ToolHandlers } from "./handlers.js";
+import { SnapshotManager } from "./snapshot.js";
+
+async function withTempHome(run: (tempRoot: string) => Promise<void>): Promise<void> {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "claude-context-mcp-search-receipt-"));
+    const homeDir = path.join(tempRoot, "home");
+    await mkdir(path.join(homeDir, ".context"), { recursive: true });
+
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+
+    try {
+        await run(tempRoot);
+    } finally {
+        if (originalHome === undefined) {
+            delete process.env.HOME;
+        } else {
+            process.env.HOME = originalHome;
+        }
+
+        if (originalUserProfile === undefined) {
+            delete process.env.USERPROFILE;
+        } else {
+            process.env.USERPROFILE = originalUserProfile;
+        }
+
+        await rm(tempRoot, { recursive: true, force: true });
+    }
+}
+
+test("search_code includes a privacy-preserving retrieval receipt", async () => {
+    await withTempHome(async (tempRoot) => {
+        const codebasePath = path.join(tempRoot, "repo");
+        await mkdir(codebasePath, { recursive: true });
+
+        const snapshotManager = new SnapshotManager();
+        snapshotManager.setCodebaseIndexed(codebasePath, {
+            indexedFiles: 2,
+            totalChunks: 3,
+            status: "completed",
+        });
+        snapshotManager.saveCodebaseSnapshot();
+
+        const context = {
+            getVectorDatabase() {
+                return {
+                    async listCollections() {
+                        return [];
+                    },
+                };
+            },
+            getEmbedding() {
+                return {
+                    getProvider() {
+                        return "OpenAI";
+                    },
+                };
+            },
+            async semanticSearch() {
+                return [{
+                    content: "function resetPassword() { return secretToken; }",
+                    relativePath: "src/auth.ts",
+                    startLine: 10,
+                    endLine: 12,
+                    language: "typescript",
+                    score: 0.876,
+                }];
+            },
+        };
+
+        const handlers = new ToolHandlers(context as any, snapshotManager);
+        const result = await handlers.handleSearchCode({
+            path: codebasePath,
+            query: "reset password token flow",
+            limit: 5,
+        });
+
+        assert.equal(result.isError, undefined);
+        const text = result.content[0].text;
+        assert.match(text, /Search receipt \(privacy-preserving\):/);
+
+        const match = text.match(/Search receipt \(privacy-preserving\):\n```json\n([\s\S]+?)\n```/);
+        assert.ok(match, "expected fenced JSON receipt");
+        const receipt = JSON.parse(match[1]);
+
+        assert.equal(receipt.tool, "search_code");
+        assert.match(receipt.receipt_id, /^sha256:[a-f0-9]{64}$/);
+        assert.match(receipt.query_hash, /^sha256:[a-f0-9]{64}$/);
+        assert.equal(receipt.result_count, 1);
+        assert.equal(receipt.index_snapshot.indexed_files, 2);
+        assert.equal(receipt.index_snapshot.total_chunks, 3);
+        assert.equal(receipt.results[0].rank, 1);
+        assert.match(receipt.results[0].chunk_hash, /^sha256:[a-f0-9]{64}$/);
+        assert.match(receipt.results[0].location_hash, /^sha256:[a-f0-9]{64}$/);
+        assert.equal(receipt.results[0].score_bucket, 0.88);
+
+        const receiptJson = JSON.stringify(receipt);
+        assert.doesNotMatch(receiptJson, /reset password token flow/);
+        assert.doesNotMatch(receiptJson, /secretToken/);
+        assert.doesNotMatch(receiptJson, /src\/auth\.ts/);
+    });
+});

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
 import { Context, COLLECTION_LIMIT_MESSAGE, FileSynchronizer, IndexAbortError } from "@zilliz/claude-context-core";
+import type { SemanticSearchResult } from "@zilliz/claude-context-core";
 import { SnapshotManager } from "./snapshot.js";
 import type { CodebaseIndexOptions, RequestSplitterType } from "./config.js";
 import { createRequestSplitter, isRequestSplitterType } from "./splitter.js";
@@ -26,6 +27,77 @@ export class ToolHandlers {
         this.snapshotManager = snapshotManager;
         this.currentWorkspace = process.cwd();
         console.log(`[WORKSPACE] Current workspace: ${this.currentWorkspace}`);
+    }
+
+    private hashValue(value: string): string {
+        return `sha256:${crypto.createHash("sha256").update(value).digest("hex")}`;
+    }
+
+    private buildSearchReceipt(params: {
+        requestedPath: string;
+        searchCodebasePath: string;
+        query: string;
+        limit: number;
+        filterExpr?: string;
+        results: SemanticSearchResult[];
+    }) {
+        const snapshotInfo = this.snapshotManager.getCodebaseInfo(params.searchCodebasePath);
+        const snapshotLastUpdated = snapshotInfo?.lastUpdated;
+        const snapshotAgeMs = snapshotLastUpdated
+            ? Math.max(0, Date.now() - Date.parse(snapshotLastUpdated))
+            : undefined;
+        const queryHash = this.hashValue(params.query);
+        const snapshotDigestInput = JSON.stringify({
+            codebase_path_hash: this.hashValue(params.searchCodebasePath),
+            status: snapshotInfo?.status ?? "unknown",
+            indexed_files: snapshotInfo && "indexedFiles" in snapshotInfo ? snapshotInfo.indexedFiles : undefined,
+            total_chunks: snapshotInfo && "totalChunks" in snapshotInfo ? snapshotInfo.totalChunks : undefined,
+            index_status: snapshotInfo && "indexStatus" in snapshotInfo ? snapshotInfo.indexStatus : undefined,
+            last_updated: snapshotLastUpdated
+        });
+
+        const results = params.results.map((result, index) => {
+            const location = `${result.relativePath}:${result.startLine}-${result.endLine}`;
+            return {
+                rank: index + 1,
+                location_hash: this.hashValue(location),
+                chunk_hash: this.hashValue(result.content),
+                score_bucket: Number(result.score.toFixed(2)),
+                dedupe_key: this.hashValue(`${params.searchCodebasePath}:${location}`)
+            };
+        });
+
+        const receiptSeed = JSON.stringify({
+            tool: "search_code",
+            queryHash,
+            requestedPathHash: this.hashValue(params.requestedPath),
+            searchCodebasePathHash: this.hashValue(params.searchCodebasePath),
+            limit: params.limit,
+            filterExprHash: params.filterExpr ? this.hashValue(params.filterExpr) : null,
+            snapshotHash: this.hashValue(snapshotDigestInput),
+            resultChunkHashes: results.map((result) => result.chunk_hash)
+        });
+
+        return {
+            receipt_id: this.hashValue(receiptSeed),
+            tool: "search_code",
+            index_snapshot: {
+                codebase_path_hash: this.hashValue(params.searchCodebasePath),
+                status: snapshotInfo?.status ?? "unknown",
+                indexed_files: snapshotInfo && "indexedFiles" in snapshotInfo ? snapshotInfo.indexedFiles : undefined,
+                total_chunks: snapshotInfo && "totalChunks" in snapshotInfo ? snapshotInfo.totalChunks : undefined,
+                index_status: snapshotInfo && "indexStatus" in snapshotInfo ? snapshotInfo.indexStatus : undefined,
+                last_updated: snapshotLastUpdated,
+                age_ms: snapshotAgeMs
+            },
+            query_hash: queryHash,
+            requested_path_hash: this.hashValue(params.requestedPath),
+            effective_codebase_path_hash: this.hashValue(params.searchCodebasePath),
+            result_count: params.results.length,
+            requested_limit: params.limit,
+            extension_filter_hash: params.filterExpr ? this.hashValue(params.filterExpr) : null,
+            results
+        };
     }
 
     /**
@@ -814,6 +886,16 @@ export class ToolHandlers {
                 resultMessage += `\nRequested path '${absolutePath}' is covered by indexed codebase '${searchCodebasePath}'.`;
             }
             resultMessage += `\n\n${formattedResults}`;
+
+            const receipt = this.buildSearchReceipt({
+                requestedPath: absolutePath,
+                searchCodebasePath,
+                query,
+                limit: Math.min(resultLimit, 50),
+                filterExpr,
+                results: searchResults
+            });
+            resultMessage += `\n\nSearch receipt (privacy-preserving):\n\`\`\`json\n${JSON.stringify(receipt, null, 2)}\n\`\`\``;
 
             if (isIndexing) {
                 resultMessage += `\n\n💡 **Tip**: This codebase is still being indexed. More results may become available as indexing progresses.`;


### PR DESCRIPTION
## Summary

Adds a compact privacy-preserving retrieval receipt to `search_code` results.

The receipt gives clients a stable `receipt_id` they can attach to downstream tool spans/evals without exposing query text, file paths, or code content. It includes:

- index snapshot metadata: status, indexed file/chunk counts, index status, last updated, age
- hashes for query, requested path, effective indexed codebase path, extension filter
- result count/requested limit
- per-result rank, score bucket, location hash, chunk hash, and dedupe key

This follows the shape suggested in #382: keep it as a retrieval receipt rather than full agent telemetry.

## Validation

From `packages/mcp`:

```bash
../../node_modules/.bin/tsc --noEmit
node --import tsx --test src/*.test.ts
```

Result: 5/5 MCP tests passed.

Note: the normal `pnpm --filter @zilliz/claude-context-mcp test` path attempted an install and was blocked by the workspace's ignored-build-script policy, so I ran the same MCP tests directly with `tsx` after building the workspace core package locally.
