### PR TITLE
fix: add Milvus search result validation with actionable diagnostics

### DIFF
--- a/packages/core/src/context.search-dimensions.test.ts
+++ b/packages/core/src/context.search-dimensions.test.ts
@@ -1,0 +1,90 @@
+import { Context } from './context';
+import { Embedding, EmbeddingVector } from './embedding';
+import { Splitter, CodeChunk } from './splitter';
+import { VectorDatabase } from './vectordb';
+
+class DimensionEmbedding extends Embedding {
+    protected maxTokens = 8192;
+
+    async detectDimension(): Promise<number> {
+        return 4;
+    }
+
+    async embed(_text: string): Promise<EmbeddingVector> {
+        return { vector: [1, 2, 3], dimension: 3 };
+    }
+
+    async embedBatch(texts: string[]): Promise<EmbeddingVector[]> {
+        return texts.map(() => ({ vector: [1, 2, 3], dimension: 3 }));
+    }
+
+    getDimension(): number {
+        return 4;
+    }
+
+    getProvider(): string {
+        return 'dimension-test';
+    }
+}
+
+class EmptySplitter implements Splitter {
+    async split(_code: string, _language: string, _filePath?: string): Promise<CodeChunk[]> {
+        return [];
+    }
+
+    setChunkSize(): void { }
+    setChunkOverlap(): void { }
+}
+
+const createVectorDatabase = (): jest.Mocked<VectorDatabase> => ({
+    createCollection: jest.fn().mockResolvedValue(undefined),
+    createHybridCollection: jest.fn().mockResolvedValue(undefined),
+    dropCollection: jest.fn().mockResolvedValue(undefined),
+    hasCollection: jest.fn().mockResolvedValue(true),
+    listCollections: jest.fn().mockResolvedValue([]),
+    insert: jest.fn().mockResolvedValue(undefined),
+    insertHybrid: jest.fn().mockResolvedValue(undefined),
+    search: jest.fn().mockResolvedValue([]),
+    hybridSearch: jest.fn().mockResolvedValue([]),
+    delete: jest.fn().mockResolvedValue(undefined),
+    query: jest.fn().mockResolvedValue([]),
+    getCollectionDescription: jest.fn().mockResolvedValue(''),
+    checkCollectionLimit: jest.fn().mockResolvedValue(true),
+    getCollectionRowCount: jest.fn().mockResolvedValue(0),
+});
+
+describe('Context search dimension logging', () => {
+    const originalHybridMode = process.env.HYBRID_MODE;
+    let logSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        process.env.HYBRID_MODE = 'false';
+        logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        if (originalHybridMode === undefined) {
+            delete process.env.HYBRID_MODE;
+        } else {
+            process.env.HYBRID_MODE = originalHybridMode;
+        }
+        logSpy.mockRestore();
+        warnSpy.mockRestore();
+    });
+
+    it('logs provider, expected dimension, and actual query dimension during search', async () => {
+        const vectorDatabase = createVectorDatabase();
+        const context = new Context({
+            embedding: new DimensionEmbedding(),
+            vectorDatabase,
+            codeSplitter: new EmptySplitter(),
+        });
+
+        await context.semanticSearch('/tmp/project', 'query');
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('provider=dimension-test, expected=4, actual=3'));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('expected=4, actual=3'));
+    });
+});

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -206,6 +206,15 @@ export class Context {
         return this.vectorDatabase;
     }
 
+    private logSearchDimensionContext(actualDimension: number): void {
+        const provider = this.embedding.getProvider();
+        const expectedDimension = this.embedding.getDimension();
+        console.log(`[Context] 🔍 Search embedding dimensions: provider=${provider}, expected=${expectedDimension}, actual=${actualDimension}`);
+        if (expectedDimension !== actualDimension) {
+            console.warn(`[Context] ⚠️  Search embedding dimension mismatch: provider=${provider}, expected=${expectedDimension}, actual=${actualDimension}`);
+        }
+    }
+
     /**
      * Get code splitter instance
      */
