### PR TITLE
fix: replace ignoredBuiltDependencies with allowBuilds for pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,21 @@ packages:
   - packages/*
   - examples/*
 
-ignoredBuiltDependencies:
-  - faiss-node
+allowBuilds:
+  '@vscode/vsce-sign': true
+  esbuild: true
+  faiss-node: true
+  keytar: true
+  protobufjs: true
+  tree-sitter: true
+  tree-sitter-c-sharp: true
+  tree-sitter-cli: true
+  tree-sitter-cpp: true
+  tree-sitter-go: true
+  tree-sitter-java: true
+  tree-sitter-javascript: true
+  tree-sitter-python: true
+  tree-sitter-rust: true
+  tree-sitter-scala: true
+  tree-sitter-typescript: true
+  unrs-resolver: true


### PR DESCRIPTION
## Problem

pnpm 11 deprecates `ignoredBuiltDependencies` and defaults to ignoring 
all build scripts. Users cloning the repo and running `pnpm install` 
get `ERR_PNPM_IGNORED_BUILDS` for 17 native packages (faiss-node, 
esbuild, tree-sitter, keytar, etc.), making `pnpm build` fail.
<img width="692" height="38" alt="image" src="https://github.com/user-attachments/assets/1898d0f1-470c-45fc-bd60-62263d6a27a6" />

## Fix

Replace `ignoredBuiltDependencies` with `allowBuilds` in 
`pnpm-workspace.yaml`, listing all native packages that need build scripts.

This is the pnpm 11 recommended approach:
https://pnpm.io/settings#allowBuilds

## Verification

Tested on pnpm 11.9.0 — `pnpm install && pnpm build` succeeds.
<img width="463" height="380" alt="image" src="https://github.com/user-attachments/assets/b420ab61-a8c1-432c-948d-11226fcb89fe" />
<img width="493" height="379" alt="image" src="https://github.com/user-attachments/assets/51e5e0b4-0919-4c30-ba27-1fbc3ac8241d" />
