### PR TITLE
Add privacy-preserving search receipts

### DIFF
--- a/packages/mcp/src/handlers.search-receipt.test.ts
+++ b/packages/mcp/src/handlers.search-receipt.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { ToolHandlers } from "./handlers.js";
+import { SnapshotManager } from "./snapshot.js";
+
+async function withTempHome(run: (tempRoot: string) => Promise<void>): Promise<void> {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "claude-context-mcp-search-receipt-"));
+    const homeDir = path.join(tempRoot, "home");
+    await mkdir(homeDir, { recursive: true });
+
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+
+    try {
+        await run(tempRoot);
+    } finally {
+        if (originalHome === undefined) {
+            delete process.env.HOME;
+        } else {
+            process.env.HOME = originalHome;
+        }
+
+        if (originalUserProfile === undefined) {
+            delete process.env.USERPROFILE;
+        } else {
+            process.env.USERPROFILE = originalUserProfile;
+        }
+
+        await rm(tempRoot, { recursive: true, force: true });
+    }
+}
+
+function extractReceipt(text: string): any {
+    const marker = "Search receipt:";
+    const markerIndex = text.indexOf(marker);
+    assert.notEqual(markerIndex, -1);
+
+    const receiptText = text.slice(markerIndex + marker.length).trim();
+    assert.ok(receiptText.startsWith("```json"));
+    assert.ok(receiptText.endsWith("```"));
+
+    return JSON.parse(receiptText.replace(/^```json\s*/, "").replace(/\s*```$/, ""));
+}
+
+test("search_code can include a privacy-preserving result receipt", async () => {
+    await withTempHome(async (tempRoot) => {
+        const codebasePath = path.join(tempRoot, "repo");
+        await mkdir(codebasePath, { recursive: true });
+
+        const snapshotManager = new SnapshotManager();
+        snapshotManager.setCodebaseIndexed(codebasePath, {
+            indexedFiles: 2,
+            totalChunks: 4,
+            status: "completed",
+        });
+        snapshotManager.saveCodebaseSnapshot();
+
+        const rawQuery = "where is the CUSTOMER_SECRET auth token?";
+        const rawContent = "const CUSTOMER_SECRET = process.env.CUSTOMER_SECRET;";
+        const rawPath = "src/private/session.ts";
+        const context = {
+            getEmbedding() {
+                return { getProvider: () => "test" };
+            },
+            async semanticSearch() {
+                return [{
+                    content: rawContent,
+                    relativePath: rawPath,
+                    startLine: 10,
+                    endLine: 12,
+                    language: "typescript",
+                    score: 0.91,
+                }];
+            },
+        };
+
+        const handlers = new ToolHandlers(context as any, snapshotManager);
+        (handlers as any).syncIndexedCodebasesFromCloud = async () => undefined;
+
+        const result = await handlers.handleSearchCode({
+            path: codebasePath,
+            query: rawQuery,
+            includeReceipt: true,
+        });
+
+        assert.equal(result.isError, undefined);
+        const text = result.content[0].text;
+        const receipt = extractReceipt(text);
+
+        assert.equal(receipt.event, "context.search.returned");
+        assert.match(receipt.receipt_id, /^sha256:[a-f0-9]{64}$/);
+        assert.match(receipt.query_hash, /^sha256:[a-f0-9]{64}$/);
+        assert.match(receipt.codebase_path_hash, /^sha256:[a-f0-9]{64}$/);
+        assert.match(receipt.index_snapshot_id, /^sha256:[a-f0-9]{64}$/);
+        assert.equal(receipt.result_count, 1);
+        assert.equal(receipt.results[0].rank, 1);
+        assert.equal(receipt.results[0].source.range, "L10-L12");
+        assert.equal(receipt.results[0].source.extension, ".ts");
+        assert.equal(receipt.results[0].score_bucket, "high");
+        assert.match(receipt.results[0].chunk.hash, /^sha256:[a-f0-9]{64}$/);
+        assert.match(receipt.results[0].duplicate.dedupe_key, /^sha256:[a-f0-9]{64}$/);
+
+        const receiptJson = JSON.stringify(receipt);
+        assert.equal(receiptJson.includes(rawQuery), false);
+        assert.equal(receiptJson.includes(rawContent), false);
+        assert.equal(receiptJson.includes(rawPath), false);
+        assert.equal(receiptJson.includes(codebasePath), false);
+    });
+});

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -7,6 +7,32 @@ import type { CodebaseIndexOptions, RequestSplitterType } from "./config.js";
 import { createRequestSplitter, isRequestSplitterType } from "./splitter.js";
 import { ensureAbsolutePath, truncateContent, trackCodebasePath } from "./utils.js";
 