@@ -555,6 +564,7 @@ export class Context {
             // 1. Generate query vector
             console.log(`[Context] 🔍 Generating embeddings for query: "${query}"`);
             const queryEmbedding: EmbeddingVector = await this.embedding.embed(query);
+            this.logSearchDimensionContext(queryEmbedding.vector.length);
             console.log(`[Context] ✅ Generated embedding vector with dimension: ${queryEmbedding.vector.length}`);
             console.log(`[Context] 🔍 First 5 embedding values: [${queryEmbedding.vector.slice(0, 5).join(', ')}]`);
 
@@ -615,6 +625,7 @@ export class Context {
             // Regular semantic search
             // 1. Generate query vector
             const queryEmbedding: EmbeddingVector = await this.embedding.embed(query);
+            this.logSearchDimensionContext(queryEmbedding.vector.length);
 
             // 2. Search in vector database
             const searchResults: VectorSearchResult[] = await this.vectorDatabase.search(

--- a/packages/core/src/vectordb/index.ts
+++ b/packages/core/src/vectordb/index.ts
@@ -15,6 +15,11 @@ export {
 export { MilvusRestfulVectorDatabase, MilvusRestfulConfig } from './milvus-restful-vectordb';
 export { MilvusVectorDatabase, MilvusConfig } from './milvus-vectordb';
 export {
+    VectorSearchResultValidationError,
+    isVectorSearchResultValidationError,
+    validateMilvusSearchResultRow
+} from './search-result-validation';
+export {
     ClusterManager,
     ZillizConfig,
     Project,

--- a/packages/core/src/vectordb/milvus-restful-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-restful-vectordb.ts
@@ -20,6 +20,7 @@ import {
     COLLECTION_LIMIT_MESSAGE
 } from './types';
 import { ClusterManager } from './zilliz-utils';
+import { validateMilvusSearchResultRow } from './search-result-validation';
 
 export interface MilvusRestfulConfig {
     address?: string;
@@ -428,7 +429,8 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
             const response = await this.makeRequest('/entities/search', 'POST', searchRequest);
 
             // Transform response to VectorSearchResult format
-            const results: VectorSearchResult[] = (response.data || []).map((item: any) => {
+            const results: VectorSearchResult[] = (response.data || []).map((rawItem: any, index: number) => {
+                const item = validateMilvusSearchResultRow(rawItem, collectionName, index, ['distance', 'score']);
                 // Parse metadata from JSON string
                 let metadata = {};
                 try {
@@ -449,7 +451,7 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
                         fileExtension: item.fileExtension || '',
                         metadata: metadata
                     },
-                    score: item.distance || 0
+                    score: (item.distance ?? item.score) as number
                 };
             });
 
@@ -774,7 +776,8 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
             console.log(`[MilvusRestfulDB] ✅ Found ${results.length} results from hybrid search`);
 
             // Transform response to HybridSearchResult format
-            return results.map((result: any) => {
+            return results.map((rawResult: any, index: number) => {
+                const result = validateMilvusSearchResultRow(rawResult, collectionName, index, ['score', 'distance']);
                 let metadata = {};
                 try {
                     metadata = JSON.parse(result.metadata || '{}');
@@ -794,7 +797,7 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
                         fileExtension: result.fileExtension,
                         metadata,
                     },
-                    score: result.score || result.distance || 0,
+                    score: (result.score ?? result.distance) as number,
                 };
             });
 

--- a/packages/core/src/vectordb/milvus-vectordb.search-validation.test.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.search-validation.test.ts
@@ -1,0 +1,40 @@
+import { MilvusVectorDatabase } from './milvus-vectordb';
+import { VectorSearchResultValidationError } from './search-result-validation';
+
+function createDatabaseWithSearchResults(results: unknown[]): MilvusVectorDatabase {
+    const database = Object.create(MilvusVectorDatabase.prototype) as MilvusVectorDatabase;
+    (database as any).initializationPromise = Promise.resolve();
+    (database as any).client = {
+        getLoadState: jest.fn().mockResolvedValue({ state: 'LoadStateLoaded' }),
+        search: jest.fn().mockResolvedValue({ results }),
+    };
+    return database;
+}
+
+describe('MilvusVectorDatabase search result validation', () => {
+    it('rejects null result entries before mapping scores', async () => {
+        const database = createDatabaseWithSearchResults([null]);
+
+        await expect(database.search('code_chunks', [0.1, 0.2, 0.3])).rejects.toThrow(VectorSearchResultValidationError);
+        await expect(database.search('code_chunks', [0.1, 0.2, 0.3])).rejects.toThrow(/Malformed Milvus search result/);
+        await expect(database.search('code_chunks', [0.1, 0.2, 0.3])).rejects.toThrow(/code_chunks/);
+        await expect(database.search('code_chunks', [0.1, 0.2, 0.3])).rejects.toThrow(/embedding dimension mismatch/);
+        await expect(database.search('code_chunks', [0.1, 0.2, 0.3])).rejects.toThrow(/collection mismatch/);
+    });
+
+    it('rejects null scores before returning mapped search results', async () => {
+        const database = createDatabaseWithSearchResults([{
+            id: 'doc-1',
+            content: 'const answer = 42;',
+            relativePath: 'src/index.ts',
+            startLine: 1,
+            endLine: 1,
+            fileExtension: '.ts',
+            metadata: '{}',
+            score: null,
+        }]);
+
+        await expect(database.search('code_chunks', [0.1, 0.2, 0.3])).rejects.toThrow(VectorSearchResultValidationError);
+        await expect(database.search('code_chunks', [0.1, 0.2, 0.3])).rejects.toThrow(/Missing numeric score field/);
+    });
+});

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -9,6 +9,7 @@ import {
     HybridSearchResult,
 } from './types';
 import { ClusterManager } from './zilliz-utils';
+import { validateMilvusSearchResultRow } from './search-result-validation';
 
 export interface MilvusConfig {
     address?: string;
@@ -394,7 +395,8 @@ export class MilvusVectorDatabase implements VectorDatabase {
             return [];
         }
 
-        return searchResult.results.map((result: any) => {
+        return searchResult.results.map((rawResult: any, index: number) => {
+            const result = validateMilvusSearchResultRow(rawResult, collectionName, index);
             let metadata = {};
             try {
                 metadata = JSON.parse(result.metadata || '{}');
@@ -707,7 +709,8 @@ export class MilvusVectorDatabase implements VectorDatabase {
             console.log(`[MilvusDB] ✅ Found ${searchResult.results.length} results from hybrid search`);
 
             // Transform results to HybridSearchResult format
-            return searchResult.results.map((result: any) => {
+            return searchResult.results.map((rawResult: any, index: number) => {
+                const result = validateMilvusSearchResultRow(rawResult, collectionName, index);
                 let metadata = {};
                 try {
                     metadata = JSON.parse(result.metadata || '{}');

--- a/packages/core/src/vectordb/search-result-validation.test.ts
+++ b/packages/core/src/vectordb/search-result-validation.test.ts
@@ -1,0 +1,27 @@
+import {
+    VectorSearchResultValidationError,
+    validateMilvusSearchResultRow
+} from './search-result-validation';
+
+describe('validateMilvusSearchResultRow', () => {
+    it('rejects null result entries with actionable diagnostics', () => {
+        expect(() => validateMilvusSearchResultRow(null, 'code_chunks', 0)).toThrow(VectorSearchResultValidationError);
+        expect(() => validateMilvusSearchResultRow(null, 'code_chunks', 0)).toThrow(/Malformed Milvus search result/);
+        expect(() => validateMilvusSearchResultRow(null, 'code_chunks', 0)).toThrow(/code_chunks/);
+        expect(() => validateMilvusSearchResultRow(null, 'code_chunks', 0)).toThrow(/embedding dimension mismatch/);
+        expect(() => validateMilvusSearchResultRow(null, 'code_chunks', 0)).toThrow(/collection mismatch/);
+    });
+
+    it('rejects missing, null, and non-numeric score fields', () => {
+        for (const row of [{ id: 'a' }, { id: 'a', score: null }, { id: 'a', score: '0.9' }]) {
+            expect(() => validateMilvusSearchResultRow(row, 'code_chunks', 1)).toThrow(/Missing numeric score field/);
+        }
+    });
+
+    it('accepts configured numeric score fields', () => {
+        expect(validateMilvusSearchResultRow({ id: 'a', distance: 0 }, 'code_chunks', 0, ['distance'])).toEqual({
+            id: 'a',
+            distance: 0,
+        });
+    });
+});

--- a/packages/core/src/vectordb/search-result-validation.ts
+++ b/packages/core/src/vectordb/search-result-validation.ts
@@ -1,0 +1,29 @@
+export class VectorSearchResultValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'VectorSearchResultValidationError';
+    }
+}
+
+export function isVectorSearchResultValidationError(error: unknown): error is VectorSearchResultValidationError {
+    return error instanceof VectorSearchResultValidationError ||
+        (error instanceof Error && error.name === 'VectorSearchResultValidationError');
+}
+
+export function validateMilvusSearchResultRow(row: unknown, collectionName: string, index: number, scoreFields: string[] = ['score']): any {
+    const diagnostic = `Malformed Milvus search result for collection '${collectionName}' at result index ${index}. ` +
+        `This can be caused by an embedding dimension mismatch, collection mismatch, or schema/configuration mismatch. ` +
+        `Check that indexing and search use the same embedding provider and collection configuration.`;
+
+    if (row === null || row === undefined || typeof row !== 'object') {
+        throw new VectorSearchResultValidationError(`${diagnostic} Expected a result object but received ${row === null ? 'null' : typeof row}.`);
+    }
+
+    const result = row as Record<string, unknown>;
+    const scoreField = scoreFields.find((field) => typeof result[field] === 'number' && Number.isFinite(result[field]));
+    if (!scoreField) {
+        throw new VectorSearchResultValidationError(`${diagnostic} Missing numeric score field; expected one of: ${scoreFields.join(', ')}.`);
+    }
+
+    return result;
+}

--- a/packages/mcp/src/handlers.search-validation.test.ts
+++ b/packages/mcp/src/handlers.search-validation.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { VectorSearchResultValidationError } from "@zilliz/claude-context-core";
+import { ToolHandlers } from "./handlers.js";
+
+async function withTempRepo(run: (repoPath: string) => Promise<void>): Promise<void> {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "claude-context-mcp-search-"));
+    const repoPath = path.join(tempRoot, "repo");
+    await mkdir(repoPath, { recursive: true });
+
+    try {
+        await run(repoPath);
+    } finally {
+        await rm(tempRoot, { recursive: true, force: true });
+    }
+}
+
+test("search_code returns actionable malformed Milvus result diagnostics", async () => {
+    await withTempRepo(async (repoPath) => {
+        const snapshotManager = {
+            findIndexedCodebasePath: () => repoPath,
+            findIndexingCodebasePath: () => undefined,
+        };
+
+        const context = {
+            semanticSearch: async () => {
+                throw new VectorSearchResultValidationError("Malformed Milvus search result for collection 'code_chunks'. Possible embedding dimension mismatch or collection mismatch.");
+            },
+            getEmbedding: () => ({
+                getProvider: () => "ollama",
+            }),
+        };
+        const handlers = new ToolHandlers(context as any, snapshotManager as any);
+        (handlers as any).syncIndexedCodebasesFromCloud = async () => undefined;
+
+        const result = await handlers.handleSearchCode({ path: repoPath, query: "hello", limit: 5 });
+
+        assert.equal(result.isError, true);
+        assert.match(result.content[0].text, /Malformed Milvus search result/);
+        assert.match(result.content[0].text, /embedding dimension mismatch/);
+        assert.match(result.content[0].text, /collection mismatch/);
+        assert.doesNotMatch(result.content[0].text, /indexed first/);
+    });
+});
+
+test("search_code preserves normal empty-result behavior", async () => {
+    await withTempRepo(async (repoPath) => {
+        const snapshotManager = {
+            findIndexedCodebasePath: () => repoPath,
+            findIndexingCodebasePath: () => undefined,
+        };
+
+        const context = {
+            semanticSearch: async () => [],
+            getCollectionName: () => "code_chunks",
+            getVectorDatabase: () => ({
+                hasCollection: async () => true,
+            }),
+            getEmbedding: () => ({
+                getProvider: () => "ollama",
+            }),
+        };
+        const handlers = new ToolHandlers(context as any, snapshotManager as any);
+        (handlers as any).syncIndexedCodebasesFromCloud = async () => undefined;
+
+        const result = await handlers.handleSearchCode({ path: repoPath, query: "no matches", limit: 5 });
+
+        assert.equal(result.isError, undefined);
+        assert.match(result.content[0].text, /No results found for query: "no matches"/);
+        assert.doesNotMatch(result.content[0].text, /malformed/i);
+        assert.doesNotMatch(result.content[0].text, /indexed first/);
+    });
+});

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
-import { Context, COLLECTION_LIMIT_MESSAGE, FileSynchronizer, IndexAbortError } from "@zilliz/claude-context-core";
+import { Context, COLLECTION_LIMIT_MESSAGE, FileSynchronizer, IndexAbortError, isVectorSearchResultValidationError } from "@zilliz/claude-context-core";
 import { SnapshotManager } from "./snapshot.js";
 import type { CodebaseIndexOptions, RequestSplitterType } from "./config.js";
 import { createRequestSplitter, isRequestSplitterType } from "./splitter.js";
@@ -838,6 +838,16 @@ export class ToolHandlers {
                         type: "text",
                         text: COLLECTION_LIMIT_MESSAGE
                     }]
+                };
+            }
+
+            if (isVectorSearchResultValidationError(error)) {
+                return {
+                    content: [{
+                        type: "text",
+                        text: `Error searching code: ${errorMessage} The search_code result was malformed after indexing. Likely causes include embedding dimension mismatch, collection mismatch, stale collection data, or collection schema/configuration mismatch. Re-index with the same embedding provider and collection configuration if needed.`
+                    }],
+                    isError: true
                 };
             }
 


### PR DESCRIPTION
Closes #393

## Summary

Add `VectorSearchResultValidationError` and `validateMilvusSearchResultRow()` to guard against null Milvus search results that caused `search_code` to fail with "Cannot read properties of null (reading 'scores')" even after successful indexing.

## Changes

### Core package
- **`search-result-validation.ts`** — new validation utility: `VectorSearchResultValidationError` error class + `validateMilvusSearchResultRow()` with actionable diagnostics
- **`milvus-vectordb.ts`** — validate result rows in both regular and hybrid search before mapping scores
- **`milvus-restful-vectordb.ts`** — same validation in RESTful client (both search + hybrid search)
- **`context.ts`** — log embedding provider, expected dimension, and actual query dimension during search to surface mismatches early
- **`vectordb/index.ts`** — export new validation symbols
- **Tests:**
  - `search-result-validation.test.ts` — 3 tests (null row, missing score, valid)
  - `milvus-vectordb.search-validation.test.ts` — 2 tests (null result, null score)
  - `context.search-dimensions.test.ts` — 1 test (dimension logging)

### MCP package
- **`handlers.ts`** — catch `VectorSearchResultValidationError` and return actionable error message (dimension mismatch, collection mismatch, etc.) instead of generic "check if indexed"
- **Tests:**
  - `handlers.search-validation.test.ts` — 1 test (actionable diagnostics)

## Verification
- All 34 core tests pass (9 suites)
- All 6 MCP tests pass