### PR TITLE
fix(core): honor negated ignore patterns

### DIFF
--- a/packages/core/src/context.ignore-patterns.test.ts
+++ b/packages/core/src/context.ignore-patterns.test.ts
@@ -211,6 +211,35 @@ describe('Context ignore pattern isolation', () => {
         ]);
     });
 
+    it('honors negated ignore patterns during indexing', async () => {
+        const project = path.join(tempRoot, 'project-with-negated-ignore');
+        await fs.mkdir(path.join(project, 'wp-content', 'plugins', 'app'), { recursive: true });
+        await fs.mkdir(path.join(project, 'wp-content', 'plugins', 'unused'), { recursive: true });
+        await fs.writeFile(
+            path.join(project, '.gitignore'),
+            'wp-content/plugins/*\n!wp-content/plugins/app\n'
+        );
+        await fs.writeFile(path.join(project, 'wp-content', 'plugins', 'app', 'main.ts'), 'should stay indexed');
+        await fs.writeFile(path.join(project, 'wp-content', 'plugins', 'unused', 'main.ts'), 'should be ignored');
+
+        const vectorDatabase = createVectorDatabase();
+        const context = new Context({
+            embedding: new TestEmbedding(),
+            vectorDatabase,
+            codeSplitter: new TestSplitter(),
+        });
+
+        await context.indexCodebase(project);
+
+        const insertedDocuments = vectorDatabase.insert.mock.calls
+            .flatMap(([, documents]) => documents);
+        const indexedPaths = insertedDocuments
+            .map(document => document.relativePath.replace(/\\/g, '/'))
+            .sort();
+
+        expect(indexedPaths).toEqual(['wp-content/plugins/app/main.ts']);
+    });
+
     it('skips dotfiles and dot directories during initial indexing', async () => {
         const project = path.join(tempRoot, 'project');
         await fs.mkdir(path.join(project, '.config'), { recursive: true });
@@ -283,5 +312,22 @@ describe('Context ignore pattern isolation', () => {
         expect(fileHashes.has(path.join('Library', 'generated.md'))).toBe(false);
         expect(fileHashes.has(path.join('src', 'Library', 'nested.md'))).toBe(true);
         expect(fileHashes.has(path.join('src', 'keep.md'))).toBe(true);
+    });
+
+    it('honors negated ignore patterns during sync', async () => {
+        const project = path.join(tempRoot, 'project-with-negated-sync-ignore');
+        await fs.mkdir(path.join(project, 'wp-content', 'plugins', 'app'), { recursive: true });
+        await fs.mkdir(path.join(project, 'wp-content', 'plugins', 'unused'), { recursive: true });
+        await fs.writeFile(path.join(project, 'wp-content', 'plugins', 'app', 'main.ts'), 'should stay tracked');
+        await fs.writeFile(path.join(project, 'wp-content', 'plugins', 'unused', 'main.ts'), 'should be ignored');
+
+        const synchronizer = new FileSynchronizer(project, [
+            'wp-content/plugins/*',
+            '!wp-content/plugins/app',
+        ], ['.ts']);
+        const fileHashes = await (synchronizer as any).generateFileHashes(project) as Map<string, string>;
+
+        expect(fileHashes.has(path.join('wp-content', 'plugins', 'app', 'main.ts'))).toBe(true);
+        expect(fileHashes.has(path.join('wp-content', 'plugins', 'unused', 'main.ts'))).toBe(false);
     });
 });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1305,13 +1305,17 @@ export class Context {
 
         const normalizedPath = relativePath.replace(/\\/g, '/'); // Normalize path separators
 
-        for (const pattern of ignorePatterns) {
-            if (this.isPatternMatch(normalizedPath, pattern)) {
-                return true;
+        let ignored = false;
+        for (const rawPattern of ignorePatterns) {
+            const negated = rawPattern.startsWith('!');
+            const pattern = negated ? rawPattern.slice(1) : rawPattern;
+
+            if (this.matchesPathOrParent(normalizedPath, pattern)) {
+                ignored = !negated;
             }
         }
 
-        return false;
+        return ignored;
     }
 
     /**
@@ -1363,6 +1367,22 @@ export class Context {
         for (let i = 0; i <= pathParts.length - dirPartCount; i++) {
             const candidate = pathParts.slice(i, i + dirPartCount).join('/');
             if (this.simpleGlobMatch(candidate, dirPattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private matchesPathOrParent(filePath: string, pattern: string): boolean {
+        if (this.isPatternMatch(filePath, pattern)) {
+            return true;
+        }
+
+        const pathParts = filePath.split('/');
+        for (let i = 0; i < pathParts.length - 1; i++) {
+            const partialPath = pathParts.slice(0, i + 1).join('/');
+            if (this.isPatternMatch(partialPath, pattern)) {
                 return true;
             }
         }

--- a/packages/core/src/sync/synchronizer.ts
+++ b/packages/core/src/sync/synchronizer.ts
@@ -119,25 +119,17 @@ export class FileSynchronizer {
             return false; // Don't ignore root
         }
 
-        // Check direct pattern matches first
-        for (const pattern of this.ignorePatterns) {
-            if (this.matchPattern(normalizedPath, pattern)) {
-                return true;
+        let ignored = false;
+        for (const rawPattern of this.ignorePatterns) {
+            const negated = rawPattern.startsWith('!');
+            const pattern = negated ? rawPattern.slice(1) : rawPattern;
+
+            if (this.matchesPathOrParent(normalizedPath, pattern)) {
+                ignored = !negated;
             }
         }
 
-        // Check if any parent directory is ignored
-        const normalizedPathParts = normalizedPath.split('/');
-        for (let i = 0; i < normalizedPathParts.length; i++) {
-            const partialPath = normalizedPathParts.slice(0, i + 1).join('/');
-            for (const pattern of this.ignorePatterns) {
-                if (this.matchPattern(partialPath, pattern)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return ignored;
     }
 
     private matchPattern(filePath: string, pattern: string): boolean {
@@ -183,6 +175,22 @@ export class FileSynchronizer {
         for (let i = 0; i <= pathParts.length - dirPartCount; i++) {
             const candidate = pathParts.slice(i, i + dirPartCount).join('/');
             if (this.simpleGlobMatch(candidate, dirPattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private matchesPathOrParent(filePath: string, pattern: string): boolean {
+        if (this.matchPattern(filePath, pattern)) {
+            return true;
+        }
+
+        const pathParts = filePath.split('/');
+        for (let i = 0; i < pathParts.length - 1; i++) {
+            const partialPath = pathParts.slice(0, i + 1).join('/');
+            if (this.matchPattern(partialPath, pattern)) {
                 return true;
             }
         }


### PR DESCRIPTION
## Summary
- support negated ignore patterns by applying ignore rules in order and letting the last matching rule win
- apply the same behavior in initial indexing and file synchronization
- add regression coverage for `.gitignore` patterns like `wp-content/plugins/*` followed by `!wp-content/plugins/app`

Closes #397

## Validation
- `git diff --check`
- `npx pnpm@10 install --frozen-lockfile`
- `npx pnpm@10 --filter @zilliz/claude-context-core test -- context.ignore-patterns.test.ts --runInBand`
- `npx pnpm@10 --filter @zilliz/claude-context-core typecheck`
- `npx pnpm@10 --filter @zilliz/claude-context-core build`

## Notes
- `npx pnpm@10 --filter @zilliz/claude-context-core lint` currently exits before linting because ESLint 9 cannot find an `eslint.config.(js|mjs|cjs)` file while the repo has `.eslintrc.js`.
- Local Node is v25.2.1 while the repo declares Node >=20 and <24; the targeted tests, typecheck, and build still passed in this environment.