+interface SearchReceiptResult {
+    rank: number;
+    score_bucket: "high" | "medium" | "low";
+    source: {
+        path_hash: string;
+        extension: string;
+        range: string;
+    };
+    chunk: {
+        hash: string;
+    };
+    duplicate: {
+        dedupe_key: string;
+    };
+}
+
+interface SearchReceipt {
+    event: "context.search.returned";
+    receipt_id: string;
+    query_hash: string;
+    codebase_path_hash: string;
+    index_snapshot_id: string;
+    result_count: number;
+    results: SearchReceiptResult[];
+}
+
 export class ToolHandlers {
     private context: Context;
     private snapshotManager: SnapshotManager;
@@ -26,6 +52,70 @@ export class ToolHandlers {
         this.snapshotManager = snapshotManager;
         this.currentWorkspace = process.cwd();
         console.log(`[WORKSPACE] Current workspace: ${this.currentWorkspace}`);
+    }
+
+    private sha256(value: unknown): string {
+        const payload = typeof value === "string" ? value : JSON.stringify(value);
+        return `sha256:${crypto.createHash("sha256").update(payload).digest("hex")}`;
+    }
+
+    private scoreBucket(score: number): "high" | "medium" | "low" {
+        if (score >= 0.8) return "high";
+        if (score >= 0.5) return "medium";
+        return "low";
+    }
+
+    private buildSearchReceipt(
+        searchCodebasePath: string,
+        query: string,
+        searchResults: Array<{
+            content: string;
+            relativePath: string;
+            startLine: number;
+            endLine: number;
+            score: number;
+        }>
+    ): SearchReceipt {
+        const snapshotInfo = this.snapshotManager.getCodebaseInfo(searchCodebasePath) ?? { status: "unknown" };
+        const results = searchResults.map((result, index) => {
+            const range = `L${result.startLine}-L${result.endLine}`;
+            const pathHash = this.sha256(result.relativePath);
+            const chunkHash = this.sha256(result.content);
+
+            return {
+                rank: index + 1,
+                score_bucket: this.scoreBucket(result.score),
+                source: {
+                    path_hash: pathHash,
+                    extension: path.extname(result.relativePath),
+                    range
+                },
+                chunk: {
+                    hash: chunkHash
+                },
+                duplicate: {
+                    dedupe_key: this.sha256({ path_hash: pathHash, range, chunk_hash: chunkHash })
+                }
+            };
+        });
+
+        const receiptCore = {
+            query_hash: this.sha256(query),
+            codebase_path_hash: this.sha256(searchCodebasePath),
+            index_snapshot_id: this.sha256(snapshotInfo),
+            result_count: searchResults.length,
+            results
+        };
+
+        return {
+            event: "context.search.returned",
+            receipt_id: this.sha256(receiptCore),
+            ...receiptCore
+        };
+    }
+
+    private formatSearchReceipt(receipt: SearchReceipt): string {
+        return `\n\nSearch receipt:\n\`\`\`json\n${JSON.stringify(receipt, null, 2)}\n\`\`\``;
     }
 
     /**
@@ -645,7 +735,7 @@ export class ToolHandlers {
     }
 
     public async handleSearchCode(args: any) {
-        const { path: codebasePath, query, limit = 10, extensionFilter } = args;
+        const { path: codebasePath, query, limit = 10, extensionFilter, includeReceipt = false } = args;
         const resultLimit = limit || 10;
 
         try {
@@ -789,6 +879,9 @@ export class ToolHandlers {
                 if (isIndexing) {
                     noResultsMessage += `\n\nNote: This codebase is still being indexed. Try searching again after indexing completes, or the query may not match any indexed content.`;
                 }
+                if (includeReceipt === true) {
+                    noResultsMessage += this.formatSearchReceipt(this.buildSearchReceipt(searchCodebasePath, query, []));
+                }
                 return {
                     content: [{
                         type: "text",
@@ -814,6 +907,9 @@ export class ToolHandlers {
                 resultMessage += `\nRequested path '${absolutePath}' is covered by indexed codebase '${searchCodebasePath}'.`;
             }
             resultMessage += `\n\n${formattedResults}`;
+            if (includeReceipt === true) {
+                resultMessage += this.formatSearchReceipt(this.buildSearchReceipt(searchCodebasePath, query, searchResults));
+            }
 
             if (isIndexing) {
                 resultMessage += `\n\n💡 **Tip**: This codebase is still being indexed. More results may become available as indexing progresses.`;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -189,6 +189,11 @@ This tool is versatile and can be used before completing various tasks to retrie
                                     },
                                     description: "Optional: List of file extensions to filter results. (e.g., ['.ts','.py']).",
                                     default: []
+                                },
+                                includeReceipt: {
+                                    type: "boolean",
+                                    description: "Optional: Include a privacy-preserving search result receipt with hashes, ranks, score buckets, and ranges.",
+                                    default: false
                                 }
                             },
                             required: ["path", "query"]


### PR DESCRIPTION
## Summary

Refs #382.

This adds an optional `includeReceipt` flag to the MCP `search_code` tool. When enabled, the existing search response is preserved and a privacy-preserving JSON receipt is appended with:

- `receipt_id`, `query_hash`, `codebase_path_hash`, and `index_snapshot_id`
- `result_count`
- per-result rank, score bucket, source range, source path hash, chunk hash, and dedupe key

The receipt intentionally avoids raw query text, raw code content, raw local codebase paths, and raw relative file paths.

## Why

Issue #382 proposes a retrieval-boundary receipt that lets downstream clients or eval harnesses correlate returned search results with later loaded context chunks without requiring Claude Context to own full agent telemetry.

## Validation

Current local validation on Windows, 2026-07-02:

- `pnpm install --frozen-lockfile --config.dangerouslyAllowAllBuilds=true`
- `pnpm --filter @zilliz/claude-context-core build`
- `pnpm --filter @zilliz/claude-context-mcp exec node --import tsx --test src/handlers.search-receipt.test.ts`
- `pnpm --filter @zilliz/claude-context-mcp test`
- `pnpm --filter @zilliz/claude-context-mcp typecheck`

All of the above pass. The install flag is only to make pnpm 11's build-script approval gate non-interactive in local verification; it does not change the package code.
