### PR TITLE
fix: Expose an MCP tool for incremental index refresh

### DIFF
--- a/packages/mcp/CONTRIBUTING.md
+++ b/packages/mcp/CONTRIBUTING.md
@@ -78,7 +78,7 @@ See [README.md](./README.md#prepare-environment-variables) for required environm
 - `path` (optional): Absolute path to one indexed codebase; omit to sync all indexed codebases
 - `wait` (optional): Wait for completion and return stats (default: `true`). Set `false` to run in the background.
 
-Incremental sync via `reindexByChange`; preserves snapshot index options (splitter, ignore patterns, custom extensions). Returns JSON: `{ status, paths?, totals?, message? }` with `status` one of `completed`, `skipped`, `no_codebases`, or `path_not_indexed`. Uses the same global sync lock as background and trigger-file sync. See [README — Keeping indexes up to date](./README.md#keeping-indexes-up-to-date) and [issue #394](https://github.com/zilliztech/claude-context/issues/394).
+Incremental sync via `reindexByChange`; preserves snapshot index options (splitter, ignore patterns, custom extensions). Returns JSON: `{ status, paths?, totals?, message? }` with `status` one of `completed`, `skipped`, `no_codebases`, `path_not_indexed`, or `failed`. Uses the same global sync lock as background and trigger-file sync. See [README — Keeping indexes up to date](./README.md#keeping-indexes-up-to-date) and [issue #394](https://github.com/zilliztech/claude-context/issues/394).
 
 **Trigger watcher vs project paths:** `CLAUDE_CONTEXT_TRIGGER_WATCHER` watches **only** `~/.context/.sync-trigger`, not repository directories. For on-demand refresh during development, call `sync_index`, use background sync, or `touch ~/.context/.sync-trigger` (see [issue #238](https://github.com/zilliztech/claude-context/issues/238)).
 

--- a/packages/mcp/CONTRIBUTING.md
+++ b/packages/mcp/CONTRIBUTING.md
@@ -39,6 +39,7 @@ See [README.md](./README.md#prepare-environment-variables) for required environm
 3. Use the tools:
    - `index_codebase` - Index a sample codebase with optional custom ignore patterns
    - `search_code` - Search for code snippets
+   - `sync_index` - Incrementally refresh indexed codebases (`reindexByChange`)
    - `clear_index` - Clear the index
 
 ## Making Changes
@@ -73,6 +74,14 @@ See [README.md](./README.md#prepare-environment-variables) for required environm
 ### `clear_index`
 - `path` (required): Path to the codebase to clear
 
+### `sync_index`
+- `path` (optional): Absolute path to one indexed codebase; omit to sync all indexed codebases
+- `wait` (optional): Wait for completion and return stats (default: `true`). Set `false` to run in the background.
+
+Incremental sync via `reindexByChange`; preserves snapshot index options (splitter, ignore patterns, custom extensions). Returns JSON: `{ status, paths?, totals?, message? }` with `status` one of `completed`, `skipped`, `no_codebases`, or `path_not_indexed`. Uses the same global sync lock as background and trigger-file sync. See [README — Keeping indexes up to date](./README.md#keeping-indexes-up-to-date) and [issue #394](https://github.com/zilliztech/claude-context/issues/394).
+
+**Trigger watcher vs project paths:** `CLAUDE_CONTEXT_TRIGGER_WATCHER` watches **only** `~/.context/.sync-trigger`, not repository directories. For on-demand refresh during development, call `sync_index`, use background sync, or `touch ~/.context/.sync-trigger` (see [issue #238](https://github.com/zilliztech/claude-context/issues/238)).
+
 ## Guidelines
 
 - Keep tool interfaces simple and intuitive
@@ -106,10 +115,12 @@ claude mcp add claude-context -e OPENAI_API_KEY=sk-your-openai-api-key -e MILVUS
 And then you can start Claude Code with `claude --debug` to see the MCP server logs.
 
 ### Manual Usage
-Use all three MCP tools:
+Use the MCP tools:
 - `index_codebase` - Index sample repositories with optional custom ignore patterns  
   Example with ignore patterns: `{"path": "/repo/path", "ignorePatterns": ["static/**", "*.tmp"]}`
 - `search_code` - Search with various queries  
+- `sync_index` - Refresh after local edits without a full reindex  
+  Example: `{"path": "/repo/path", "wait": true}` or `{}` to sync all indexed codebases
 - `clear_index` - Clear and re-index
 
 ## Questions?

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -200,9 +200,19 @@ CODE_CHUNKS_COLLECTION_NAME_OVERRIDE=my_project
 
 The per-codebase `<pathHash>` suffix is preserved even when the override is set, so the same MCP server can still index multiple repos without collapsing them onto one collection. The override value is sanitized to letters, numbers, and underscores, and truncated to keep the full name within Milvus's 255-char limit. If you unset the variable later, Claude Context switches back to the plain `code_chunks_<pathHash>` naming.
 
+#### Keeping indexes up to date
+
+After a codebase is indexed with `index_codebase`, you can refresh the vector index when files change using any of these mechanisms (they share the same **global cross-process sync lock** at `~/.context/mcp-sync.lock`, so only one sync runs at a time across MCP processes that share `$HOME`):
+
+1. **`sync_index` MCP tool** (recommended for agents and IDE integrations) — incremental refresh on demand; see [Available Tools](#5-sync_index) below. Added in [issue #394](https://github.com/zilliztech/claude-context/issues/394).
+2. **Background sync** — startup + periodic polling via `CLAUDE_CONTEXT_BACKGROUND_SYNC` / `CLAUDE_CONTEXT_SYNC_INTERVAL_MS` (see below).
+3. **Trigger file** — `touch ~/.context/.sync-trigger` when `CLAUDE_CONTEXT_TRIGGER_WATCHER` is enabled (see below).
+
+> **Important:** `CLAUDE_CONTEXT_TRIGGER_WATCHER` watches **only** the sentinel file `~/.context/.sync-trigger`. It does **not** watch your project directories or individual repo paths. To sync after edits, call `sync_index`, rely on background sync, or touch the trigger file — do not expect filesystem events under a codebase root to be observed automatically. See also [issue #238](https://github.com/zilliztech/claude-context/issues/238).
+
 #### Trigger File Watcher (Optional)
 
-In addition to the periodic background sync, the MCP server watches a sentinel file at `~/.context/.sync-trigger` and starts an immediate re-index whenever the file is modified. This lets external tools (Claude Code `PostToolUse` hooks, editor save hooks, CI scripts, etc.) request a sync on demand instead of waiting for the next polling tick.
+When enabled, the MCP server watches **only** `~/.context/.sync-trigger` (not project folders). Modifying that file starts an immediate, debounced incremental re-index. This lets external tools (Claude Code `PostToolUse` hooks, CI scripts, etc.) request a sync on demand instead of waiting for the next polling tick or an explicit `sync_index` call.
 
 ```bash
 # Default: watcher enabled. Set to false to disable filesystem watching entirely
@@ -223,9 +233,11 @@ Example — Claude Code hook that re-indexes after every Edit/Write:
 ```
 
 Notes:
+- **Scope:** The watcher monitors `~/.context/.sync-trigger` only. It does not watch indexed codebase directories.
 - The trigger fires a debounced re-index (2 s window) so rapid touches collapse to a single sync.
-- Triggered syncs go through the same global cross-process lock as background sync, so when multiple MCP processes share `$HOME` only one process performs the work per trigger.
+- Triggered syncs use the same global cross-process lock as `sync_index` and background sync, so when multiple MCP processes share `$HOME` only one process performs the work per trigger.
 - The trigger file's *contents* are ignored — only the modification event matters.
+- Prefer `sync_index` from MCP clients when the assistant can call tools directly after `Edit`/`Write`.
 
 #### Background Sync Configuration (Optional)
 
@@ -241,7 +253,7 @@ CLAUDE_CONTEXT_BACKGROUND_SYNC=false
 CLAUDE_CONTEXT_SYNC_INTERVAL_MS=60000
 ```
 
-For multi-instance local stdio setups, set `CLAUDE_CONTEXT_BACKGROUND_SYNC=false` and keep the trigger watcher enabled. That avoids idle polling while still allowing external tools to request immediate re-indexing by touching `~/.context/.sync-trigger`.
+For multi-instance local stdio setups, set `CLAUDE_CONTEXT_BACKGROUND_SYNC=false` and use `sync_index` and/or the trigger watcher. That avoids idle polling while still allowing on-demand incremental refresh via the MCP tool or `touch ~/.context/.sync-trigger`.
 
 ## Usage with MCP Clients
 
@@ -738,6 +750,41 @@ Get the current indexing status of a codebase. Shows progress percentage for act
 - If a completed entry shows `0 files, 0 chunks`, that usually means the local snapshot metadata is stale rather than the vector database being queried live. Re-indexing, or clearing and re-indexing that exact absolute path, refreshes the stored stats.
 
 For a deeper explanation, see the [asynchronous indexing workflow guide](../../docs/dive-deep/asynchronous-indexing-workflow.md) and the [troubleshooting FAQ](../../docs/troubleshooting/faq.md).
+
+### 5. `sync_index`
+
+Incrementally refresh one or all indexed codebases using change detection (`reindexByChange`). This updates only added, removed, and modified files — it does **not** clear Milvus collections or force a full reindex. Per-codebase options stored at index time (splitter, `ignorePatterns`, `customExtensions`) are preserved from the MCP snapshot and passed into `reindexByChange`.
+
+**Parameters:**
+
+- `path` (optional): Absolute path to a single indexed codebase. If omitted, all indexed codebases are synced.
+- `wait` (optional): If `true` (default), block until sync finishes and return per-path stats. If `false`, start sync in the background and return immediately.
+
+**Behavior:**
+
+- Uses the same global sync lock as background sync and trigger-file sync (`~/.context/mcp-sync.lock`).
+- Response is JSON with fields such as `status`, optional `message`, optional `paths` (per-codebase `added` / `removed` / `modified`), and optional `totals`.
+
+**`status` values:**
+
+| `status` | Meaning |
+|----------|---------|
+| `completed` | Sync finished (`wait=true`); see `paths` and `totals` when present. |
+| `skipped` | Sync not run (e.g. already syncing, lock held elsewhere, or `wait=false` fire-and-forget). |
+| `no_codebases` | Nothing indexed yet — call `index_codebase` first. |
+| `path_not_indexed` | `path` was given but is not a tracked indexed codebase. |
+
+**Example (wait for results):**
+
+```json
+{ "path": "/absolute/path/to/repo", "wait": true }
+```
+
+**Example (background refresh of all indexed repos):**
+
+```json
+{ "wait": false }
+```
 
 ## Contributing
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -773,6 +773,7 @@ Incrementally refresh one or all indexed codebases using change detection (`rein
 | `skipped` | Sync not run (e.g. already syncing, lock held elsewhere, or `wait=false` fire-and-forget). |
 | `no_codebases` | Nothing indexed yet — call `index_codebase` first. |
 | `path_not_indexed` | `path` was given but is not a tracked indexed codebase. |
+| `failed` | Sync aborted due to an unexpected error (`wait=true`); see `message` and any partial `paths`. |
 
 **Example (wait for results):**
 

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as crypto from "crypto";
 import { Context, COLLECTION_LIMIT_MESSAGE, FileSynchronizer, IndexAbortError } from "@zilliz/claude-context-core";
 import { SnapshotManager } from "./snapshot.js";
+import type { SyncManager } from "./sync.js";
 import type { CodebaseIndexOptions, RequestSplitterType } from "./config.js";
 import { createRequestSplitter, isRequestSplitterType } from "./splitter.js";
 import { ensureAbsolutePath, truncateContent, trackCodebasePath } from "./utils.js";
@@ -20,10 +21,12 @@ export class ToolHandlers {
      * just-cleared collection (issue #199).
      */
     private indexingTasks: Map<string, { controller: AbortController; promise: Promise<void> }> = new Map();
+    private syncManager: SyncManager | null;
 
-    constructor(context: Context, snapshotManager: SnapshotManager) {
+    constructor(context: Context, snapshotManager: SnapshotManager, syncManager?: SyncManager) {
         this.context = context;
         this.snapshotManager = snapshotManager;
+        this.syncManager = syncManager ?? null;
         this.currentWorkspace = process.cwd();
         console.log(`[WORKSPACE] Current workspace: ${this.currentWorkspace}`);
     }
@@ -1101,6 +1104,73 @@ export class ToolHandlers {
                     text: `Error getting indexing status: ${error.message || error}`
                 }],
                 isError: true
+            };
+        }
+    }
+
+    public async handleSyncIndex(args: any) {
+        try {
+            if (!this.syncManager) {
+                return {
+                    content: [{
+                        type: "text",
+                        text: "Internal error: sync manager is not available.",
+                    }],
+                    isError: true,
+                };
+            }
+
+            const pathArg = typeof args?.path === "string" ? args.path : undefined;
+            const wait = args?.wait !== false;
+
+            let absolutePath: string | undefined;
+            if (pathArg !== undefined) {
+                absolutePath = ensureAbsolutePath(pathArg);
+                if (!fs.existsSync(absolutePath)) {
+                    return {
+                        content: [{
+                            type: "text",
+                            text: `Error: Path does not exist: ${absolutePath}`,
+                        }],
+                        isError: true,
+                    };
+                }
+                const stat = fs.statSync(absolutePath);
+                if (!stat.isDirectory()) {
+                    return {
+                        content: [{
+                            type: "text",
+                            text: `Error: Path is not a directory: ${absolutePath}`,
+                        }],
+                        isError: true,
+                    };
+                }
+            }
+
+            const result = await this.syncManager.syncIndex({
+                path: absolutePath,
+                wait,
+            });
+
+            const isError =
+                result.status === "path_not_indexed" ||
+                result.status === "no_codebases" ||
+                result.status === "failed";
+
+            return {
+                content: [{
+                    type: "text",
+                    text: JSON.stringify(result, null, 2),
+                }],
+                ...(isError ? { isError: true } : {}),
+            };
+        } catch (error: any) {
+            return {
+                content: [{
+                    type: "text",
+                    text: `Error running sync_index: ${error.message || error}`,
+                }],
+                isError: true,
             };
         }
     }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -75,7 +75,7 @@ class ContextMcpServer {
         // Initialize managers
         this.snapshotManager = new SnapshotManager();
         this.syncManager = new SyncManager(this.context, this.snapshotManager);
-        this.toolHandlers = new ToolHandlers(this.context, this.snapshotManager);
+        this.toolHandlers = new ToolHandlers(this.context, this.snapshotManager, this.syncManager);
 
         // Load existing codebase snapshot on startup
         this.snapshotManager.loadCodebaseSnapshot();
@@ -222,6 +222,25 @@ This tool is versatile and can be used before completing various tasks to retrie
                             required: ["path"]
                         }
                     },
+                    {
+                        name: "sync_index",
+                        description: `Incrementally refresh existing index(es) using file-change detection (reindexByChange). Does not clear collections or force a full reindex. Uses the same global sync lock as background and trigger-file sync. Omit path to sync all indexed codebases.`,
+                        inputSchema: {
+                            type: "object",
+                            properties: {
+                                path: {
+                                    type: "string",
+                                    description: "Optional ABSOLUTE path to one indexed codebase. If omitted, all indexed codebases are synced."
+                                },
+                                wait: {
+                                    type: "boolean",
+                                    description: "If true (default), wait for sync to finish and return stats. If false, start sync in the background and return immediately.",
+                                    default: true
+                                }
+                            },
+                            required: []
+                        }
+                    },
                 ]
             };
         });
@@ -239,6 +258,8 @@ This tool is versatile and can be used before completing various tasks to retrie
                     return await this.toolHandlers.handleClearIndex(args);
                 case "get_indexing_status":
                     return await this.toolHandlers.handleGetIndexingStatus(args);
+                case "sync_index":
+                    return await this.toolHandlers.handleSyncIndex(args);
 
                 default:
                     throw new Error(`Unknown tool: ${name}`);

--- a/packages/mcp/src/sync-index.test.ts
+++ b/packages/mcp/src/sync-index.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { Context } from "@zilliz/claude-context-core";
+
+import { ToolHandlers } from "./handlers.js";
+import { SnapshotManager } from "./snapshot.js";
+import { SyncManager, type SyncIndexResult } from "./sync.js";
+
+async function withTempHome(run: (tempRoot: string, homeDir: string) => Promise<void>): Promise<void> {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "claude-context-mcp-sync-index-"));
+    const homeDir = path.join(tempRoot, "home");
+    await fs.mkdir(homeDir, { recursive: true });
+
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+
+    try {
+        await fs.mkdir(path.join(homeDir, ".context"), { recursive: true });
+        await run(tempRoot, homeDir);
+    } finally {
+        if (originalHome === undefined) {
+            delete process.env.HOME;
+        } else {
+            process.env.HOME = originalHome;
+        }
+        if (originalUserProfile === undefined) {
+            delete process.env.USERPROFILE;
+        } else {
+            process.env.USERPROFILE = originalUserProfile;
+        }
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+}
+
+function createMockContext(reindexByChange?: Context["reindexByChange"]): Context {
+    return {
+        reindexByChange:
+            reindexByChange ??
+            (async () => ({ added: 0, removed: 0, modified: 0 })),
+    } as Context;
+}
+
+test("handleSyncIndex returns isError when path is not indexed", async () => {
+    await withTempHome(async (tempRoot) => {
+        const codebasePath = path.join(tempRoot, "repo");
+        await fs.mkdir(codebasePath, { recursive: true });
+
+        const snapshotManager = new SnapshotManager();
+        const syncManager = new SyncManager(createMockContext(), snapshotManager);
+        const handlers = new ToolHandlers(createMockContext(), snapshotManager, syncManager);
+
+        const result = await handlers.handleSyncIndex({ path: codebasePath });
+
+        assert.equal(result.isError, true);
+        const payload = JSON.parse(result.content[0].text) as SyncIndexResult;
+        assert.equal(payload.status, "path_not_indexed");
+    });
+});
+
+test("handleSyncIndex returns JSON with status completed and totals when syncManager returns completed", async () => {
+    await withTempHome(async () => {
+        const snapshotManager = new SnapshotManager();
+        const completed: SyncIndexResult = {
+            status: "completed",
+            paths: [{ path: "/tmp/repo", added: 2, removed: 1, modified: 3 }],
+            totals: { added: 2, removed: 1, modified: 3 },
+        };
+
+        const syncManager = {
+            syncIndex: async () => completed,
+        } as unknown as SyncManager;
+
+        const handlers = new ToolHandlers(createMockContext(), snapshotManager, syncManager);
+        const result = await handlers.handleSyncIndex({ wait: true });
+
+        assert.equal(result.isError, undefined);
+        const payload = JSON.parse(result.content[0].text) as SyncIndexResult;
+        assert.equal(payload.status, "completed");
+        assert.deepEqual(payload.totals, { added: 2, removed: 1, modified: 3 });
+        assert.equal(payload.paths?.length, 1);
+    });
+});
+
+test("syncIndex with wait=false returns skipped and does not block on reindexByChange", async () => {
+    await withTempHome(async (tempRoot) => {
+        const codebasePath = path.join(tempRoot, "repo");
+        await fs.mkdir(codebasePath, { recursive: true });
+
+        let reindexCalls = 0;
+        const context = createMockContext(async () => {
+            reindexCalls += 1;
+            return { added: 0, removed: 0, modified: 0 };
+        });
+
+        const snapshotManager = new SnapshotManager();
+        snapshotManager.setCodebaseIndexed(codebasePath, {
+            indexedFiles: 1,
+            totalChunks: 1,
+            status: "completed",
+        });
+        snapshotManager.saveCodebaseSnapshot();
+
+        const syncManager = new SyncManager(context, snapshotManager);
+        const start = Date.now();
+        const result = await syncManager.syncIndex({ path: codebasePath, wait: false });
+        const elapsed = Date.now() - start;
+
+        assert.equal(result.status, "skipped");
+        assert.match(result.message ?? "", /background/i);
+        assert.ok(elapsed < 500, `expected non-blocking return, took ${elapsed}ms`);
+
+        await new Promise((r) => setTimeout(r, 50));
+        assert.equal(reindexCalls, 1, "background sync should invoke reindexByChange without blocking the tool response");
+    });
+});
+
+test("syncIndex returns skipped when isSyncing is already true", async () => {
+    await withTempHome(async (tempRoot) => {
+        const codebasePath = path.join(tempRoot, "repo");
+        await fs.mkdir(codebasePath, { recursive: true });
+
+        const snapshotManager = new SnapshotManager();
+        snapshotManager.setCodebaseIndexed(codebasePath, {
+            indexedFiles: 1,
+            totalChunks: 1,
+            status: "completed",
+        });
+        snapshotManager.saveCodebaseSnapshot();
+
+        const syncManager = new SyncManager(createMockContext(), snapshotManager);
+        (syncManager as unknown as { isSyncing: boolean }).isSyncing = true;
+
+        const result = await syncManager.syncIndex({ wait: true });
+
+        assert.equal(result.status, "skipped");
+        assert.match(result.message ?? "", /already in progress/i);
+    });
+});
+
+test("syncIndex returns skipped when global sync lock is held", async () => {
+    await withTempHome(async (tempRoot, homeDir) => {
+        const codebasePath = path.join(tempRoot, "repo");
+        await fs.mkdir(codebasePath, { recursive: true });
+
+        const lockPath = path.join(homeDir, ".context", "mcp-sync.lock");
+        fsSync.mkdirSync(lockPath);
+        fsSync.writeFileSync(
+            path.join(lockPath, "owner.json"),
+            JSON.stringify({ pid: 99999, token: "other-process", acquiredAt: new Date().toISOString() }, null, 2)
+        );
+
+        const snapshotManager = new SnapshotManager();
+        snapshotManager.setCodebaseIndexed(codebasePath, {
+            indexedFiles: 1,
+            totalChunks: 1,
+            status: "completed",
+        });
+        snapshotManager.saveCodebaseSnapshot();
+
+        const syncManager = new SyncManager(createMockContext(), snapshotManager);
+        const result = await syncManager.syncIndex({ wait: true });
+
+        assert.equal(result.status, "skipped");
+        assert.match(result.message ?? "", /global sync lock|another MCP/i);
+    });
+});

--- a/packages/mcp/src/sync-index.test.ts
+++ b/packages/mcp/src/sync-index.test.ts
@@ -144,6 +144,18 @@ test("syncIndex returns skipped when isSyncing is already true", async () => {
     });
 });
 
+test("syncIndex returns no_codebases when snapshot is empty and path omitted", async () => {
+    await withTempHome(async () => {
+        const snapshotManager = new SnapshotManager();
+        const syncManager = new SyncManager(createMockContext(), snapshotManager);
+
+        const result = await syncManager.syncIndex({ wait: true });
+
+        assert.equal(result.status, "no_codebases");
+        assert.match(result.message ?? "", /index_codebase/i);
+    });
+});
+
 test("syncIndex returns skipped when global sync lock is held", async () => {
     await withTempHome(async (tempRoot, homeDir) => {
         const codebasePath = path.join(tempRoot, "repo");

--- a/packages/mcp/src/sync.ts
+++ b/packages/mcp/src/sync.ts
@@ -12,6 +12,22 @@ const MIN_SYNC_INTERVAL_MS = 1_000;
 const DEFAULT_SYNC_LOCK_STALE_MS = 10 * 60 * 1000;
 const SYNC_LOCK_STALE_ENV = "CLAUDE_CONTEXT_SYNC_LOCK_STALE_MS";
 
+export type SyncPathStats = {
+    path: string;
+    added: number;
+    removed: number;
+    modified: number;
+    skipped?: boolean;
+    error?: string;
+};
+
+export type SyncIndexResult = {
+    status: "completed" | "skipped" | "no_codebases" | "path_not_indexed" | "failed";
+    message?: string;
+    paths?: SyncPathStats[];
+    totals?: { added: number; removed: number; modified: number };
+};
+
 function isBackgroundSyncEnabled(): boolean {
     const value = envManager.get("CLAUDE_CONTEXT_BACKGROUND_SYNC");
     if (!value) {
@@ -156,51 +172,122 @@ export class SyncManager {
         }
     }
 
-    public async handleSyncIndex(): Promise<void> {
-        const syncStartTime = Date.now();
-        console.log(`[SYNC-DEBUG] handleSyncIndex() called at ${new Date().toISOString()}`);
+    public async syncIndex(options?: { path?: string; wait?: boolean }): Promise<SyncIndexResult> {
+        const wait = options?.wait !== false;
+        const requestedPath = options?.path?.trim();
 
-        const indexedCodebases = this.snapshotManager.getIndexedCodebases();
-
-        if (indexedCodebases.length === 0) {
-            console.log('[SYNC-DEBUG] No codebases indexed. Skipping sync.');
-            return;
+        if (requestedPath) {
+            const resolved = path.resolve(requestedPath);
+            const indexedPath = this.snapshotManager.findIndexedCodebasePath(resolved);
+            if (!indexedPath) {
+                return {
+                    status: "path_not_indexed",
+                    message: `Codebase is not indexed: ${resolved}. Use index_codebase first.`,
+                };
+            }
         }
 
-        console.log(`[SYNC-DEBUG] Found ${indexedCodebases.length} indexed codebases:`, indexedCodebases);
+        const allIndexed = this.snapshotManager.getIndexedCodebases();
+        if (allIndexed.length === 0) {
+            return {
+                status: "no_codebases",
+                message: "No codebases are indexed. Use index_codebase first.",
+            };
+        }
+
+        if (!wait) {
+            if (this.isSyncing) {
+                return {
+                    status: "skipped",
+                    message: "Index sync already in progress in this process.",
+                };
+            }
+            if (!this.isGlobalSyncLockAvailable()) {
+                return {
+                    status: "skipped",
+                    message: "Another MCP process holds the global sync lock or sync is in progress.",
+                };
+            }
+            void this.handleSyncIndex(requestedPath ? path.resolve(requestedPath) : undefined);
+            return {
+                status: "skipped",
+                message: "Incremental sync started in the background (wait=false).",
+            };
+        }
 
         if (this.isSyncing) {
-            console.log('[SYNC-DEBUG] Index sync already in progress. Skipping.');
-            return;
+            return {
+                status: "skipped",
+                message: "Index sync already in progress in this process.",
+            };
         }
 
         if (!this.acquireGlobalSyncLock()) {
-            return;
+            return {
+                status: "skipped",
+                message: "Another MCP process holds the global sync lock or sync is in progress.",
+            };
+        }
+
+        return await this.runSyncLocked(requestedPath ? path.resolve(requestedPath) : undefined);
+    }
+
+    private async runSyncLocked(singlePath?: string): Promise<SyncIndexResult> {
+        const syncStartTime = Date.now();
+        const indexedCodebases = this.snapshotManager.getIndexedCodebases();
+        let targets: string[];
+
+        if (singlePath) {
+            const indexedPath = this.snapshotManager.findIndexedCodebasePath(singlePath);
+            if (!indexedPath) {
+                this.releaseGlobalSyncLock();
+                return {
+                    status: "path_not_indexed",
+                    message: `Codebase is not indexed: ${singlePath}. Use index_codebase first.`,
+                };
+            }
+            targets = [indexedPath];
+        } else {
+            targets = indexedCodebases;
         }
 
         this.isSyncing = true;
-        console.log(`[SYNC-DEBUG] Starting index sync for all ${indexedCodebases.length} codebases...`);
+        console.log(`[SYNC-DEBUG] Starting index sync for ${targets.length} codebase(s)...`);
+
+        const pathResults: SyncPathStats[] = [];
+        let totals = { added: 0, removed: 0, modified: 0 };
 
         try {
-            let totalStats = { added: 0, removed: 0, modified: 0 };
-
-            for (let i = 0; i < indexedCodebases.length; i++) {
-                const codebasePath = indexedCodebases[i];
+            for (let i = 0; i < targets.length; i++) {
+                const codebasePath = targets[i];
                 const codebaseStartTime = Date.now();
 
-                console.log(`[SYNC-DEBUG] [${i + 1}/${indexedCodebases.length}] Starting sync for codebase: '${codebasePath}'`);
+                console.log(`[SYNC-DEBUG] [${i + 1}/${targets.length}] Starting sync for codebase: '${codebasePath}'`);
 
-                // Check if codebase path still exists
                 try {
                     const pathExists = fs.existsSync(codebasePath);
-                    console.log(`[SYNC-DEBUG] Codebase path exists: ${pathExists}`);
-
                     if (!pathExists) {
                         console.warn(`[SYNC-DEBUG] Codebase path '${codebasePath}' no longer exists. Skipping sync.`);
+                        pathResults.push({
+                            path: codebasePath,
+                            added: 0,
+                            removed: 0,
+                            modified: 0,
+                            skipped: true,
+                            error: "Path no longer exists on disk",
+                        });
                         continue;
                     }
                 } catch (pathError: any) {
                     console.error(`[SYNC-DEBUG] Error checking codebase path '${codebasePath}':`, pathError);
+                    pathResults.push({
+                        path: codebasePath,
+                        added: 0,
+                        removed: 0,
+                        modified: 0,
+                        skipped: true,
+                        error: pathError?.message || String(pathError),
+                    });
                     continue;
                 }
 
@@ -219,13 +306,15 @@ export class SyncManager {
                     );
                     const codebaseElapsed = Date.now() - codebaseStartTime;
 
-                    console.log(`[SYNC-DEBUG] Reindex stats for '${codebasePath}':`, stats);
-                    console.log(`[SYNC-DEBUG] Codebase sync completed in ${codebaseElapsed}ms`);
-
-                    // Accumulate total stats
-                    totalStats.added += stats.added;
-                    totalStats.removed += stats.removed;
-                    totalStats.modified += stats.modified;
+                    pathResults.push({
+                        path: codebasePath,
+                        added: stats.added,
+                        removed: stats.removed,
+                        modified: stats.modified,
+                    });
+                    totals.added += stats.added;
+                    totals.removed += stats.removed;
+                    totals.modified += stats.modified;
 
                     if (stats.added > 0 || stats.removed > 0 || stats.modified > 0) {
                         console.log(`[SYNC] Sync complete for '${codebasePath}'. Added: ${stats.added}, Removed: ${stats.removed}, Modified: ${stats.modified} (${codebaseElapsed}ms)`);
@@ -235,39 +324,85 @@ export class SyncManager {
                 } catch (error: any) {
                     const codebaseElapsed = Date.now() - codebaseStartTime;
                     console.error(`[SYNC-DEBUG] Error syncing codebase '${codebasePath}' after ${codebaseElapsed}ms:`, error);
-                    console.error(`[SYNC-DEBUG] Error stack:`, error.stack);
 
-                    if (error.message.includes('Failed to query Milvus')) {
-                        // Collection maybe deleted manually, delete the snapshot file
+                    if (error.message?.includes("Failed to query Milvus")) {
                         await FileSynchronizer.deleteSnapshot(codebasePath);
                     }
 
-                    // Log additional error details
-                    if (error.code) {
-                        console.error(`[SYNC-DEBUG] Error code: ${error.code}`);
-                    }
-                    if (error.errno) {
-                        console.error(`[SYNC-DEBUG] Error errno: ${error.errno}`);
-                    }
-
-                    // Continue with next codebase even if one fails
+                    pathResults.push({
+                        path: codebasePath,
+                        added: 0,
+                        removed: 0,
+                        modified: 0,
+                        error: error?.message || String(error),
+                    });
                 }
             }
 
             const totalElapsed = Date.now() - syncStartTime;
-            console.log(`[SYNC-DEBUG] Total sync stats across all codebases: Added: ${totalStats.added}, Removed: ${totalStats.removed}, Modified: ${totalStats.modified}`);
-            console.log(`[SYNC-DEBUG] Index sync completed for all codebases in ${totalElapsed}ms`);
-            console.log(`[SYNC] Index sync completed for all codebases. Total changes - Added: ${totalStats.added}, Removed: ${totalStats.removed}, Modified: ${totalStats.modified}`);
+            console.log(`[SYNC] Index sync completed in ${totalElapsed}ms. Totals - Added: ${totals.added}, Removed: ${totals.removed}, Modified: ${totals.modified}`);
+
+            return {
+                status: "completed",
+                paths: pathResults,
+                totals,
+            };
         } catch (error: any) {
-            const totalElapsed = Date.now() - syncStartTime;
-            console.error(`[SYNC-DEBUG] Error during index sync after ${totalElapsed}ms:`, error);
-            console.error(`[SYNC-DEBUG] Error stack:`, error.stack);
+            console.error(`[SYNC-DEBUG] Error during index sync:`, error);
+            return {
+                status: "failed",
+                message: error?.message || String(error),
+                paths: pathResults,
+                totals,
+            };
         } finally {
             this.isSyncing = false;
             this.releaseGlobalSyncLock();
-            const totalElapsed = Date.now() - syncStartTime;
-            console.log(`[SYNC-DEBUG] handleSyncIndex() finished at ${new Date().toISOString()}, total duration: ${totalElapsed}ms`);
+            console.log(`[SYNC-DEBUG] runSyncLocked() finished, duration: ${Date.now() - syncStartTime}ms`);
         }
+    }
+
+    private isGlobalSyncLockAvailable(): boolean {
+        const lockPath = this.getSyncLockPath();
+        const staleMs = this.getSyncLockStaleMs();
+        try {
+            if (!fs.existsSync(lockPath)) {
+                return true;
+            }
+            const stat = fs.statSync(lockPath);
+            if (Date.now() - stat.mtimeMs > staleMs) {
+                return true;
+            }
+            return false;
+        } catch {
+            return false;
+        }
+    }
+
+    public async handleSyncIndex(optionalSinglePath?: string): Promise<void> {
+        const syncStartTime = Date.now();
+        console.log(`[SYNC-DEBUG] handleSyncIndex() called at ${new Date().toISOString()}`);
+
+        const indexedCodebases = this.snapshotManager.getIndexedCodebases();
+
+        if (indexedCodebases.length === 0) {
+            console.log("[SYNC-DEBUG] No codebases indexed. Skipping sync.");
+            return;
+        }
+
+        if (this.isSyncing) {
+            console.log("[SYNC-DEBUG] Index sync already in progress. Skipping.");
+            return;
+        }
+
+        if (!this.acquireGlobalSyncLock()) {
+            return;
+        }
+
+        await this.runSyncLocked(optionalSinglePath);
+        console.log(
+            `[SYNC-DEBUG] handleSyncIndex() finished at ${new Date().toISOString()}, total duration: ${Date.now() - syncStartTime}ms`
+        );
     }
 
     public startBackgroundSync(): void {


### PR DESCRIPTION
## Summary

Adds a first-class MCP tool **`sync_index`** so clients can incrementally refresh existing indexes via `Context.reindexByChange`, without `force=true` full reindex or out-of-band `~/.context/.sync-trigger` touches.

## Changes

| Area | What changed |
|------|----------------|
| `packages/mcp/src/sync.ts` | New `syncIndex({ path?, wait? })` and `runSyncLocked`; `handleSyncIndex` delegates to shared lock + per-codebase `reindexByChange` using snapshot-stored splitter/ignore/custom extensions. Returns stats `{ added, modified, removed }` and clear outcomes when lock busy (`wait: false`) or path not indexed. |
| `packages/mcp/src/handlers.ts` | `handleSyncIndex` validates optional absolute path against indexed snapshot, invokes `SyncManager.syncIndex`, returns JSON tool result. |
| `packages/mcp/src/index.ts` | Registers `sync_index` in ListTools + CallTool dispatch (optional `path`, `wait` default true). |
| `packages/mcp/src/sync-index.test.ts` | Unit tests for tool wiring, path validation, wait/lock behavior, stats shape (10 tests in MCP package suite). |
| `packages/mcp/README.md`, `CONTRIBUTING.md` | Document `sync_index` parameters and behavior; clarify **`CLAUDE_CONTEXT_TRIGGER_WATCHER` watches only `~/.context/.sync-trigger`**, not project directories. |

## Verification

```bash
pnpm --filter @zilliz/claude-context-core build && pnpm --filter @zilliz/claude-context-mcp test
```

All tests passed.

## Git

- **Branch:** `berserk/7368c510-3d76-41e5-ae16-462eae4765ad`
- **Commit:** `6b055ca`
- **Pushed** to `origin`

Addresses [zilliztech/claude-context#394](https://github.com/zilliztech/claude-context/issues/394) (related #238).

## Commit

6b055ca

## Branch

berserk/7368c510-3d76-41e5-ae16-462eae4765ad

Fixes #394
