### PR TITLE
feat(core): content-hash embedding cache to avoid re-embedding identical chunks

### DIFF
--- a/packages/core/jest.config.cjs
+++ b/packages/core/jest.config.cjs
@@ -2,4 +2,5 @@ module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     testMatch: ['<rootDir>/src/**/*.test.ts'],
+    setupFiles: ['<rootDir>/jest.setup.cjs'],
 };

--- a/packages/core/jest.setup.cjs
+++ b/packages/core/jest.setup.cjs
@@ -1,0 +1,11 @@
+// Redirect the embedding cache to a throwaway directory during tests so the
+// suite never reads from or writes to the developer's real
+// `~/.context/embedding-cache`. Individual tests that assert on embedder calls
+// can still set EMBEDDING_CACHE=false to bypass the cache entirely.
+const os = require('os');
+const path = require('path');
+
+process.env.EMBEDDING_CACHE_DIR = path.join(
+    os.tmpdir(),
+    `claude-context-test-embcache-${process.pid}`
+);

--- a/packages/core/src/context.embedding-error.test.ts
+++ b/packages/core/src/context.embedding-error.test.ts
@@ -86,6 +86,7 @@ describe('Context embedding failure handling', () => {
     let originalHome: string | undefined;
     let originalHybridMode: string | undefined;
     let originalEmbeddingBatchSize: string | undefined;
+    let originalEmbeddingCache: string | undefined;
 
     beforeEach(async () => {
         tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-context-embedding-error-'));
@@ -94,8 +95,13 @@ describe('Context embedding failure handling', () => {
         originalHome = process.env.HOME;
         originalHybridMode = process.env.HYBRID_MODE;
         originalEmbeddingBatchSize = process.env.EMBEDDING_BATCH_SIZE;
+        originalEmbeddingCache = process.env.EMBEDDING_CACHE;
         process.env.HOME = homeDir;
         process.env.HYBRID_MODE = 'false';
+        // These tests assert on how the embedder itself behaves, so bypass the
+        // content-addressed cache — a cache hit would short-circuit the very
+        // embedder call under test.
+        process.env.EMBEDDING_CACHE = 'false';
     });
 
     afterEach(async () => {
@@ -113,6 +119,11 @@ describe('Context embedding failure handling', () => {
             delete process.env.EMBEDDING_BATCH_SIZE;
         } else {
             process.env.EMBEDDING_BATCH_SIZE = originalEmbeddingBatchSize;
+        }
+        if (originalEmbeddingCache === undefined) {
+            delete process.env.EMBEDDING_CACHE;
+        } else {
+            process.env.EMBEDDING_CACHE = originalEmbeddingCache;
         }
         await fs.rm(tempRoot, { recursive: true, force: true });
     });

--- a/packages/core/src/context.ignore-patterns.test.ts
+++ b/packages/core/src/context.ignore-patterns.test.ts
@@ -169,8 +169,7 @@ describe('Context ignore pattern isolation', () => {
         try {
             await context.reindexByChange(project, undefined, ['*.ts'], ['foo']);
 
-            const collectionName = context.getCollectionName(project);
-            const synchronizer = context.getSynchronizers().get(collectionName);
+            const synchronizer = context.getSynchronizers().get(path.resolve(project));
 
             expect(synchronizer).toBeDefined();
             expect(synchronizer?.getFileHash('custom.foo')).toBeDefined();

--- a/packages/core/src/context.overlay-refresh.test.ts
+++ b/packages/core/src/context.overlay-refresh.test.ts
@@ -1,0 +1,265 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { Context } from './context';
+import { Embedding, EmbeddingVector } from './embedding';
+import { Splitter, CodeChunk } from './splitter';
+import { VectorDatabase } from './vectordb';
+
+class TestEmbedding extends Embedding {
+    protected maxTokens = 8192;
+
+    async detectDimension(): Promise<number> {
+        return 3;
+    }
+
+    async embed(_text: string): Promise<EmbeddingVector> {
+        return { vector: [1, 0, 0], dimension: 3 };
+    }
+
+    async embedBatch(texts: string[]): Promise<EmbeddingVector[]> {
+        return texts.map(() => ({ vector: [1, 0, 0], dimension: 3 }));
+    }
+
+    getDimension(): number {
+        return 3;
+    }
+
+    getProvider(): string {
+        return 'test';
+    }
+}
+
+class PassthroughSplitter implements Splitter {
+    async split(code: string, language: string, filePath?: string): Promise<CodeChunk[]> {
+        return [{
+            content: code,
+            metadata: {
+                startLine: 1,
+                endLine: code.split('\n').length,
+                language,
+                filePath,
+            },
+        }];
+    }
+
+    setChunkSize(): void { }
+    setChunkOverlap(): void { }
+}
+
+const createVectorDatabase = (): jest.Mocked<VectorDatabase> => ({
+    createCollection: jest.fn().mockResolvedValue(undefined),
+    createHybridCollection: jest.fn().mockResolvedValue(undefined),
+    dropCollection: jest.fn().mockResolvedValue(undefined),
+    hasCollection: jest.fn().mockResolvedValue(true),
+    listCollections: jest.fn().mockResolvedValue([]),
+    insert: jest.fn().mockResolvedValue(undefined),
+    insertHybrid: jest.fn().mockResolvedValue(undefined),
+    search: jest.fn().mockResolvedValue([]),
+    hybridSearch: jest.fn().mockResolvedValue([]),
+    delete: jest.fn().mockResolvedValue(undefined),
+    query: jest.fn().mockResolvedValue([]),
+    getCollectionDescription: jest.fn().mockResolvedValue(''),
+    checkCollectionLimit: jest.fn().mockResolvedValue(true),
+    getCollectionRowCount: jest.fn().mockResolvedValue(0),
+});
+
+/** Comfortably past BASE_STALENESS_WARN_COMMITS so the notice must fire. */
+const BASE_DRIFT_COMMITS = 12;
+
+const git = (repo: string, ...args: string[]): string =>
+    execFileSync('git', ['-C', repo, ...args], { encoding: 'utf-8' });
+
+/** Paths passed to insert(), across every call, as repo-relative strings. */
+const insertedPaths = (vectorDatabase: jest.Mocked<VectorDatabase>): string[] =>
+    vectorDatabase.insert.mock.calls.flatMap(([, documents]) =>
+        (documents as Array<{ relativePath: string }>).map(d => d.relativePath));
+
+describe('Context lazy overlay refresh on search', () => {
+    let tempRoot: string;
+    let repo: string;
+    let originalHome: string | undefined;
+    let originalHybridMode: string | undefined;
+
+    beforeEach(async () => {
+        tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-context-overlay-'));
+        const homeDir = path.join(tempRoot, 'home');
+        await fs.mkdir(homeDir, { recursive: true });
+        originalHome = process.env.HOME;
+        originalHybridMode = process.env.HYBRID_MODE;
+        process.env.HOME = homeDir;
+        process.env.HYBRID_MODE = 'false';
+
+        repo = path.join(tempRoot, 'repo');
+        await fs.mkdir(repo, { recursive: true });
+        git(repo, 'init', '-b', 'main');
+        git(repo, 'config', 'user.email', 'test@example.com');
+        git(repo, 'config', 'user.name', 'Test');
+        await fs.writeFile(path.join(repo, 'base.ts'), 'export const base = 1;\n');
+        await fs.writeFile(path.join(repo, 'feature.ts'), 'export const feature = 1;\n');
+        git(repo, 'add', '.');
+        git(repo, 'commit', '-m', 'base');
+        git(repo, 'checkout', '-b', 'feature');
+    });
+
+    afterEach(async () => {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalHybridMode === undefined) delete process.env.HYBRID_MODE;
+        else process.env.HYBRID_MODE = originalHybridMode;
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    });
+
+    const newContext = (vectorDatabase: jest.Mocked<VectorDatabase>) => new Context({
+        embedding: new TestEmbedding(),
+        vectorDatabase,
+        codeSplitter: new PassthroughSplitter(),
+    });
+
+    it('indexes a file the branch touched before answering the search', async () => {
+        await fs.writeFile(path.join(repo, 'feature.ts'), 'export const feature = 2;\n');
+        const vectorDatabase = createVectorDatabase();
+
+        await newContext(vectorDatabase).semanticSearch(repo, 'feature', 5, 0.5);
+
+        expect(insertedPaths(vectorDatabase)).toEqual(['feature.ts']);
+    });
+
+    it('leaves an unchanged overlay alone on the next search', async () => {
+        await fs.writeFile(path.join(repo, 'feature.ts'), 'export const feature = 2;\n');
+        const vectorDatabase = createVectorDatabase();
+        const context = newContext(vectorDatabase);
+
+        await context.semanticSearch(repo, 'feature', 5, 0.5);
+        vectorDatabase.insert.mockClear();
+        await context.semanticSearch(repo, 'feature', 5, 0.5);
+
+        expect(vectorDatabase.insert).not.toHaveBeenCalled();
+    });
+
+    it('re-indexes only the file that changed between searches', async () => {
+        const featurePath = path.join(repo, 'feature.ts');
+        const basePath = path.join(repo, 'base.ts');
+        await fs.writeFile(featurePath, 'export const feature = 2;\n');
+        await fs.writeFile(basePath, 'export const base = 2;\n');
+        const vectorDatabase = createVectorDatabase();
+        const context = newContext(vectorDatabase);
+
+        await context.semanticSearch(repo, 'feature', 5, 0.5);
+        vectorDatabase.insert.mockClear();
+        await fs.writeFile(featurePath, 'export const feature = 3;\n');
+        await context.semanticSearch(repo, 'feature', 5, 0.5);
+
+        expect(insertedPaths(vectorDatabase)).toEqual(['feature.ts']);
+    });
+
+    it('survives a branch switch by re-deriving the touched set from git', async () => {
+        await fs.writeFile(path.join(repo, 'feature.ts'), 'export const feature = 2;\n');
+        const vectorDatabase = createVectorDatabase();
+        const context = newContext(vectorDatabase);
+        await context.semanticSearch(repo, 'feature', 5, 0.5);
+
+        // A second branch touching a different file — the kind of event a
+        // filesystem watcher would see as an unattributable storm of writes.
+        git(repo, 'stash');
+        git(repo, 'checkout', '-b', 'other');
+        await fs.writeFile(path.join(repo, 'base.ts'), 'export const base = 3;\n');
+        vectorDatabase.insert.mockClear();
+        await context.semanticSearch(repo, 'base', 5, 0.5);
+
+        expect(insertedPaths(vectorDatabase)).toEqual(['base.ts']);
+    });
+
+    it('drops branch rows for a file that no longer differs from base', async () => {
+        const featurePath = path.join(repo, 'feature.ts');
+        await fs.writeFile(featurePath, 'export const feature = 2;\n');
+        const vectorDatabase = createVectorDatabase();
+        const context = newContext(vectorDatabase);
+        await context.semanticSearch(repo, 'feature', 5, 0.5);
+
+        // Revert the edit: the file is identical to base again, so its branch rows
+        // must go or they keep shadowing a base index that is already correct.
+        vectorDatabase.query.mockResolvedValue([{ id: 'chunk-1' }]);
+        await fs.writeFile(featurePath, 'export const feature = 1;\n');
+        await context.semanticSearch(repo, 'feature', 5, 0.5);
+
+        expect(vectorDatabase.delete).toHaveBeenCalledWith(expect.any(String), ['chunk-1']);
+    });
+
+    it('does not touch the index when CODEINDEX_LAZY_REFRESH=false', async () => {
+        await fs.writeFile(path.join(repo, 'feature.ts'), 'export const feature = 2;\n');
+        const vectorDatabase = createVectorDatabase();
+        process.env.CODEINDEX_LAZY_REFRESH = 'false';
+        try {
+            await newContext(vectorDatabase).semanticSearch(repo, 'feature', 5, 0.5);
+        } finally {
+            delete process.env.CODEINDEX_LAZY_REFRESH;
+        }
+
+        expect(vectorDatabase.insert).not.toHaveBeenCalled();
+    });
+
+    it('declines to refresh an overlay larger than the inline bound', async () => {
+        // 201 touched files: an unindexed or long-diverged worktree, which is an
+        // indexing job rather than a freshness top-up.
+        for (let i = 0; i < 201; i++) {
+            await fs.writeFile(path.join(repo, `gen-${i}.ts`), `export const v${i} = 1;\n`);
+        }
+        const vectorDatabase = createVectorDatabase();
+        const context = newContext(vectorDatabase);
+
+        await context.semanticSearch(repo, 'anything', 5, 0.5);
+
+        expect(vectorDatabase.insert).not.toHaveBeenCalled();
+        expect(context.pendingOverlayNotice(repo)).toContain('201 changed files');
+    });
+
+    it('refreshes normally at the inline bound', async () => {
+        for (let i = 0; i < 200; i++) {
+            await fs.writeFile(path.join(repo, `gen-${i}.ts`), `export const v${i} = 1;\n`);
+        }
+        const vectorDatabase = createVectorDatabase();
+        const context = newContext(vectorDatabase);
+
+        await context.semanticSearch(repo, 'anything', 5, 0.5);
+
+        expect(insertedPaths(vectorDatabase).length).toBe(200);
+        expect(context.pendingOverlayNotice(repo)).toBeNull();
+    });
+
+    it('reports how far the base index has drifted from the base branch', async () => {
+        const context = newContext(createVectorDatabase());
+        // Stamp the base index at the current main, then move main forward.
+        git(repo, 'checkout', 'main');
+        await context.indexCodebase(repo);
+        for (let i = 0; i < BASE_DRIFT_COMMITS; i++) {
+            await fs.writeFile(path.join(repo, `later-${i}.ts`), `export const later = ${i};\n`);
+            git(repo, 'add', '.');
+            git(repo, 'commit', '-m', `later ${i}`);
+        }
+
+        expect(context.baseIndexDrift(repo)?.commits).toBe(BASE_DRIFT_COMMITS);
+        expect(context.baseStalenessNotice(repo)).toContain(`${BASE_DRIFT_COMMITS} commits behind main`);
+    });
+
+    it('stays quiet while the base index is fresh', async () => {
+        const context = newContext(createVectorDatabase());
+        git(repo, 'checkout', 'main');
+        await context.indexCodebase(repo);
+
+        expect(context.baseIndexDrift(repo)?.commits).toBe(0);
+        expect(context.baseStalenessNotice(repo)).toBeNull();
+    });
+
+    it('still answers the search when the refresh throws', async () => {
+        await fs.writeFile(path.join(repo, 'feature.ts'), 'export const feature = 2;\n');
+        const vectorDatabase = createVectorDatabase();
+        vectorDatabase.insert.mockRejectedValue(new Error('milvus down'));
+
+        await expect(
+            newContext(vectorDatabase).semanticSearch(repo, 'feature', 5, 0.5)
+        ).resolves.toEqual([]);
+        expect(vectorDatabase.search).toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/context.splitter.test.ts
+++ b/packages/core/src/context.splitter.test.ts
@@ -148,7 +148,7 @@ describe('Context request-scoped splitters', () => {
                 context.getEffectiveSupportedExtensions()
             );
             await synchronizer.initialize();
-            context.setSynchronizer(context.getCollectionName(project), synchronizer);
+            context.setSynchronizer(project, synchronizer);
 
             await fs.writeFile(filePath, 'second version');
             await context.reindexByChange(project, undefined, [], [], requestSplitter);

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -6,7 +6,9 @@ import {
 import {
     Embedding,
     EmbeddingVector,
-    OpenAIEmbedding
+    OpenAIEmbedding,
+    CachedEmbedding,
+    FileSystemEmbeddingCache
 } from './embedding';
 import {
     VectorDatabase,
@@ -149,6 +151,13 @@ export class Context {
             ...(envManager.get('OPENAI_BASE_URL') && { baseURL: envManager.get('OPENAI_BASE_URL') })
         });
 
+        // Wrap the embedder in a content-addressed cache so an identical chunk
+        // is embedded once and reused across every collection on this machine
+        // (e.g. the same repository checked out into multiple git worktrees, or
+        // a re-clone at a different path). Enabled by default; opt out with
+        // EMBEDDING_CACHE=false. Override the location with EMBEDDING_CACHE_DIR.
+        this.embedding = this.maybeWrapWithEmbeddingCache(this.embedding);
+
         if (!config.vectorDatabase) {
             throw new Error('VectorDatabase is required. Please provide a vectorDatabase instance in the config.');
         }
@@ -190,6 +199,24 @@ export class Context {
         if (envCustomIgnorePatterns.length > 0) {
             console.log(`[Context] 🚫 Loaded ${envCustomIgnorePatterns.length} custom ignore patterns from environment: ${envCustomIgnorePatterns.join(', ')}`);
         }
+    }
+
+    /**
+     * Wrap an embedder in the content-addressed cache unless disabled via
+     * EMBEDDING_CACHE=false. The cache lives under EMBEDDING_CACHE_DIR (default
+     * `~/.context/embedding-cache`) and is safe to share across concurrent
+     * indexers targeting different collections.
+     */
+    private maybeWrapWithEmbeddingCache(embedding: Embedding): Embedding {
+        const disabled = (envManager.get('EMBEDDING_CACHE') || '').trim().toLowerCase() === 'false';
+        if (disabled) {
+            console.log('[Context] 🗃️  Embedding cache disabled (EMBEDDING_CACHE=false)');
+            return embedding;
+        }
+        const cacheDir = envManager.get('EMBEDDING_CACHE_DIR') || undefined;
+        const cache = new FileSystemEmbeddingCache(cacheDir);
+        console.log(`[Context] 🗃️  Embedding cache enabled at ${cacheDir || FileSystemEmbeddingCache.getDefaultCacheDir()}`);
+        return new CachedEmbedding(embedding, cache);
     }
 
     /**

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -116,7 +116,12 @@ const DEFAULT_IGNORE_PATTERNS = [
     '*.map', // source map files
     'node_modules', '.git', '.svn', '.hg', 'build', 'dist', 'out',
     'target', '.vscode', '.idea', '__pycache__', '.pytest_cache',
-    'coverage', '.nyc_output', 'logs', 'tmp', 'temp'
+    'coverage', '.nyc_output', 'logs', 'tmp', 'temp',
+    // Storybook build output: content-hashed single-line bundles (e.g.
+    // storybook-static/assets/*.js) whose extension is plain .js, so the *.min.js
+    // / *.bundle.js patterns above miss them. Feeding one to a CPU embedder can
+    // hang the request and wedge indexing — exclude the whole tree by directory.
+    'storybook-static', 'storybook-static/**'
 ];
 
 export interface ContextConfig {

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -23,8 +23,19 @@ import { envManager } from './utils/env-manager';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import { execFileSync } from 'node:child_process';
 import { FileSynchronizer } from './sync/synchronizer';
 import { IgnoreMatcher } from './utils/ignore-matcher';
+
+/**
+ * Branch tag written on every chunk when the branch overlay is disabled or the
+ * codebase is not a git repository. Keeps all rows in a single namespace so the
+ * overlay code paths collapse to exactly today's single-branch behavior.
+ */
+const LEGACY_BRANCH = '_';
+
+/** Delete Milvus ids in batches of at most this many per delete call. */
+const MAX_DELETE_BATCH = 1000;
 
 /**
  * Thrown by indexCodebase / processFileList when an AbortSignal fires
@@ -147,6 +158,12 @@ export class Context {
     private collectionNameOverride?: string;
     private warnedOverrideSanitization = new Set<string>();
     private synchronizers = new Map<string, FileSynchronizer>();
+    // Memoize the resolved git context (branch + per-repo id) per absolute path.
+    // A null entry caches "not a git repo / overlay disabled" so we don't re-shell.
+    private gitCtxCache = new Map<string, { branch: string; repoId: string } | null>();
+    // Cache the branch's touched-file set per `${collectionName}:${branch}` so the
+    // two-pass search merge doesn't re-query Milvus on every search.
+    private branchPathsCache = new Map<string, Set<string>>();
 
     constructor(config: ContextConfig = {}) {
         // Initialize services
@@ -276,10 +293,12 @@ export class Context {
     }
 
     /**
-     * Set synchronizer for a collection
+     * Set synchronizer for a codebase. Keyed by the resolved codebase path (not the
+     * collection name) because the Milvus collection is now shared across every git
+     * worktree of a repo — keying by collection name would collide across worktrees.
      */
-    setSynchronizer(collectionName: string, synchronizer: FileSynchronizer): void {
-        this.synchronizers.set(collectionName, synchronizer);
+    setSynchronizer(codebasePath: string, synchronizer: FileSynchronizer): void {
+        this.synchronizers.set(path.resolve(codebasePath), synchronizer);
     }
 
     /**
@@ -316,13 +335,170 @@ export class Context {
     }
 
     /**
+     * Whether the file-grain git-branch overlay is active. Enabled by default;
+     * opt out with CODEINDEX_BRANCH_OVERLAY=false to restore single-namespace
+     * (pre-overlay) behavior.
+     */
+    private branchOverlayEnabled(): boolean {
+        return (envManager.get('CODEINDEX_BRANCH_OVERLAY') || '').trim().toLowerCase() !== 'false';
+    }
+
+    /**
+     * The base branch a worktree overlays (its untouched files resolve here).
+     * Defaults to 'main'; override with CODEINDEX_BASE_BRANCH.
+     */
+    private baseBranch(): string {
+        return envManager.get('CODEINDEX_BASE_BRANCH') || 'main';
+    }
+
+    /**
+     * Resolve the git context (current branch + a stable per-repo id shared across
+     * all worktrees of the repo) for a codebase path. Returns null when the overlay
+     * is disabled or the path is not a git repository (→ legacy single namespace).
+     * The per-repo id derives from the git common dir, so every linked worktree of
+     * the same repository maps to one Milvus collection.
+     */
+    private gitContext(codebasePath: string): { branch: string; repoId: string } | null {
+        if (!this.branchOverlayEnabled()) {
+            return null;
+        }
+        const cacheKey = path.resolve(codebasePath);
+        if (this.gitCtxCache.has(cacheKey)) {
+            return this.gitCtxCache.get(cacheKey)!;
+        }
+        let result: { branch: string; repoId: string } | null;
+        try {
+            const branch = execFileSync('git', ['-C', codebasePath, 'rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf-8' }).trim();
+            const commonDir = execFileSync('git', ['-C', codebasePath, 'rev-parse', '--git-common-dir'], { encoding: 'utf-8' }).trim();
+            const absCommon = path.resolve(codebasePath, commonDir);
+            const repoId = crypto.createHash('md5').update(absCommon).digest('hex').substring(0, 8);
+            result = { branch: branch || 'HEAD', repoId };
+        } catch {
+            // Not a git repo (or git unavailable) → legacy single-namespace behavior.
+            result = null;
+        }
+        this.gitCtxCache.set(cacheKey, result);
+        return result;
+    }
+
+    /**
+     * Drop memoized git/branch state for a codebase so the next resolve re-reads
+     * git. Called at the start of each top-level op (index/search/clear) so a
+     * branch switch or a fresh index within the long-lived, worktree-shared MCP
+     * server is reflected immediately instead of serving a stale branch or a
+     * stale shadow set.
+     */
+    private refreshGitState(codebasePath: string): void {
+        this.gitCtxCache.delete(path.resolve(codebasePath));
+        this.branchPathsCache.clear();
+    }
+
+    /**
+     * The branch tag a codebase's chunks are stored under. LEGACY_BRANCH when the
+     * overlay is off or the path is not a git repo.
+     */
+    private resolveBranch(codebasePath: string): string {
+        return this.gitContext(codebasePath)?.branch ?? LEGACY_BRANCH;
+    }
+
+    /**
+     * True iff we are on a non-base branch with the overlay active — i.e. this
+     * worktree should overlay the shared base index at file granularity.
+     */
+    private isOverlayBranch(codebasePath: string): boolean {
+        const ctx = this.gitContext(codebasePath);
+        return ctx !== null && ctx.branch !== this.baseBranch();
+    }
+
+    /**
+     * The set of absolute file paths this branch has touched relative to the base
+     * branch (tracked files differing from base tip, plus untracked files). Returns
+     * null when the touched set can't be determined (e.g. base branch unknown
+     * locally) so callers fall back to indexing all files.
+     */
+    private touchedFiles(codebasePath: string): Set<string> | null {
+        const base = this.baseBranch();
+        try {
+            // Tracked files differing from the base tip, excluding deletions.
+            const diff = execFileSync(
+                'git',
+                ['-C', codebasePath, 'diff', '--name-only', '--diff-filter=d', base, '--'],
+                { encoding: 'utf-8' }
+            );
+            const untracked = execFileSync(
+                'git',
+                ['-C', codebasePath, 'ls-files', '--others', '--exclude-standard'],
+                { encoding: 'utf-8' }
+            );
+            const touched = new Set<string>();
+            for (const block of [diff, untracked]) {
+                for (const rel of block.split('\n')) {
+                    const trimmed = rel.trim();
+                    if (trimmed) {
+                        touched.add(path.resolve(codebasePath, trimmed));
+                    }
+                }
+            }
+            return touched;
+        } catch {
+            // e.g. base branch not present locally → can't scope, index everything.
+            return null;
+        }
+    }
+
+    /**
+     * Delete only the rows of a single branch from a shared collection, never the
+     * collection itself. Batches deletes so a large branch doesn't overflow a
+     * single delete call.
+     */
+    private async clearBranchRows(collectionName: string, branch: string): Promise<void> {
+        const rows = await this.vectorDatabase.query(collectionName, `branch == "${branch}"`, ['id']);
+        const ids = rows.map(r => r.id as string).filter(Boolean);
+        if (ids.length === 0) {
+            return;
+        }
+        for (let i = 0; i < ids.length; i += MAX_DELETE_BATCH) {
+            await this.vectorDatabase.delete(collectionName, ids.slice(i, i + MAX_DELETE_BATCH));
+        }
+        console.log(`[Context] 🧹 Cleared ${ids.length} rows for branch '${branch}' in ${collectionName}`);
+    }
+
+    /**
+     * The set of relativePaths a branch has indexed in the shared collection.
+     * Used by the two-pass search merge so a base-branch result is suppressed for
+     * any file the branch shadows. Cached per `${collectionName}:${branch}`.
+     */
+    private async getBranchPaths(collectionName: string, branch: string): Promise<Set<string>> {
+        const cacheKey = `${collectionName}:${branch}`;
+        const cached = this.branchPathsCache.get(cacheKey);
+        if (cached) {
+            return cached;
+        }
+        const rows = await this.vectorDatabase.query(collectionName, `branch == "${branch}"`, ['relativePath']);
+        const paths = new Set<string>(rows.map(r => r.relativePath as string).filter(Boolean));
+        this.branchPathsCache.set(cacheKey, paths);
+        return paths;
+    }
+
+    /**
+     * Compose two Milvus filter expressions with AND. Either may be empty.
+     */
+    private composeFilter(a: string | undefined, b: string): string {
+        return a && a.trim().length > 0 ? `(${a}) && (${b})` : b;
+    }
+
+    /**
      * Generate collection name based on codebase path and hybrid mode
      */
     public getCollectionName(codebasePath: string): string {
         const isHybrid = this.getIsHybrid();
         const prefix = isHybrid === true ? 'hybrid_code_chunks' : 'code_chunks';
         const normalizedPath = path.resolve(codebasePath);
-        const pathHash = crypto.createHash('md5').update(normalizedPath).digest('hex').substring(0, 8);
+        // When the path is a git repo (and overlay is on), derive the per-collection
+        // hash from the shared repo id so every worktree of the repo maps to ONE
+        // collection. Otherwise fall back to hashing the absolute path (legacy).
+        const gitCtx = this.gitContext(codebasePath);
+        const pathHash = gitCtx ? gitCtx.repoId : crypto.createHash('md5').update(normalizedPath).digest('hex').substring(0, 8);
 
         // Overrides always keep the per-codebase `_<pathHash>` suffix so that multiple
         // codebases indexed by the same MCP server can't collapse into one collection.
@@ -393,6 +569,7 @@ export class Context {
         requestSplitter?: Splitter,
         signal?: AbortSignal
     ): Promise<{ indexedFiles: number; totalChunks: number; status: 'completed' | 'limit_reached' }> {
+        this.refreshGitState(codebasePath);
         const isHybrid = this.getIsHybrid();
         const searchType = isHybrid === true ? 'hybrid search' : 'semantic search';
         console.log(`[Context] 🚀 Starting to index codebase with ${searchType}: ${codebasePath}`);
@@ -413,7 +590,18 @@ export class Context {
         const codeFiles = await this.getCodeFiles(codebasePath, ignorePatterns, supportedExtensions);
         console.log(`[Context] 📁 Found ${codeFiles.length} code files`);
 
-        if (codeFiles.length === 0) {
+        // On a non-base branch, index only the files this branch has touched; the
+        // rest resolve from the shared base index at search time (file overlay).
+        let filesToProcess = codeFiles;
+        if (this.isOverlayBranch(codebasePath)) {
+            const touched = this.touchedFiles(codebasePath);
+            if (touched) {
+                filesToProcess = codeFiles.filter(f => touched.has(path.resolve(f)));
+            }
+            console.log(`[Context] 🌿 Branch overlay '${this.resolveBranch(codebasePath)}': indexing ${filesToProcess.length}/${codeFiles.length} touched files`);
+        }
+
+        if (filesToProcess.length === 0) {
             progressCallback?.({ phase: 'No files to index', current: 100, total: 100, percentage: 100 });
             return { indexedFiles: 0, totalChunks: 0, status: 'completed' };
         }
@@ -425,7 +613,7 @@ export class Context {
         const indexingRange = indexingEndPercentage - indexingStartPercentage;
 
         const result = await this.processFileList(
-            codeFiles,
+            filesToProcess,
             codebasePath,
             (filePath, fileIndex, totalFiles) => {
                 // Calculate progress percentage
@@ -448,7 +636,7 @@ export class Context {
         progressCallback?.({
             phase: 'Indexing complete!',
             current: result.processedFiles,
-            total: codeFiles.length,
+            total: filesToProcess.length,
             percentage: 100
         });
 
@@ -466,8 +654,13 @@ export class Context {
         additionalSupportedExtensions: string[] = [],
         requestSplitter?: Splitter
     ): Promise<{ added: number, removed: number, modified: number }> {
+        this.refreshGitState(codebasePath);
         const collectionName = this.getCollectionName(codebasePath);
-        const synchronizer = this.synchronizers.get(collectionName);
+        // The synchronizer map is keyed by resolved codebase path, not collection
+        // name: the collection is shared across worktrees, but each worktree needs
+        // its own change-tracking snapshot.
+        const syncKey = path.resolve(codebasePath);
+        const synchronizer = this.synchronizers.get(syncKey);
         const splitter = requestSplitter || this.codeSplitter;
 
         if (!synchronizer) {
@@ -479,10 +672,10 @@ export class Context {
             // To be safe, let's initialize if it's not there.
             const newSynchronizer = new FileSynchronizer(codebasePath, ignorePatterns, supportedExtensions);
             await newSynchronizer.initialize();
-            this.synchronizers.set(collectionName, newSynchronizer);
+            this.synchronizers.set(syncKey, newSynchronizer);
         }
 
-        const currentSynchronizer = this.synchronizers.get(collectionName)!;
+        const currentSynchronizer = this.synchronizers.get(syncKey)!;
 
         progressCallback?.({ phase: 'Checking for file changes...', current: 0, total: 100, percentage: 0 });
         const { added, removed, modified } = await currentSynchronizer.checkForChanges();
@@ -503,15 +696,17 @@ export class Context {
             progressCallback?.({ phase, current: processedChanges, total: totalChanges, percentage });
         };
 
+        const branch = this.resolveBranch(codebasePath);
+
         // Handle removed files
         for (const file of removed) {
-            await this.deleteFileChunks(collectionName, file);
+            await this.deleteFileChunks(collectionName, file, branch);
             updateProgress(`Removed ${file}`);
         }
 
         // Handle modified files
         for (const file of modified) {
-            await this.deleteFileChunks(collectionName, file);
+            await this.deleteFileChunks(collectionName, file, branch);
             updateProgress(`Deleted old chunks for ${file}`);
         }
 
@@ -535,12 +730,14 @@ export class Context {
         return { added: added.length, removed: removed.length, modified: modified.length };
     }
 
-    private async deleteFileChunks(collectionName: string, relativePath: string): Promise<void> {
+    private async deleteFileChunks(collectionName: string, relativePath: string, branch: string): Promise<void> {
         // Escape backslashes for Milvus query expression (Windows path compatibility)
         const escapedPath = relativePath.replace(/\\/g, '\\\\');
+        // Branch-scope the delete: a shared collection holds base + branch rows, so
+        // only remove this branch's chunks for the file — never the base's.
         const results = await this.vectorDatabase.query(
             collectionName,
-            `relativePath == "${escapedPath}"`,
+            `relativePath == "${escapedPath}" && branch == "${branch}"`,
             ['id']
         );
 
@@ -561,6 +758,7 @@ export class Context {
      * @param threshold Similarity threshold
      */
     async semanticSearch(codebasePath: string, query: string, topK: number = 5, threshold: number = 0.5, filterExpr?: string): Promise<SemanticSearchResult[]> {
+        this.refreshGitState(codebasePath);
         const isHybrid = this.getIsHybrid();
         const searchType = isHybrid === true ? 'hybrid search' : 'semantic search';
         console.log(`[Context] 🔍 Executing ${searchType}: "${query}" in ${codebasePath}`);
@@ -575,100 +773,93 @@ export class Context {
             return [];
         }
 
-        if (isHybrid === true) {
-            try {
-                // Check collection stats to see if it has data
-                const stats = await this.vectorDatabase.query(collectionName, '', ['id'], 1);
-                console.log(`[Context] 🔍 Collection '${collectionName}' exists and appears to have data`);
-            } catch (error) {
-                console.log(`[Context] ⚠️  Collection '${collectionName}' exists but may be empty or not properly indexed:`, error);
-            }
+        const branch = this.resolveBranch(codebasePath);
+        const base = this.baseBranch();
 
-            // 1. Generate query vector
-            console.log(`[Context] 🔍 Generating embeddings for query: "${query}"`);
-            const queryEmbedding: EmbeddingVector = await this.embedding.embed(query);
-            console.log(`[Context] ✅ Generated embedding vector with dimension: ${queryEmbedding.vector.length}`);
-            console.log(`[Context] 🔍 First 5 embedding values: [${queryEmbedding.vector.slice(0, 5).join(', ')}]`);
-
-            // 2. Prepare hybrid search requests
-            const searchRequests: HybridSearchRequest[] = [
-                {
-                    data: queryEmbedding.vector,
-                    anns_field: "vector",
-                    param: { "nprobe": 10 },
-                    limit: topK
-                },
-                {
-                    data: query,
-                    anns_field: "sparse_vector",
-                    param: { "drop_ratio_search": 0.2 },
-                    limit: topK
-                }
-            ];
-
-            console.log(`[Context] 🔍 Search request 1 (dense): anns_field="${searchRequests[0].anns_field}", vector_dim=${queryEmbedding.vector.length}, limit=${searchRequests[0].limit}`);
-            console.log(`[Context] 🔍 Search request 2 (sparse): anns_field="${searchRequests[1].anns_field}", query_text="${query}", limit=${searchRequests[1].limit}`);
-
-            // 3. Execute hybrid search
-            console.log(`[Context] 🔍 Executing hybrid search with RRF reranking...`);
-            const searchResults: HybridSearchResult[] = await this.vectorDatabase.hybridSearch(
-                collectionName,
-                searchRequests,
-                {
-                    rerank: {
-                        strategy: 'rrf',
-                        params: { k: 100 }
-                    },
-                    limit: topK,
-                    filterExpr
-                }
-            );
-
-            console.log(`[Context] 🔍 Raw search results count: ${searchResults.length}`);
-
-            // 4. Convert to semantic search result format
-            const results: SemanticSearchResult[] = searchResults.map(result => ({
-                content: result.document.content,
-                relativePath: result.document.relativePath,
-                startLine: result.document.startLine,
-                endLine: result.document.endLine,
-                language: result.document.metadata.language || 'unknown',
-                score: result.score
-            }));
-
-            const dedupedResults = this.deduplicateResults(results);
-            console.log(`[Context] ✅ Found ${results.length} results, ${dedupedResults.length} after dedup`);
-            if (dedupedResults.length > 0) {
-                console.log(`[Context] 🔍 Top result score: ${dedupedResults[0].score}, path: ${dedupedResults[0].relativePath}`);
-            }
-
-            return dedupedResults;
-        } else {
-            // Regular semantic search
-            // 1. Generate query vector
-            const queryEmbedding: EmbeddingVector = await this.embedding.embed(query);
-
-            // 2. Search in vector database
-            const searchResults: VectorSearchResult[] = await this.vectorDatabase.search(
-                collectionName,
-                queryEmbedding.vector,
-                { topK, threshold, filterExpr }
-            );
-
-            // 3. Convert to semantic search result format
-            const results: SemanticSearchResult[] = searchResults.map(result => ({
-                content: result.document.content,
-                relativePath: result.document.relativePath,
-                startLine: result.document.startLine,
-                endLine: result.document.endLine,
-                language: result.document.metadata.language || 'unknown',
-                score: result.score
-            }));
-
+        // A search from the base branch (or with the overlay off) sees only its own
+        // branch's rows — the branch filter scopes it to a single namespace.
+        if (!this.isOverlayBranch(codebasePath)) {
+            const scoped = this.composeFilter(filterExpr, `branch == "${branch}"`);
+            const results = isHybrid === true
+                ? await this.hybridSearchMapped(collectionName, query, topK, scoped)
+                : await this.vectorSearchMapped(collectionName, query, topK, threshold, scoped);
             const dedupedResults = this.deduplicateResults(results);
             console.log(`[Context] ✅ Found ${results.length} results, ${dedupedResults.length} after dedup`);
             return dedupedResults;
         }
+
+        // Overlay branch: two-pass "branch shadows base" merge. The branch's own
+        // rows win; base rows survive only for files the branch never touched.
+        const branchFilter = this.composeFilter(filterExpr, `branch == "${branch}"`);
+        const mainFilter = this.composeFilter(filterExpr, `branch == "${base}"`);
+
+        const branchResults = isHybrid === true
+            ? await this.hybridSearchMapped(collectionName, query, topK, branchFilter)
+            : await this.vectorSearchMapped(collectionName, query, topK, threshold, branchFilter);
+        const mainResults = isHybrid === true
+            ? await this.hybridSearchMapped(collectionName, query, topK, mainFilter)
+            : await this.vectorSearchMapped(collectionName, query, topK, threshold, mainFilter);
+
+        const branchPaths = await this.getBranchPaths(collectionName, branch);
+        const merged = [
+            ...branchResults,
+            ...mainResults.filter(r => !branchPaths.has(r.relativePath))
+        ];
+        merged.sort((a, b) => b.score - a.score);
+        const dedupedResults = this.deduplicateResults(merged).slice(0, topK);
+        console.log(`[Context] 🌿 Overlay '${branch}': ${branchResults.length} branch + ${mainResults.length} base → ${dedupedResults.length} merged`);
+        return dedupedResults;
+    }
+
+    /**
+     * Run a single hybrid (dense + sparse RRF) search and map to SemanticSearchResult[]
+     * without dedup so callers can merge multiple passes. filterExpr scopes the rows.
+     */
+    private async hybridSearchMapped(collectionName: string, query: string, topK: number, filterExpr?: string): Promise<SemanticSearchResult[]> {
+        const queryEmbedding: EmbeddingVector = await this.embedding.embed(query);
+
+        const searchRequests: HybridSearchRequest[] = [
+            { data: queryEmbedding.vector, anns_field: "vector", param: { "nprobe": 10 }, limit: topK },
+            { data: query, anns_field: "sparse_vector", param: { "drop_ratio_search": 0.2 }, limit: topK }
+        ];
+
+        const searchResults: HybridSearchResult[] = await this.vectorDatabase.hybridSearch(
+            collectionName,
+            searchRequests,
+            { rerank: { strategy: 'rrf', params: { k: 100 } }, limit: topK, filterExpr }
+        );
+
+        return searchResults.map(result => ({
+            content: result.document.content,
+            relativePath: result.document.relativePath,
+            startLine: result.document.startLine,
+            endLine: result.document.endLine,
+            language: result.document.metadata.language || 'unknown',
+            score: result.score
+        }));
+    }
+
+    /**
+     * Run a single dense vector search and map to SemanticSearchResult[] without
+     * dedup so callers can merge multiple passes. filterExpr scopes the rows.
+     */
+    private async vectorSearchMapped(collectionName: string, query: string, topK: number, threshold: number, filterExpr?: string): Promise<SemanticSearchResult[]> {
+        const queryEmbedding: EmbeddingVector = await this.embedding.embed(query);
+
+        const searchResults: VectorSearchResult[] = await this.vectorDatabase.search(
+            collectionName,
+            queryEmbedding.vector,
+            { topK, threshold, filterExpr }
+        );
+
+        return searchResults.map(result => ({
+            content: result.document.content,
+            relativePath: result.document.relativePath,
+            startLine: result.document.startLine,
+            endLine: result.document.endLine,
+            language: result.document.metadata.language || 'unknown',
+            score: result.score
+        }));
     }
 
     /**
@@ -717,6 +908,7 @@ export class Context {
         progressCallback?: (progress: { phase: string; current: number; total: number; percentage: number }) => void
     ): Promise<void> {
         console.log(`[Context] 🧹 Cleaning index data for ${codebasePath}...`);
+        this.refreshGitState(codebasePath);
 
         progressCallback?.({ phase: 'Checking existing index...', current: 0, total: 100, percentage: 0 });
 
@@ -725,7 +917,13 @@ export class Context {
 
         progressCallback?.({ phase: 'Removing index data...', current: 50, total: 100, percentage: 50 });
 
-        if (collectionExists) {
+        if (this.isOverlayBranch(codebasePath)) {
+            // Shared collection: clear only this branch's rows, never drop the
+            // collection (that would take out the base index other worktrees rely on).
+            if (collectionExists) {
+                await this.clearBranchRows(collectionName, this.resolveBranch(codebasePath));
+            }
+        } else if (collectionExists) {
             await this.vectorDatabase.dropCollection(collectionName);
         }
 
@@ -809,6 +1007,21 @@ export class Context {
 
         // Check if collection already exists
         const collectionExists = await this.vectorDatabase.hasCollection(collectionName);
+        const overlayBranch = this.isOverlayBranch(codebasePath);
+
+        if (overlayBranch) {
+            // A non-base branch shares the collection with base (and sibling
+            // worktrees). Never drop it — that would delete the base index. Ensure
+            // it exists, and on force clear only this branch's rows.
+            if (!collectionExists) {
+                await this.createCollectionForMode(collectionName, codebasePath, isHybrid);
+            }
+            if (forceReindex) {
+                console.log(`[Context] 🌿 Force reindex on branch '${this.resolveBranch(codebasePath)}': clearing branch rows only`);
+                await this.clearBranchRows(collectionName, this.resolveBranch(codebasePath));
+            }
+            return;
+        }
 
         if (collectionExists && !forceReindex) {
             console.log(`📋 Collection ${collectionName} already exists, skipping creation`);
@@ -821,10 +1034,16 @@ export class Context {
             console.log(`[Context] ✅ Collection ${collectionName} dropped successfully`);
         }
 
+        await this.createCollectionForMode(collectionName, codebasePath, isHybrid);
+    }
+
+    /**
+     * Detect the embedding dimension and create the hybrid or dense collection.
+     */
+    private async createCollectionForMode(collectionName: string, codebasePath: string, isHybrid: boolean): Promise<void> {
         console.log(`[Context] 🔍 Detecting embedding dimension for ${this.embedding.getProvider()} provider...`);
         const dimension = await this.embedding.detectDimension();
         console.log(`[Context] 📏 Detected dimension: ${dimension} for ${this.embedding.getProvider()}`);
-        const dirName = path.basename(codebasePath);
 
         if (isHybrid === true) {
             await this.vectorDatabase.createHybridCollection(collectionName, dimension, `codebasePath:${codebasePath}`);
@@ -1018,6 +1237,7 @@ export class Context {
      */
     private async processChunkBatch(chunks: CodeChunk[], codebasePath: string): Promise<void> {
         const isHybrid = this.getIsHybrid();
+        const branch = this.resolveBranch(codebasePath);
 
         // Generate embedding vectors
         const chunkContents = chunks.map(chunk => chunk.content);
@@ -1046,13 +1266,14 @@ export class Context {
                 const { filePath, startLine, endLine, ...restMetadata } = chunk.metadata;
 
                 return {
-                    id: this.generateId(relativePath, chunk.metadata.startLine || 0, chunk.metadata.endLine || 0, chunk.content),
+                    id: this.generateId(branch, relativePath, chunk.metadata.startLine || 0, chunk.metadata.endLine || 0, chunk.content),
                     content: chunk.content, // Full text content for BM25 and storage
                     vector: embeddings[index].vector, // Dense vector
                     relativePath,
                     startLine: chunk.metadata.startLine || 0,
                     endLine: chunk.metadata.endLine || 0,
                     fileExtension,
+                    branch,
                     metadata: {
                         ...restMetadata,
                         codebasePath,
@@ -1076,13 +1297,14 @@ export class Context {
                 const { filePath, startLine, endLine, ...restMetadata } = chunk.metadata;
 
                 return {
-                    id: this.generateId(relativePath, chunk.metadata.startLine || 0, chunk.metadata.endLine || 0, chunk.content),
+                    id: this.generateId(branch, relativePath, chunk.metadata.startLine || 0, chunk.metadata.endLine || 0, chunk.content),
                     vector: embeddings[index].vector,
                     content: chunk.content,
                     relativePath,
                     startLine: chunk.metadata.startLine || 0,
                     endLine: chunk.metadata.endLine || 0,
                     fileExtension,
+                    branch,
                     metadata: {
                         ...restMetadata,
                         codebasePath,
@@ -1163,15 +1385,19 @@ export class Context {
     }
 
     /**
-     * Generate unique ID based on chunk content and location
+     * Generate unique ID based on branch, chunk content and location.
+     * The branch is folded into the hash so main and branch copies of an
+     * identical chunk get distinct primary keys (otherwise they collide on the
+     * PK and the branch row silently overwrites — or is overwritten by — main).
+     * @param branch Git branch tag the chunk is stored under
      * @param relativePath Relative path to the file
      * @param startLine Start line number
      * @param endLine End line number
      * @param content Chunk content
      * @returns Hash-based unique ID
      */
-    private generateId(relativePath: string, startLine: number, endLine: number, content: string): string {
-        const combinedString = `${relativePath}:${startLine}:${endLine}:${content}`;
+    private generateId(branch: string, relativePath: string, startLine: number, endLine: number, content: string): string {
+        const combinedString = `${branch}:${relativePath}:${startLine}:${endLine}:${content}`;
         const hash = crypto.createHash('sha256').update(combinedString, 'utf-8').digest('hex');
         return `chunk_${hash.substring(0, 16)}`;
     }

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -21,6 +21,7 @@ import {
 import { SemanticSearchResult } from './types';
 import { envManager } from './utils/env-manager';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import { execFileSync } from 'node:child_process';
@@ -36,6 +37,36 @@ const LEGACY_BRANCH = '_';
 
 /** Delete Milvus ids in batches of at most this many per delete call. */
 const MAX_DELETE_BATCH = 1000;
+
+/**
+ * Where the lazy overlay refresh records what it last indexed for a
+ * (worktree, branch) pair: `relativePath -> "<mtimeMs>:<size>"`. Kept beside the
+ * merkle snapshots under ~/.context so a fresh MCP process doesn't re-index the
+ * whole touched set on its first search.
+ */
+const OVERLAY_STATE_DIR = 'overlay-state';
+
+/**
+ * How far the base index may fall behind the base branch before a search says so.
+ * The overlay keeps a branch's own files current, but every *untouched* file
+ * answers from the shared base index — so once base drifts, searches quietly
+ * return code that has since moved or been deleted. Ten commits is roughly a
+ * morning's merges on an active repo: high enough not to nag, low enough that a
+ * genuinely stale index is never silent.
+ */
+const BASE_STALENESS_WARN_COMMITS = 10;
+
+/**
+ * Most files one lazy refresh will index inline, before a search.
+ *
+ * A short-lived branch touches a handful of files, but a long-lived one can
+ * differ from base by thousands (measured: 1,510 on a real worktree) — and
+ * embedding those on CPU is minutes, not milliseconds. Past this bound the
+ * refresh declines the work and says so rather than turning one search into a
+ * full index run: keeping freshness cheap is the whole point, and initial
+ * indexing is `index_codebase`'s job, not a search's.
+ */
+const LAZY_REFRESH_MAX_FILES = 200;
 
 /**
  * Thrown by indexCodebase / processFileList when an AbortSignal fires
@@ -164,6 +195,9 @@ export class Context {
     // Cache the branch's touched-file set per `${collectionName}:${branch}` so the
     // two-pass search merge doesn't re-query Milvus on every search.
     private branchPathsCache = new Map<string, Set<string>>();
+    // Worktrees whose overlay was too large to refresh inline, and how many files
+    // they were behind, so a search can say why it is answering from stale rows.
+    private pendingOverlayFiles = new Map<string, number>();
 
     constructor(config: ContextConfig = {}) {
         // Initialize services
@@ -447,6 +481,235 @@ export class Context {
     }
 
     /**
+     * Whether a search should first bring this branch's overlay up to date.
+     * Default on; CODEINDEX_LAZY_REFRESH=false restores search-only behavior.
+     */
+    private lazyRefreshEnabled(): boolean {
+        return (envManager.get('CODEINDEX_LAZY_REFRESH') || '').trim().toLowerCase() !== 'false';
+    }
+
+    /**
+     * State file for one (worktree, branch) overlay. Keyed by the resolved
+     * worktree path — two worktrees on the same branch have distinct working
+     * trees and must not share a stamp map.
+     */
+    private overlayStatePath(codebasePath: string, branch: string): string {
+        const key = crypto.createHash('md5')
+            .update(`${path.resolve(codebasePath)}::${branch}`)
+            .digest('hex');
+        return path.join(os.homedir(), '.context', OVERLAY_STATE_DIR, `${key}.json`);
+    }
+
+    private readOverlayState(statePath: string): Record<string, string> {
+        try {
+            return JSON.parse(fs.readFileSync(statePath, 'utf-8')) as Record<string, string>;
+        } catch {
+            // Missing or corrupt → treat as "nothing indexed yet"; the refresh
+            // rebuilds it from the touched set.
+            return {};
+        }
+    }
+
+    private writeOverlayState(statePath: string, state: Record<string, string>): void {
+        try {
+            fs.mkdirSync(path.dirname(statePath), { recursive: true });
+            fs.writeFileSync(statePath, JSON.stringify(state));
+        } catch (error: any) {
+            // A state write failure only costs redundant work next time.
+            console.warn(`[Context] ⚠️  Could not persist overlay state: ${error?.message || String(error)}`);
+        }
+    }
+
+    /**
+     * Bring a branch's overlay up to date before searching it.
+     *
+     * The overlay is small by construction — the files this branch touches
+     * relative to base — so freshness is cheap to maintain lazily rather than by
+     * watching the filesystem: `git diff` costs milliseconds, one `stat` per
+     * touched file costs microseconds, and only files whose (mtime, size) actually
+     * moved are re-chunked and re-embedded. Unchanged chunks hit the content-hash
+     * embedding cache, so a re-index after a one-line edit is a single file's work.
+     *
+     * Being lazy (rather than a daemon) is what makes this correct across `git
+     * checkout`, rebase, stash and crashes: every search re-derives the touched set
+     * from git instead of trusting accumulated events. A file that leaves the
+     * touched set has its branch rows dropped so the base index shows through again.
+     */
+    private async refreshOverlay(
+        codebasePath: string,
+        additionalIgnorePatterns: string[] = [],
+        additionalSupportedExtensions: string[] = [],
+        splitter?: Splitter
+    ): Promise<{ reindexed: number; dropped: number }> {
+        const unchanged = { reindexed: 0, dropped: 0 };
+        if (!this.lazyRefreshEnabled() || !this.isOverlayBranch(codebasePath)) {
+            return unchanged;
+        }
+
+        const touched = this.touchedFiles(codebasePath);
+        if (!touched) {
+            // Base branch not resolvable locally — indexCodebase would fall back to
+            // a full index here, which is far too expensive to do inside a search.
+            return unchanged;
+        }
+
+        const ignoreMatcher = new IgnoreMatcher(
+            await this.loadIgnorePatterns(codebasePath, additionalIgnorePatterns)
+        );
+        const supportedExtensions = this.getEffectiveSupportedExtensions(additionalSupportedExtensions);
+
+        // Stamp every touched file that the indexer would actually accept.
+        const current: Record<string, string> = {};
+        for (const abs of touched) {
+            const relativePath = path.relative(codebasePath, abs);
+            if (!supportedExtensions.includes(path.extname(abs))) continue;
+            if (ignoreMatcher.ignores(relativePath, false)) continue;
+            try {
+                const st = fs.statSync(abs);
+                current[relativePath] = `${st.mtimeMs}:${st.size}`;
+            } catch {
+                // Vanished between the diff and the stat — nothing to index.
+            }
+        }
+
+        const statePath = this.overlayStatePath(codebasePath, this.resolveBranch(codebasePath));
+        const previous = this.readOverlayState(statePath);
+        const changed = Object.keys(current).filter(rel => previous[rel] !== current[rel]);
+        const gone = Object.keys(previous).filter(rel => !(rel in current));
+        if (changed.length === 0 && gone.length === 0) {
+            return unchanged;
+        }
+        if (changed.length > LAZY_REFRESH_MAX_FILES) {
+            // Almost always a worktree that was never indexed, or a branch that has
+            // diverged far from base. Either way this is an indexing job, not a
+            // freshness top-up — declining keeps every search fast and honest.
+            this.pendingOverlayFiles.set(path.resolve(codebasePath), changed.length);
+            console.log(`[Context] 🌿 Overlay refresh declined: ${changed.length} files exceed the ${LAZY_REFRESH_MAX_FILES}-file inline bound`);
+            return unchanged;
+        }
+        this.pendingOverlayFiles.delete(path.resolve(codebasePath));
+
+        const collectionName = this.getCollectionName(codebasePath);
+        const branch = this.resolveBranch(codebasePath);
+
+        // Files that left the touched set (reverted, or rebased onto a base that
+        // now carries the change) must lose their branch rows or they would keep
+        // shadowing a base index that is already correct.
+        for (const rel of gone) {
+            await this.deleteFileChunks(collectionName, rel, branch);
+        }
+        for (const rel of changed) {
+            await this.deleteFileChunks(collectionName, rel, branch);
+        }
+        if (changed.length > 0) {
+            await this.processFileList(
+                changed.map(rel => path.join(codebasePath, rel)),
+                codebasePath,
+                undefined,
+                splitter || this.codeSplitter
+            );
+        }
+
+        this.writeOverlayState(statePath, current);
+        // The shadow set just moved; the next search must not reuse the old one.
+        this.branchPathsCache.clear();
+        console.log(`[Context] 🌿 Overlay refresh on '${branch}': ${changed.length} re-indexed, ${gone.length} dropped`);
+        return { reindexed: changed.length, dropped: gone.length };
+    }
+
+    /**
+     * State file recording the commit the shared base index was built at. One per
+     * repository, since every worktree of the repo shares that base index.
+     */
+    private baseStatePath(codebasePath: string): string {
+        const repoId = this.gitContext(codebasePath)?.repoId ?? 'legacy';
+        return path.join(os.homedir(), '.context', OVERLAY_STATE_DIR, `base-${repoId}.json`);
+    }
+
+    /**
+     * Record which commit the base index now reflects. Called after a successful
+     * index run on the base branch — the only time base rows change.
+     */
+    private recordBaseIndexCommit(codebasePath: string): void {
+        try {
+            const commit = execFileSync('git', ['-C', codebasePath, 'rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim();
+            const statePath = this.baseStatePath(codebasePath);
+            fs.mkdirSync(path.dirname(statePath), { recursive: true });
+            fs.writeFileSync(statePath, JSON.stringify({ commit, indexedAt: new Date().toISOString() }));
+        } catch (error: any) {
+            console.warn(`[Context] ⚠️  Could not record base index commit: ${error?.message || String(error)}`);
+        }
+    }
+
+    /**
+     * How many commits the base branch has moved since the base index was built,
+     * or null when that can't be determined (no record, not a git repo, base tip
+     * unknown locally). Pure git arithmetic — no vector-store access.
+     *
+     * This is the blind spot the file overlay does not cover: a branch's own files
+     * stay current, but everything it did not touch answers from base, and base
+     * only moves when someone re-indexes it. Left unsurfaced, a long-lived index
+     * degrades into confidently-wrong answers.
+     */
+    baseIndexDrift(codebasePath: string): { commits: number; indexedAt: string } | null {
+        try {
+            const raw = fs.readFileSync(this.baseStatePath(codebasePath), 'utf-8');
+            const { commit, indexedAt } = JSON.parse(raw) as { commit?: string; indexedAt?: string };
+            if (!commit) return null;
+            const base = this.baseBranch();
+            // Prefer the remote tip: it is what the base index is expected to track,
+            // and a local base branch may itself be days behind.
+            const tip = ['origin/' + base, base]
+                .map(ref => {
+                    try {
+                        return execFileSync('git', ['-C', codebasePath, 'rev-parse', '--verify', '--quiet', ref], { encoding: 'utf-8' }).trim();
+                    } catch {
+                        return '';
+                    }
+                })
+                .find(Boolean);
+            if (!tip) return null;
+            const count = execFileSync(
+                'git',
+                ['-C', codebasePath, 'rev-list', '--count', `${commit}..${tip}`],
+                { encoding: 'utf-8' }
+            ).trim();
+            return { commits: Number.parseInt(count, 10) || 0, indexedAt: indexedAt || 'unknown' };
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * A one-line warning when the base index has drifted far enough to distrust,
+     * or null when it is fresh enough (or unknown). Surfaced on search results so
+     * staleness is visible at the moment it would mislead someone.
+     */
+    baseStalenessNotice(codebasePath: string): string | null {
+        const drift = this.baseIndexDrift(codebasePath);
+        if (!drift || drift.commits < BASE_STALENESS_WARN_COMMITS) {
+            return null;
+        }
+        return `⚠️ The shared base index is ${drift.commits} commits behind ${this.baseBranch()} ` +
+            `(built ${drift.indexedAt}). Files this branch has not touched answer from that snapshot, ` +
+            `so results may reference code that has since moved. Refresh with \`codeindex index-base\`.`;
+    }
+
+    /**
+     * A one-line warning when this worktree's overlay was too large to bring up to
+     * date inline, so the caller knows the branch's own edits may not be reflected
+     * and what to run about it.
+     */
+    pendingOverlayNotice(codebasePath: string): string | null {
+        const pending = this.pendingOverlayFiles.get(path.resolve(codebasePath));
+        if (!pending) {
+            return null;
+        }
+        return `⚠️ ${pending} changed files on this branch exceed the inline refresh bound, ` +
+            `so this branch's edits are not all indexed. Run \`codeindex index\` for this worktree.`;
+    }
+
+    /**
      * Delete only the rows of a single branch from a shared collection, never the
      * collection itself. Batches deletes so a large branch doesn't overflow a
      * single delete call.
@@ -633,6 +896,12 @@ export class Context {
 
         console.log(`[Context] ✅ Codebase indexing completed! Processed ${result.processedFiles} files in total, generated ${result.totalChunks} code chunks`);
 
+        // Base rows only change on a base-branch run; stamp the commit they now
+        // reflect so searches can tell how far the shared index has drifted.
+        if (!this.isOverlayBranch(codebasePath) && result.status === 'completed') {
+            this.recordBaseIndexCommit(codebasePath);
+        }
+
         progressCallback?.({
             phase: 'Indexing complete!',
             current: result.processedFiles,
@@ -771,6 +1040,16 @@ export class Context {
         if (!hasCollection) {
             console.log(`[Context] ⚠️  Collection '${collectionName}' does not exist. Please index the codebase first.`);
             return [];
+        }
+
+        // Bring this branch's overlay up to date before reading it, so a search
+        // never answers from files the working tree has already moved past. Never
+        // let a refresh failure cost the caller their search — a stale answer beats
+        // no answer.
+        try {
+            await this.refreshOverlay(codebasePath);
+        } catch (error: any) {
+            console.warn(`[Context] ⚠️  Overlay refresh failed, searching as-is: ${error?.message || String(error)}`);
         }
 
         const branch = this.resolveBranch(codebasePath);

--- a/packages/core/src/embedding/base-embedding.ts
+++ b/packages/core/src/embedding/base-embedding.ts
@@ -73,4 +73,15 @@ export abstract class Embedding {
      * @returns Provider name
      */
     abstract getProvider(): string;
+
+    /**
+     * Fully-qualified model identity, used to key the embedding cache so that
+     * two different models can never collide. Subclasses that support multiple
+     * models should override this to include the model name; the default is the
+     * provider name alone.
+     * @returns A stable identifier for the (provider, model) pair
+     */
+    getModelIdentifier(): string {
+        return this.getProvider();
+    }
 } 

--- a/packages/core/src/embedding/cached-embedding.test.ts
+++ b/packages/core/src/embedding/cached-embedding.test.ts
@@ -1,0 +1,127 @@
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Embedding, EmbeddingVector } from './base-embedding';
+import { CachedEmbedding } from './cached-embedding';
+import { FileSystemEmbeddingCache, computeEmbeddingCacheKey } from './embedding-cache';
+
+/** Deterministic fake embedder that counts how many texts it actually embeds. */
+class CountingEmbedding extends Embedding {
+    protected maxTokens = 1000;
+    embedCalls = 0;
+    batchCalls = 0;
+    embeddedTexts: string[] = [];
+
+    constructor(private readonly modelId = 'Fake:model-a', private readonly dim = 4) {
+        super();
+    }
+
+    private vectorFor(text: string): number[] {
+        // Stable pseudo-vector derived from the text length and first char code.
+        const base = (text.length % 7) + 1;
+        return Array.from({ length: this.dim }, (_, i) => base + i);
+    }
+
+    async embed(text: string): Promise<EmbeddingVector> {
+        this.embedCalls++;
+        this.embeddedTexts.push(text);
+        return { vector: this.vectorFor(text), dimension: this.dim };
+    }
+
+    async embedBatch(texts: string[]): Promise<EmbeddingVector[]> {
+        this.batchCalls++;
+        this.embeddedTexts.push(...texts);
+        return texts.map(t => ({ vector: this.vectorFor(t), dimension: this.dim }));
+    }
+
+    async detectDimension(): Promise<number> {
+        return this.dim;
+    }
+    getDimension(): number {
+        return this.dim;
+    }
+    getProvider(): string {
+        return 'Fake';
+    }
+    getModelIdentifier(): string {
+        return this.modelId;
+    }
+}
+
+describe('CachedEmbedding', () => {
+    let cacheDir: string;
+
+    beforeEach(() => {
+        cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'embcache-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(cacheDir, { recursive: true, force: true });
+    });
+
+    const newCached = (inner: Embedding) =>
+        new CachedEmbedding(inner, new FileSystemEmbeddingCache(cacheDir));
+
+    it('embeds each unique text once and serves repeats from cache', async () => {
+        const inner = new CountingEmbedding();
+        const first = newCached(inner);
+        const r1 = await first.embedBatch(['alpha', 'beta']);
+        expect(inner.batchCalls).toBe(1);
+        expect(inner.embeddedTexts).toEqual(['alpha', 'beta']);
+
+        // A brand-new wrapper (fresh process) sharing the same cache dir must
+        // hit the cache and never call the inner embedder again.
+        const inner2 = new CountingEmbedding();
+        const second = newCached(inner2);
+        const r2 = await second.embedBatch(['alpha', 'beta']);
+        expect(inner2.batchCalls).toBe(0);
+        expect(r2).toEqual(r1);
+    });
+
+    it('only embeds the misses in a partially-cached batch', async () => {
+        const inner = new CountingEmbedding();
+        const cached = newCached(inner);
+        await cached.embedBatch(['alpha', 'beta']);
+
+        const inner2 = new CountingEmbedding();
+        const cached2 = newCached(inner2);
+        const results = await cached2.embedBatch(['alpha', 'gamma', 'beta']);
+        // Only 'gamma' is new; 'alpha' and 'beta' come from the cache.
+        expect(inner2.embeddedTexts).toEqual(['gamma']);
+        expect(results).toHaveLength(3);
+        const direct = await new CountingEmbedding().embedBatch(['alpha', 'gamma', 'beta']);
+        expect(results.map(v => v.vector)).toEqual(direct.map(v => v.vector));
+    });
+
+    it('preserves input order across cache hits and misses', async () => {
+        const inner = new CountingEmbedding();
+        const cached = newCached(inner);
+        // Prime 'b' only.
+        await cached.embedBatch(['b']);
+
+        const inner2 = new CountingEmbedding();
+        const cached2 = newCached(inner2);
+        const out = await cached2.embedBatch(['a', 'b', 'c']);
+        const direct = await new CountingEmbedding().embedBatch(['a', 'b', 'c']);
+        expect(out.map(v => v.vector)).toEqual(direct.map(v => v.vector));
+    });
+
+    it('does not let two different models share cache entries', async () => {
+        const key1 = computeEmbeddingCacheKey('Fake:model-a', 'same text');
+        const key2 = computeEmbeddingCacheKey('Fake:model-b', 'same text');
+        expect(key1).not.toEqual(key2);
+    });
+
+    it('single embed() round-trips through the cache', async () => {
+        const inner = new CountingEmbedding();
+        const cached = newCached(inner);
+        const a = await cached.embed('solo');
+        expect(inner.embedCalls).toBe(1);
+
+        const inner2 = new CountingEmbedding();
+        const cached2 = newCached(inner2);
+        const b = await cached2.embed('solo');
+        expect(inner2.embedCalls).toBe(0);
+        expect(b.vector).toEqual(a.vector);
+    });
+});

--- a/packages/core/src/embedding/cached-embedding.ts
+++ b/packages/core/src/embedding/cached-embedding.ts
@@ -1,0 +1,93 @@
+import { Embedding, EmbeddingVector } from './base-embedding';
+import { EmbeddingCache, computeEmbeddingCacheKey } from './embedding-cache';
+
+/**
+ * Wraps any {@link Embedding} provider with a content-addressed cache so that
+ * an identical chunk of text is only sent to the underlying embedder once,
+ * ever — across every collection indexed on this machine.
+ *
+ * Correctness rests on two facts: embeddings are deterministic for a given
+ * (model, text) pair, and {@link Embedding.getModelIdentifier} fully qualifies
+ * the model. The cache key mixes both, so two different models can never
+ * return each other's vectors. Caching never changes results; it only avoids
+ * recomputation.
+ *
+ * The wrapper is transparent: it delegates dimension detection and metadata to
+ * the inner provider and preserves input→output ordering for batches.
+ */
+export class CachedEmbedding extends Embedding {
+    // Unused: caching keys on the exact text the caller passes, so this wrapper
+    // never invokes the base preprocessing path.
+    protected maxTokens = Number.MAX_SAFE_INTEGER;
+
+    constructor(
+        private readonly inner: Embedding,
+        private readonly cache: EmbeddingCache
+    ) {
+        super();
+    }
+
+    async embed(text: string): Promise<EmbeddingVector> {
+        const key = computeEmbeddingCacheKey(this.inner.getModelIdentifier(), text);
+        const cached = this.cache.get(key);
+        if (cached) {
+            return { vector: cached, dimension: cached.length };
+        }
+        const result = await this.inner.embed(text);
+        this.cache.set(key, result.vector);
+        return result;
+    }
+
+    async embedBatch(texts: string[]): Promise<EmbeddingVector[]> {
+        const modelId = this.inner.getModelIdentifier();
+        const results = new Array<EmbeddingVector | undefined>(texts.length);
+        const missTexts: string[] = [];
+        const missIndexes: number[] = [];
+        const missKeys: string[] = [];
+
+        texts.forEach((text, i) => {
+            const key = computeEmbeddingCacheKey(modelId, text);
+            const cached = this.cache.get(key);
+            if (cached) {
+                results[i] = { vector: cached, dimension: cached.length };
+            } else {
+                missTexts.push(text);
+                missIndexes.push(i);
+                missKeys.push(key);
+            }
+        });
+
+        if (missTexts.length > 0) {
+            const embedded = await this.inner.embedBatch(missTexts);
+            // Stay faithful to a misbehaving provider: if it did not return
+            // exactly one vector per requested text, do not reshape by index —
+            // pass the raw result through so the caller's length validation can
+            // reject it. Reassembling would mask empty or mismatched batches.
+            if (embedded.length !== missTexts.length) {
+                return embedded;
+            }
+            embedded.forEach((vec, j) => {
+                results[missIndexes[j]] = vec;
+                this.cache.set(missKeys[j], vec.vector);
+            });
+        }
+
+        return results as EmbeddingVector[];
+    }
+
+    async detectDimension(testText?: string): Promise<number> {
+        return this.inner.detectDimension(testText);
+    }
+
+    getDimension(): number {
+        return this.inner.getDimension();
+    }
+
+    getProvider(): string {
+        return this.inner.getProvider();
+    }
+
+    getModelIdentifier(): string {
+        return this.inner.getModelIdentifier();
+    }
+}

--- a/packages/core/src/embedding/embedding-cache.ts
+++ b/packages/core/src/embedding/embedding-cache.ts
@@ -1,0 +1,110 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as crypto from 'crypto';
+
+/**
+ * A content-addressed cache mapping (model, text) -> embedding vector.
+ *
+ * Embeddings are a pure function of the model and the input text, so an
+ * identical chunk of code produces an identical vector every time it is
+ * embedded. Across many collections indexed on the same machine - for
+ * example the same repository checked out into several git worktrees, each
+ * on a different branch - the overwhelming majority of chunks are byte-for-byte
+ * identical. Without a cache each collection re-embeds all of them from
+ * scratch, which on a CPU embedder dominates indexing time. This cache lets
+ * every unique chunk be embedded once and reused everywhere.
+ */
+export interface EmbeddingCache {
+    /** Return the cached vector for a key, or null on a miss. */
+    get(key: string): number[] | null;
+    /** Store a vector for a key. Best-effort; failures must not throw. */
+    set(key: string, vector: number[]): void;
+}
+
+/** Bytes per float in the on-disk vector encoding (Float32). */
+const BYTES_PER_FLOAT = 4;
+
+/**
+ * Number of hex characters of the key used as a shard subdirectory. Two hex
+ * chars => 256 shards, keeping any single directory to a manageable file count
+ * even for repositories with hundreds of thousands of chunks.
+ */
+const SHARD_PREFIX_LENGTH = 2;
+
+/**
+ * Compute a stable cache key for a (model, text) pair.
+ *
+ * A NUL byte separates the two fields so that no (model, text) pair can be
+ * confused with another by shifting the boundary between them.
+ *
+ * @param modelIdentifier Fully qualifies the embedding model (provider + model
+ *   name + anything else that changes the output space). Two different models
+ *   must never share a key.
+ * @param text The exact text handed to the embedder.
+ */
+export function computeEmbeddingCacheKey(modelIdentifier: string, text: string): string {
+    return crypto
+        .createHash('sha256')
+        .update(modelIdentifier, 'utf-8')
+        .update(Buffer.from([0]))
+        .update(text, 'utf-8')
+        .digest('hex');
+}
+
+/**
+ * Filesystem-backed {@link EmbeddingCache}. Zero runtime dependencies; stores
+ * each vector as a little-endian Float32 blob under a sharded directory tree
+ * (mirrors how {@link FileSynchronizer} persists snapshots under `~/.context`).
+ *
+ * Writes are atomic (temp file + rename) so that concurrent indexers - one per
+ * worktree - can safely populate the same cache directory.
+ */
+export class FileSystemEmbeddingCache implements EmbeddingCache {
+    private readonly cacheDir: string;
+
+    constructor(cacheDir?: string) {
+        this.cacheDir = cacheDir || FileSystemEmbeddingCache.getDefaultCacheDir();
+    }
+
+    static getDefaultCacheDir(): string {
+        return path.join(os.homedir(), '.context', 'embedding-cache');
+    }
+
+    private pathForKey(key: string): string {
+        const shard = key.substring(0, SHARD_PREFIX_LENGTH);
+        return path.join(this.cacheDir, shard, key);
+    }
+
+    get(key: string): number[] | null {
+        try {
+            const buffer = fs.readFileSync(this.pathForKey(key));
+            if (buffer.length === 0 || buffer.length % BYTES_PER_FLOAT !== 0) {
+                return null;
+            }
+            const floats = new Float32Array(
+                buffer.buffer,
+                buffer.byteOffset,
+                buffer.length / BYTES_PER_FLOAT
+            );
+            return Array.from(floats);
+        } catch {
+            // Miss (ENOENT) or unreadable/corrupt entry - treat as a miss.
+            return null;
+        }
+    }
+
+    set(key: string, vector: number[]): void {
+        try {
+            const filePath = this.pathForKey(key);
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            const buffer = Buffer.from(new Float32Array(vector).buffer);
+            // Atomic write: a concurrent worktree indexer may target the same key.
+            const tmpPath = `${filePath}.${process.pid}.${crypto.randomBytes(4).toString('hex')}.tmp`;
+            fs.writeFileSync(tmpPath, buffer);
+            fs.renameSync(tmpPath, filePath);
+        } catch {
+            // Best-effort: a cache write failure must never break indexing.
+        }
+    }
+}

--- a/packages/core/src/embedding/gemini-embedding.ts
+++ b/packages/core/src/embedding/gemini-embedding.ts
@@ -138,6 +138,10 @@ export class GeminiEmbedding extends Embedding {
         return 'Gemini';
     }
 
+    getModelIdentifier(): string {
+        return `${this.getProvider()}:${this.config.model || 'gemini-embedding-001'}`;
+    }
+
     /**
      * Set model type
      * @param model Model name

--- a/packages/core/src/embedding/index.ts
+++ b/packages/core/src/embedding/index.ts
@@ -5,4 +5,8 @@ export * from './base-embedding';
 export * from './openai-embedding';
 export * from './voyageai-embedding';
 export * from './ollama-embedding';
-export * from './gemini-embedding'; 
+export * from './gemini-embedding';
+
+// Content-addressed embedding cache
+export * from './embedding-cache';
+export * from './cached-embedding'; 

--- a/packages/core/src/embedding/ollama-embedding.ts
+++ b/packages/core/src/embedding/ollama-embedding.ts
@@ -1,6 +1,18 @@
 import { Ollama } from 'ollama';
 import { Embedding, EmbeddingVector } from './base-embedding';
 
+// Per-request embed timeout. A single chunk embed on a CPU embedder finishes in
+// well under this; without a bound, one request that never returns (e.g. a
+// pathological minified/single-line bundle) hangs indexing forever with no
+// self-recovery. AbortSignal.timeout cancels the socket so the request rejects
+// instead of wedging. Override via OLLAMA_EMBED_TIMEOUT_MS.
+const EMBED_REQUEST_TIMEOUT_MS = Number(process.env.OLLAMA_EMBED_TIMEOUT_MS) || 120_000;
+// Bounded retries for TRANSIENT failures only (connection reset, 5xx). A timeout
+// is deterministic for a given input, so it is never retried — we fail fast and
+// let the caller drop/skip. Override via OLLAMA_EMBED_MAX_ATTEMPTS.
+const EMBED_MAX_ATTEMPTS = Number(process.env.OLLAMA_EMBED_MAX_ATTEMPTS) || 2;
+const EMBED_RETRY_DELAY_MS = 1_000;
+
 export interface OllamaEmbeddingConfig {
     model: string;
     host?: string;
@@ -21,10 +33,7 @@ export class OllamaEmbedding extends Embedding {
     constructor(config: OllamaEmbeddingConfig) {
         super();
         this.config = config;
-        this.client = new Ollama({
-            host: config.host || 'http://127.0.0.1:11434',
-            fetch: config.fetch,
-        });
+        this.client = this.makeClient(config.host || 'http://127.0.0.1:11434');
 
         // Set dimension based on config or will be detected on first use
         if (config.dimension) {
@@ -41,6 +50,45 @@ export class OllamaEmbedding extends Embedding {
         }
 
         // If no dimension is provided, it will be detected in the first embed call
+    }
+
+    /**
+     * Build an Ollama client whose requests are bounded by EMBED_REQUEST_TIMEOUT_MS.
+     * The Ollama SDK has no per-request timeout, so we inject a fetch that attaches
+     * an AbortSignal.timeout — a hung embed then rejects (and is caught upstream)
+     * instead of wedging indexing forever. A caller-provided signal is respected.
+     */
+    private makeClient(host: string): Ollama {
+        const providedFetch = this.config.fetch;
+        const timeoutFetch = (input: any, init: any = {}) => {
+            const signal = init?.signal ?? AbortSignal.timeout(EMBED_REQUEST_TIMEOUT_MS);
+            return (providedFetch ?? fetch)(input, { ...init, signal });
+        };
+        return new Ollama({ host, fetch: timeoutFetch });
+    }
+
+    /**
+     * Run a single embed request with a bounded per-request timeout (via the
+     * client's timeout fetch) and retry only transient failures. A timeout is
+     * deterministic for a given input, so it is never retried: we throw so the
+     * caller drops the batch rather than looping on a request that will hang again.
+     */
+    private async embedWithRetry(embedOptions: any): Promise<any> {
+        let lastError: unknown;
+        for (let attempt = 1; attempt <= EMBED_MAX_ATTEMPTS; attempt++) {
+            try {
+                return await this.client.embed(embedOptions);
+            } catch (error) {
+                lastError = error;
+                const name = (error as { name?: string })?.name;
+                const message = error instanceof Error ? error.message : String(error);
+                const isTimeout = name === 'TimeoutError' || name === 'AbortError';
+                console.error(`[OllamaEmbedding] embed attempt ${attempt}/${EMBED_MAX_ATTEMPTS} failed (${name || 'Error'}): ${message}`);
+                if (isTimeout || attempt >= EMBED_MAX_ATTEMPTS) break;
+                await new Promise(resolve => setTimeout(resolve, EMBED_RETRY_DELAY_MS));
+            }
+        }
+        throw lastError;
     }
 
     private setDefaultMaxTokensForModel(model: string): void {
@@ -76,7 +124,7 @@ export class OllamaEmbedding extends Embedding {
             embedOptions.keep_alive = this.config.keepAlive;
         }
 
-        const response = await this.client.embed(embedOptions);
+        const response = await this.embedWithRetry(embedOptions);
 
         if (!response.embeddings || !response.embeddings[0]) {
             throw new Error('Ollama API returned invalid response');
@@ -111,7 +159,7 @@ export class OllamaEmbedding extends Embedding {
             embedOptions.keep_alive = this.config.keepAlive;
         }
 
-        const response = await this.client.embed(embedOptions);
+        const response = await this.embedWithRetry(embedOptions);
 
         if (!response.embeddings || !Array.isArray(response.embeddings)) {
             throw new Error('Ollama API returned invalid batch response');
@@ -161,10 +209,7 @@ export class OllamaEmbedding extends Embedding {
      */
     setHost(host: string): void {
         this.config.host = host;
-        this.client = new Ollama({
-            host: host,
-            fetch: this.config.fetch,
-        });
+        this.client = this.makeClient(host);
     }
 
     /**
@@ -214,7 +259,7 @@ export class OllamaEmbedding extends Embedding {
                 embedOptions.keep_alive = this.config.keepAlive;
             }
 
-            const response = await this.client.embed(embedOptions);
+            const response = await this.embedWithRetry(embedOptions);
 
             if (!response.embeddings || !response.embeddings[0]) {
                 throw new Error('Ollama API returned invalid response');

--- a/packages/core/src/embedding/ollama-embedding.ts
+++ b/packages/core/src/embedding/ollama-embedding.ts
@@ -132,6 +132,10 @@ export class OllamaEmbedding extends Embedding {
         return 'Ollama';
     }
 
+    getModelIdentifier(): string {
+        return `${this.getProvider()}:${this.config.model}`;
+    }
+
     /**
      * Set model type and detect its dimension
      * @param model Model name

--- a/packages/core/src/embedding/openai-embedding.ts
+++ b/packages/core/src/embedding/openai-embedding.ts
@@ -134,6 +134,10 @@ export class OpenAIEmbedding extends Embedding {
         return 'OpenAI';
     }
 
+    getModelIdentifier(): string {
+        return `${this.getProvider()}:${this.config.model || 'text-embedding-3-small'}`;
+    }
+
     /**
      * Set model type
      * @param model Model name

--- a/packages/core/src/embedding/voyageai-embedding.ts
+++ b/packages/core/src/embedding/voyageai-embedding.ts
@@ -103,6 +103,10 @@ export class VoyageAIEmbedding extends Embedding {
         return 'VoyageAI';
     }
 
+    getModelIdentifier(): string {
+        return `${this.getProvider()}:${this.config.model || 'voyage-code-3'}`;
+    }
+
     /**
      * Set model type
      * @param model Model name

--- a/packages/core/src/vectordb/milvus-restful-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-restful-vectordb.ts
@@ -243,6 +243,13 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
                             }
                         },
                         {
+                            fieldName: "branch",
+                            dataType: "VarChar",
+                            elementTypeParams: {
+                                max_length: 256
+                            }
+                        },
+                        {
                             fieldName: "metadata",
                             dataType: "VarChar",
                             elementTypeParams: {
@@ -374,6 +381,7 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
                 startLine: doc.startLine,
                 endLine: doc.endLine,
                 fileExtension: doc.fileExtension,
+                branch: doc.branch,
                 metadata: JSON.stringify(doc.metadata) // Convert metadata object to JSON string
             }));
 
@@ -412,6 +420,7 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
                     "startLine",
                     "endLine",
                     "fileExtension",
+                    "branch",
                     "metadata"
                 ],
                 searchParams: {
@@ -447,6 +456,7 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
                         startLine: item.startLine || 0,
                         endLine: item.endLine || 0,
                         fileExtension: item.fileExtension || '',
+                        branch: item.branch || '',
                         metadata: metadata
                     },
                     score: item.distance || 0
@@ -593,6 +603,13 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
                             }
                         },
                         {
+                            fieldName: "branch",
+                            dataType: "VarChar",
+                            elementTypeParams: {
+                                max_length: 256
+                            }
+                        },
+                        {
                             fieldName: "metadata",
                             dataType: "VarChar",
                             elementTypeParams: {
@@ -673,6 +690,7 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
                 startLine: doc.startLine,
                 endLine: doc.endLine,
                 fileExtension: doc.fileExtension,
+                branch: doc.branch,
                 metadata: JSON.stringify(doc.metadata),
             }));
 
@@ -760,7 +778,7 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
                 search: [search_param_1, search_param_2],
                 rerank: rerank_strategy,
                 limit: options?.limit || searchRequests[0]?.limit || 10,
-                outputFields: ['id', 'content', 'relativePath', 'startLine', 'endLine', 'fileExtension', 'metadata'],
+                outputFields: ['id', 'content', 'relativePath', 'startLine', 'endLine', 'fileExtension', 'branch', 'metadata'],
             };
 
             console.log(`[MilvusRestfulDB] 🔍 Executing REST API hybrid search...`);
@@ -792,6 +810,7 @@ export class MilvusRestfulVectorDatabase implements VectorDatabase {
                         startLine: result.startLine,
                         endLine: result.endLine,
                         fileExtension: result.fileExtension,
+                        branch: result.branch,
                         metadata,
                     },
                     score: result.score || result.distance || 0,

--- a/packages/core/src/vectordb/milvus-vectordb.ts
+++ b/packages/core/src/vectordb/milvus-vectordb.ts
@@ -260,6 +260,12 @@ export class MilvusVectorDatabase implements VectorDatabase {
                 max_length: 32,
             },
             {
+                name: 'branch',
+                description: 'Git branch tag for overlay indexing',
+                data_type: DataType.VarChar,
+                max_length: 256,
+            },
+            {
                 name: 'metadata',
                 description: 'Additional document metadata as JSON string',
                 data_type: DataType.VarChar,
@@ -359,6 +365,7 @@ export class MilvusVectorDatabase implements VectorDatabase {
             startLine: doc.startLine,
             endLine: doc.endLine,
             fileExtension: doc.fileExtension,
+            branch: doc.branch,
             metadata: JSON.stringify(doc.metadata),
         }));
 
@@ -380,7 +387,7 @@ export class MilvusVectorDatabase implements VectorDatabase {
             collection_name: collectionName,
             data: [queryVector],
             limit: options?.topK || 10,
-            output_fields: ['id', 'content', 'relativePath', 'startLine', 'endLine', 'fileExtension', 'metadata'],
+            output_fields: ['id', 'content', 'relativePath', 'startLine', 'endLine', 'fileExtension', 'branch', 'metadata'],
         };
 
         // Apply boolean expression filter if provided (e.g., fileExtension in [".ts",".py"]) 
@@ -411,6 +418,7 @@ export class MilvusVectorDatabase implements VectorDatabase {
                     startLine: result.startLine,
                     endLine: result.endLine,
                     fileExtension: result.fileExtension,
+                    branch: result.branch,
                     metadata,
                 },
                 score: result.score,
@@ -528,6 +536,12 @@ export class MilvusVectorDatabase implements VectorDatabase {
                 max_length: 32,
             },
             {
+                name: 'branch',
+                description: 'Git branch tag for overlay indexing',
+                data_type: DataType.VarChar,
+                max_length: 256,
+            },
+            {
                 name: 'metadata',
                 description: 'Additional document metadata as JSON string',
                 data_type: DataType.VarChar,
@@ -615,6 +629,7 @@ export class MilvusVectorDatabase implements VectorDatabase {
             startLine: doc.startLine,
             endLine: doc.endLine,
             fileExtension: doc.fileExtension,
+            branch: doc.branch,
             metadata: JSON.stringify(doc.metadata),
         }));
 
@@ -679,7 +694,7 @@ export class MilvusVectorDatabase implements VectorDatabase {
                 data: [search_param_1, search_param_2],
                 limit: options?.limit || searchRequests[0]?.limit || 10,
                 rerank: rerank_strategy,
-                output_fields: ['id', 'content', 'relativePath', 'startLine', 'endLine', 'fileExtension', 'metadata'],
+                output_fields: ['id', 'content', 'relativePath', 'startLine', 'endLine', 'fileExtension', 'branch', 'metadata'],
             };
 
             if (options?.filterExpr && options.filterExpr.trim().length > 0) {
@@ -725,6 +740,7 @@ export class MilvusVectorDatabase implements VectorDatabase {
                         startLine: result.startLine,
                         endLine: result.endLine,
                         fileExtension: result.fileExtension,
+                        branch: result.branch,
                         metadata,
                     },
                     score: result.score,

--- a/packages/core/src/vectordb/types.ts
+++ b/packages/core/src/vectordb/types.ts
@@ -7,6 +7,7 @@ export interface VectorDocument {
     startLine: number;
     endLine: number;
     fileExtension: string;
+    branch: string;
     metadata: Record<string, any>;
 }
 

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -201,6 +201,8 @@ export function logConfigurationSummary(config: ContextMcpConfig): void {
     if (config.collectionNameOverride) {
         console.log(`[MCP]   Collection Name Override: ✅ Configured`);
     }
+    const embeddingCacheOn = (envManager.get('EMBEDDING_CACHE') || '').trim().toLowerCase() !== 'false';
+    console.log(`[MCP]   Embedding Cache: ${embeddingCacheOn ? '✅ Enabled' : '❌ Disabled'}`);
 
     // Log provider-specific configuration without exposing sensitive data
     switch (config.embeddingProvider) {
@@ -273,6 +275,16 @@ Environment Variables:
                           after sanitization (letters/digits/underscore, 255 chars max).
                           The per-codebase pathHash is preserved so multiple
                           codebases stay distinct under the same override.
+
+  Embedding Cache Configuration:
+  EMBEDDING_CACHE         Cache embeddings by content hash so an identical chunk
+                          is embedded once and reused across every collection on
+                          this machine — e.g. the same repo in multiple git
+                          worktrees, or a re-clone at a different path. Greatly
+                          speeds up (re)indexing, especially on CPU embedders.
+                          Enabled by default; set to "false" to disable.
+  EMBEDDING_CACHE_DIR     Directory for the embedding cache
+                          (default: ~/.context/embedding-cache).
 
   MCP Sync Configuration:
   CLAUDE_CONTEXT_BACKGROUND_SYNC

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -576,10 +576,10 @@ export class ToolHandlers {
             const synchronizer = new FileSynchronizer(absolutePath, ignorePatterns, supportedExtensions);
             await synchronizer.initialize();
 
-            // Store synchronizer in the context (let context manage collection names)
+            // Store synchronizer in the context (keyed by codebase path — the
+            // collection is shared across worktrees, so a per-collection key collides).
             await this.context.getPreparedCollection(absolutePath);
-            const collectionName = this.context.getCollectionName(absolutePath);
-            this.context.setSynchronizer(collectionName, synchronizer);
+            this.context.setSynchronizer(absolutePath, synchronizer);
 
             console.log(`[BACKGROUND-INDEX] Starting indexing with ${splitterType} splitter for: ${absolutePath}`);
 

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -5,7 +5,7 @@ import { Context, COLLECTION_LIMIT_MESSAGE, FileSynchronizer, IndexAbortError } 
 import { SnapshotManager } from "./snapshot.js";
 import type { CodebaseIndexOptions, RequestSplitterType } from "./config.js";
 import { createRequestSplitter, isRequestSplitterType } from "./splitter.js";
-import { ensureAbsolutePath, truncateContent, trackCodebasePath } from "./utils.js";
+import { ensureAbsolutePath, truncateContent, trackCodebasePath, describeToolError, isBackendUnreachableError } from "./utils.js";
 
 export class ToolHandlers {
     private context: Context;
@@ -854,7 +854,9 @@ export class ToolHandlers {
             return {
                 content: [{
                     type: "text",
-                    text: `Error searching code: ${errorMessage} Please check if the codebase has been indexed first.`
+                    text: isBackendUnreachableError(error)
+                        ? describeToolError(error, 'searching code')
+                        : `Error searching code: ${errorMessage} Please check if the codebase has been indexed first.`
                 }],
                 isError: true
             };
@@ -992,7 +994,7 @@ export class ToolHandlers {
             return {
                 content: [{
                     type: "text",
-                    text: `Error clearing index: ${errorMessage}`
+                    text: describeToolError(error, 'clearing index')
                 }],
                 isError: true
             };
@@ -1108,7 +1110,7 @@ export class ToolHandlers {
             return {
                 content: [{
                     type: "text",
-                    text: `Error getting indexing status: ${error.message || error}`
+                    text: describeToolError(error, 'getting indexing status')
                 }],
                 isError: true
             };

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -813,6 +813,16 @@ export class ToolHandlers {
             if (searchCodebasePath !== absolutePath) {
                 resultMessage += `\nRequested path '${absolutePath}' is covered by indexed codebase '${searchCodebasePath}'.`;
             }
+            // Say it on the results, not in a log nobody reads: a drifted base index
+            // answers plausibly about code that has already moved.
+            for (const notice of [
+                this.context.pendingOverlayNotice(searchCodebasePath),
+                this.context.baseStalenessNotice(searchCodebasePath),
+            ]) {
+                if (notice) {
+                    resultMessage += `\n${notice}`;
+                }
+            }
             resultMessage += `\n\n${formattedResults}`;
 
             if (isIndexing) {

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -5,7 +5,17 @@ import { Context, COLLECTION_LIMIT_MESSAGE, FileSynchronizer, IndexAbortError } 
 import { SnapshotManager } from "./snapshot.js";
 import type { CodebaseIndexOptions, RequestSplitterType } from "./config.js";
 import { createRequestSplitter, isRequestSplitterType } from "./splitter.js";
-import { ensureAbsolutePath, truncateContent, trackCodebasePath, describeToolError, isBackendUnreachableError } from "./utils.js";
+import {
+    ensureAbsolutePath,
+    truncateContent,
+    trackCodebasePath,
+    describeToolError,
+    isBackendUnreachableError,
+    rerankByCodeRole,
+    isTestPath,
+    MAX_SEARCH_RESULTS,
+    RERANK_OVERFETCH_FACTOR,
+} from "./utils.js";
 
 export class ToolHandlers {
     private context: Context;
@@ -759,13 +769,18 @@ export class ToolHandlers {
             }
 
             // Search in the specified codebase
-            const searchResults = await this.context.semanticSearch(
+            // Search wider than asked, re-rank, then trim: a re-rank confined to
+            // the caller's limit can only reorder what already won, so an
+            // implementation crowded out by its own tests never enters the list.
+            const rawResults = await this.context.semanticSearch(
                 searchCodebasePath,
                 query,
-                Math.min(resultLimit, 50),
+                Math.min(resultLimit * RERANK_OVERFETCH_FACTOR, MAX_SEARCH_RESULTS),
                 0.3,
                 filterExpr
             );
+
+            const searchResults = rerankByCodeRole(rawResults, query).slice(0, resultLimit);
 
             console.log(`[SEARCH] ✅ Search completed! Found ${searchResults.length} results using ${embeddingProvider.getProvider()} embeddings`);
 
@@ -803,8 +818,13 @@ export class ToolHandlers {
                 const context = truncateContent(result.content, 5000);
                 const codebaseInfo = path.basename(searchCodebasePath);
 
+                // Mark tests explicitly: a reader scanning locations should not
+                // have to infer from the path whether they are looking at the
+                // implementation or at something exercising it.
+                const roleTag = isTestPath(result.relativePath) ? ' [test]' : '';
+
                 return `${index + 1}. Code snippet (${result.language}) [${codebaseInfo}]\n` +
-                    `   Location: ${location}\n` +
+                    `   Location: ${location}${roleTag}\n` +
                     `   Rank: ${index + 1}\n` +
                     `   Context: \n\`\`\`${result.language}\n${context}\n\`\`\`\n`;
             }).join('\n');

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -299,6 +299,22 @@ process.on('SIGTERM', () => {
     process.exit(0);
 });
 
+// A rejection escaping a background task must never take the server down with
+// it. Node's default is to promote an unhandled rejection to a fatal uncaught
+// exception, and the rejection we hit in practice — the Milvus gRPC client
+// reporting ECONNREFUSED while the backend is stopped — settles moments AFTER
+// the MCP handshake has already advertised the tools. The client is left with a
+// dead stdio server and no error to surface, so `search_code` simply vanishes
+// for the rest of the session and agents fall back to grep without noticing.
+//
+// Staying up is strictly better: every tool already answers with `isError` when
+// the backend is unreachable, which is a signal the caller can act on. Note this
+// deliberately does NOT trap `uncaughtException` — a synchronous throw can leave
+// genuinely inconsistent state, and the failure this guards against is async.
+process.on('unhandledRejection', (reason) => {
+    console.error('[MCP] Unhandled promise rejection — server stays up:', reason);
+});
+
 // Always start the server - this is designed to be the main entry point
 main().catch((error) => {
     console.error("Fatal error:", error);

--- a/packages/mcp/src/sync.periodic-rejection.test.ts
+++ b/packages/mcp/src/sync.periodic-rejection.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { SyncManager } from "./sync.js";
+
+/**
+ * The periodic sync is fire-and-forget: there is no caller to propagate to, so a
+ * rejection escaping it becomes an unhandled rejection. Node promotes that to a
+ * fatal uncaught exception, which killed the MCP server minutes into a session
+ * whenever the vector backend went away — taking every registered tool with it.
+ *
+ * Driven with the real timer at the 1s floor rather than mock timers, so it runs
+ * identically on the Node 18 a developer may have locally and the 20/22/24 matrix CI uses.
+ */
+test("a failing periodic sync is contained instead of escaping as an unhandled rejection", async () => {
+    const previousInterval = process.env.CLAUDE_CONTEXT_SYNC_INTERVAL_MS;
+    process.env.CLAUDE_CONTEXT_SYNC_INTERVAL_MS = "1000";
+
+    const escaped: unknown[] = [];
+    const onUnhandled = (reason: unknown) => escaped.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    const manager = new SyncManager({} as any, {} as any);
+    let ticks = 0;
+    (manager as any).handleSyncIndex = async () => {
+        ticks += 1;
+        throw new Error("14 UNAVAILABLE: connect ECONNREFUSED 127.0.0.1:19530");
+    };
+    // The trigger watcher touches the real filesystem; the interval is the subject here.
+    (manager as any).setupTriggerWatcher = () => { };
+
+    try {
+        manager.startBackgroundSync();
+        await new Promise((resolve) => setTimeout(resolve, 2_500));
+
+        assert.ok(ticks >= 1, `the periodic sync should have run at least once (ran ${ticks})`);
+        assert.deepEqual(escaped, [], "no rejection may escape the periodic sync");
+    } finally {
+        process.off("unhandledRejection", onUnhandled);
+        manager.stopBackgroundSync();
+        if (previousInterval === undefined) delete process.env.CLAUDE_CONTEXT_SYNC_INTERVAL_MS;
+        else process.env.CLAUDE_CONTEXT_SYNC_INTERVAL_MS = previousInterval;
+    }
+});

--- a/packages/mcp/src/sync.ts
+++ b/packages/mcp/src/sync.ts
@@ -63,6 +63,7 @@ export class SyncManager {
     private syncLockToken: string | null = null;
     private triggerWatcher: fs.FSWatcher | null = null;
     private triggerDebounceTimer: NodeJS.Timeout | null = null;
+    private syncInterval: NodeJS.Timeout | null = null;
 
     constructor(context: Context, snapshotManager: SnapshotManager) {
         this.context = context;
@@ -302,12 +303,30 @@ export class SyncManager {
 
         // Periodically check for file changes and update the index
         console.log(`[SYNC-DEBUG] Setting up periodic sync every ${syncIntervalMs}ms`);
-        const syncInterval = setInterval(() => {
+        this.syncInterval = setInterval(() => {
             console.log('[SYNC-DEBUG] Executing scheduled periodic sync');
-            this.handleSyncIndex();
+            // Fire-and-forget with an explicit catch, like the initial sync above
+            // and the trigger watcher below: a rejection here has no caller to
+            // propagate to, so without this it escapes as an unhandled rejection
+            // and — before the guard in index.ts — killed the whole server.
+            void this.handleSyncIndex().catch((error) => {
+                console.error('[SYNC-DEBUG] Periodic sync failed:', error);
+            });
         }, syncIntervalMs);
 
-        console.log('[SYNC-DEBUG] Background sync setup complete. Interval ID:', syncInterval);
+        console.log('[SYNC-DEBUG] Background sync setup complete. Interval ID:', this.syncInterval);
+    }
+
+    /**
+     * Stop the periodic sync. The handle used to be a local that nothing kept,
+     * so the timer could not be cancelled once started — which also made the
+     * loop untestable without leaking a live interval into the test runner.
+     */
+    public stopBackgroundSync(): void {
+        if (this.syncInterval) {
+            clearInterval(this.syncInterval);
+            this.syncInterval = null;
+        }
     }
 
     /**

--- a/packages/mcp/src/utils.backend-error.test.ts
+++ b/packages/mcp/src/utils.backend-error.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { describeToolError, isBackendUnreachableError } from "./utils.js";
+
+// The shape the Milvus SDK actually produces when the backend is stopped —
+// captured verbatim from a server started against a closed port.
+function grpcUnavailable(): Error & { code: number } {
+    const error = new Error(
+        '14 UNAVAILABLE: No connection established. Last error: Error: connect ECONNREFUSED 127.0.0.1:19530'
+    ) as Error & { code: number };
+    error.code = 14;
+    return error;
+}
+
+test("a stopped backend is recognised through both the gRPC status and the socket cause", () => {
+    assert.equal(isBackendUnreachableError(grpcUnavailable()), true);
+    assert.equal(isBackendUnreachableError(new Error('connect ECONNREFUSED 127.0.0.1:19530')), true);
+    assert.equal(isBackendUnreachableError(new Error('getaddrinfo ENOTFOUND milvus.internal')), true);
+
+    // A numeric gRPC code alone is enough: the message wording is not stable.
+    const bare = new Error('rpc failed') as Error & { code: number };
+    bare.code = 14;
+    assert.equal(isBackendUnreachableError(bare), true);
+});
+
+test("ordinary failures are not mistaken for an unreachable backend", () => {
+    assert.equal(isBackendUnreachableError(new Error('collection not found')), false);
+    assert.equal(isBackendUnreachableError(new Error('dimension mismatch: 768 vs 1536')), false);
+    assert.equal(isBackendUnreachableError('some string failure'), false);
+});
+
+test("an unreachable backend is reported as such, and steers away from re-indexing", () => {
+    const previous = process.env.MILVUS_ADDRESS;
+    process.env.MILVUS_ADDRESS = '127.0.0.1:19530';
+    try {
+        const text = describeToolError(grpcUnavailable(), 'searching code');
+
+        // Names the real problem and the address, so the reader can check it.
+        assert.match(text, /unreachable/);
+        assert.match(text, /127\.0\.0\.1:19530/);
+        // Points at the one command that fixes it.
+        assert.match(text, /codeindex up/);
+        // The old text sent readers to re-index, which is exactly the wrong move
+        // and fails identically — this is the regression being guarded.
+        assert.doesNotMatch(text, /has been indexed first/);
+    } finally {
+        if (previous === undefined) delete process.env.MILVUS_ADDRESS;
+        else process.env.MILVUS_ADDRESS = previous;
+    }
+});
+
+test("unrelated failures keep their original message", () => {
+    const text = describeToolError(new Error('collection not found'), 'clearing index');
+    assert.equal(text, 'Error clearing index: collection not found');
+});

--- a/packages/mcp/src/utils.rerank.test.ts
+++ b/packages/mcp/src/utils.rerank.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isTestPath, isTestSeekingQuery, rerankByCodeRole } from "./utils.js";
+
+test("test, fixture and mock paths are recognised across ecosystems", () => {
+    for (const testPath of [
+        "tests/nora/test_signal.py",
+        "tests/nora/signal/test_utils.py",
+        "src/lib/parser.test.ts",
+        "src/lib/parser.spec.tsx",
+        "packages/core/src/context.abort.test.ts",
+        "internal/server/server_test.go",
+        "tests/conftest.py",
+        "spec/models/user_spec.rb".replace("_spec.rb", "_test.rb"),
+        "app/__tests__/render.js",
+        "app/__mocks__/fs.js",
+        "tests/fixtures/sample.json",
+        "internal/testdata/golden.txt",
+    ]) {
+        assert.equal(isTestPath(testPath), true, `expected a test path: ${testPath}`);
+    }
+});
+
+test("production code that merely contains the word is not demoted", () => {
+    // The regression this guards: a substring match would swallow shipped
+    // helper packages and any path with 'test' inside a longer word.
+    for (const sourcePath of [
+        "src/echelon/nora/testing/harness.py",
+        "src/echelon/nora/signal/utils.py",
+        "src/contest/leaderboard.ts",
+        "src/latest/index.ts",
+        "packages/core/src/context.ts",
+        "lib/protest.go",
+    ]) {
+        assert.equal(isTestPath(sourcePath), false, `expected an implementation path: ${sourcePath}`);
+    }
+});
+
+test("implementation outranks its own tests at comparable relevance", () => {
+    const results = [
+        { relativePath: "tests/nora/test_signal.py", score: 0.020 },
+        { relativePath: "tests/nora/signal/test_utils.py", score: 0.019 },
+        { relativePath: "src/echelon/nora/signal/utils.py", score: 0.017 },
+    ];
+
+    const ranked = rerankByCodeRole(results);
+
+    assert.equal(ranked[0].relativePath, "src/echelon/nora/signal/utils.py");
+    // Demoted, not dropped — the tests are still reachable below it.
+    assert.equal(ranked.length, 3);
+    assert.deepEqual(
+        ranked.slice(1).map((r) => r.relativePath),
+        ["tests/nora/test_signal.py", "tests/nora/signal/test_utils.py"]
+    );
+});
+
+test("a decisively more relevant test still wins", () => {
+    // "How do I call this?" is a real query shape, and the penalty is a nudge,
+    // not a partition: a test that is far ahead on relevance stays on top.
+    const ranked = rerankByCodeRole([
+        { relativePath: "tests/test_api.py", score: 0.9 },
+        { relativePath: "src/api.py", score: 0.2 },
+    ]);
+
+    assert.equal(ranked[0].relativePath, "tests/test_api.py");
+});
+
+test("equal scores keep the vector store's ordering", () => {
+    const ranked = rerankByCodeRole([
+        { relativePath: "src/a.ts", score: 0.5 },
+        { relativePath: "src/b.ts", score: 0.5 },
+        { relativePath: "src/c.ts", score: 0.5 },
+    ]);
+
+    assert.deepEqual(ranked.map((r) => r.relativePath), ["src/a.ts", "src/b.ts", "src/c.ts"]);
+});
+
+test("the penalty can be switched off", () => {
+    const previous = process.env.CLAUDE_CONTEXT_TEST_RANK_PENALTY;
+    process.env.CLAUDE_CONTEXT_TEST_RANK_PENALTY = "1";
+    try {
+        const ranked = rerankByCodeRole([
+            { relativePath: "tests/test_api.py", score: 0.20 },
+            { relativePath: "src/api.py", score: 0.19 },
+        ]);
+        assert.equal(ranked[0].relativePath, "tests/test_api.py");
+    } finally {
+        if (previous === undefined) delete process.env.CLAUDE_CONTEXT_TEST_RANK_PENALTY;
+        else process.env.CLAUDE_CONTEXT_TEST_RANK_PENALTY = previous;
+    }
+});
+
+test("a query that asks for tests is recognised", () => {
+    for (const query of [
+        "where do we test entity resolution merging",
+        "test coverage for the correction tiers",
+        "unit tests for the Cypher builder",
+        "fixtures used by the extraction tests",
+        "what does conftest.py set up",
+        "the spec for the retry decorator",
+    ]) {
+        assert.equal(isTestSeekingQuery(query), true, `expected test-seeking: ${query}`);
+    }
+
+    for (const query of [
+        "how is a factoid persisted to the graph",
+        "retry with exponential backoff on rate limit",
+        "the latest protestor count endpoint",   // 'latest'/'protestor' must not match
+    ]) {
+        assert.equal(isTestSeekingQuery(query), false, `expected implementation-seeking: ${query}`);
+    }
+});
+
+test("asking for tests skips the penalty entirely", () => {
+    const results = [
+        { relativePath: "tests/nora/test_resolution.py", score: 0.20 },
+        { relativePath: "src/echelon/nora/memory/resolution.py", score: 0.19 },
+    ];
+
+    // Without the query the penalty applies and the implementation is promoted...
+    assert.equal(rerankByCodeRole(results)[0].relativePath, "src/echelon/nora/memory/resolution.py");
+    // ...but when the caller explicitly asked for tests, demoting them is wrong.
+    assert.equal(
+        rerankByCodeRole(results, "where do we test entity resolution")[0].relativePath,
+        "tests/nora/test_resolution.py"
+    );
+});
+
+test("an out-of-range penalty falls back to the default instead of inverting the ranking", () => {
+    const previous = process.env.CLAUDE_CONTEXT_TEST_RANK_PENALTY;
+    process.env.CLAUDE_CONTEXT_TEST_RANK_PENALTY = "-3";
+    try {
+        const ranked = rerankByCodeRole([
+            { relativePath: "tests/test_api.py", score: 0.20 },
+            { relativePath: "src/api.py", score: 0.19 },
+        ]);
+        assert.equal(ranked[0].relativePath, "src/api.py");
+    } finally {
+        if (previous === undefined) delete process.env.CLAUDE_CONTEXT_TEST_RANK_PENALTY;
+        else process.env.CLAUDE_CONTEXT_TEST_RANK_PENALTY = previous;
+    }
+});

--- a/packages/mcp/src/utils.ts
+++ b/packages/mcp/src/utils.ts
@@ -27,4 +27,47 @@ export function ensureAbsolutePath(inputPath: string): string {
 export function trackCodebasePath(codebasePath: string): void {
     const absolutePath = ensureAbsolutePath(codebasePath);
     console.log(`[TRACKING] Tracked codebase path: ${absolutePath} (not marked as indexed)`);
-} 
+}
+
+/**
+ * Markers of "the vector database is not reachable", as opposed to any other
+ * failure. The Milvus gRPC client reports an unreachable backend as status 14
+ * UNAVAILABLE wrapping a socket-level cause, so match on both layers.
+ */
+const BACKEND_UNREACHABLE_MARKERS = [
+    'UNAVAILABLE',
+    'ECONNREFUSED',
+    'ENOTFOUND',
+    'ETIMEDOUT',
+    'EHOSTUNREACH',
+    'No connection established',
+    'Connection refused',
+];
+
+export function isBackendUnreachableError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    // gRPC status 14 is UNAVAILABLE; the SDK exposes it as a numeric `code`.
+    if (typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 14) {
+        return true;
+    }
+    return BACKEND_UNREACHABLE_MARKERS.some((marker) => message.includes(marker));
+}
+
+/**
+ * Turn a tool failure into text the caller can act on.
+ *
+ * A down backend used to surface as "check if the codebase has been indexed
+ * first", which points at the one thing that is *not* wrong — the index is
+ * intact and the address simply refuses connections. An agent that reads the
+ * old message re-indexes, fails again, and concludes the tool is useless.
+ */
+export function describeToolError(error: unknown, action: string): string {
+    const message = error instanceof Error ? error.message : String(error);
+    if (isBackendUnreachableError(error)) {
+        const address = process.env.MILVUS_ADDRESS || 'the configured MILVUS_ADDRESS';
+        return `Error ${action}: the code index backend at ${address} is unreachable (${message}). ` +
+            `The index itself is fine — the vector database is not running. Start it with \`codeindex up\`, ` +
+            `then retry. Do NOT re-index: that will fail the same way.`;
+    }
+    return `Error ${action}: ${message}`;
+}

--- a/packages/mcp/src/utils.ts
+++ b/packages/mcp/src/utils.ts
@@ -29,6 +29,111 @@ export function trackCodebasePath(codebasePath: string): void {
     console.log(`[TRACKING] Tracked codebase path: ${absolutePath} (not marked as indexed)`);
 }
 
+/** Hard ceiling on what we ask the vector store for, per the search tool's contract. */
+export const MAX_SEARCH_RESULTS = 50;
+
+/**
+ * How much wider than the caller's limit we search before re-ranking. Without
+ * headroom a re-rank can only reorder what already won: if tests fill every
+ * slot, the implementation is not in the list to be promoted.
+ */
+export const RERANK_OVERFETCH_FACTOR = 4;
+
+const DEFAULT_TEST_RANK_PENALTY = 0.75;
+
+/** Path segments that mark a file as exercising code rather than being it. */
+const TEST_DIR_SEGMENTS = new Set([
+    'test', 'tests', '__tests__', '__mocks__', 'testdata', 'fixtures', 'spec', '__fixtures__',
+]);
+
+/** Filename shapes for the same, across the ecosystems this indexes. */
+const TEST_FILE_PATTERNS = [
+    /\.(test|spec)\.[cm]?[jt]sx?$/,   // foo.test.ts, foo.spec.jsx
+    /^test_.*\.py$/,                  // pytest
+    /_test\.(py|go|rb)$/,             // foo_test.go
+    /^conftest\.py$/,
+];
+
+/**
+ * Is this path a test, fixture or mock rather than the implementation?
+ *
+ * Matches whole path segments deliberately: a substring match would also catch
+ * production packages that merely contain the word, such as `src/.../testing/`
+ * (a shipped helper module) or `contest/`.
+ */
+export function isTestPath(relativePath: string): boolean {
+    const segments = relativePath.split(/[\\/]/);
+    const fileName = segments[segments.length - 1] ?? '';
+
+    if (segments.slice(0, -1).some((segment) => TEST_DIR_SEGMENTS.has(segment.toLowerCase()))) {
+        return true;
+    }
+    return TEST_FILE_PATTERNS.some((pattern) => pattern.test(fileName));
+}
+
+function getTestRankPenalty(): number {
+    const raw = process.env.CLAUDE_CONTEXT_TEST_RANK_PENALTY;
+    if (!raw) return DEFAULT_TEST_RANK_PENALTY;
+
+    const value = Number.parseFloat(raw);
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+        console.warn(
+            `[SEARCH] Invalid CLAUDE_CONTEXT_TEST_RANK_PENALTY '${raw}' (want 0..1). ` +
+            `Falling back to ${DEFAULT_TEST_RANK_PENALTY}.`
+        );
+        return DEFAULT_TEST_RANK_PENALTY;
+    }
+    return value;
+}
+
+const TEST_SEEKING_QUERY = /\b(tests?|testing|tested|specs?|fixtures?|mocks?|coverage|conftest)\b/i;
+
+/**
+ * Did the caller ask for tests? Demoting them would then be actively wrong.
+ *
+ * Measured: without this, "where do we test entity resolution merging" and
+ * friends lose test hits they should be getting — one such query dropped tests
+ * out of its top 5 entirely.
+ */
+export function isTestSeekingQuery(query: string): boolean {
+    return TEST_SEEKING_QUERY.test(query);
+}
+
+/**
+ * Push tests below implementation at comparable relevance.
+ *
+ * A test restates the query's vocabulary almost literally — the error strings,
+ * the option names, the call itself — while the implementation encodes the
+ * mechanism and often names none of it. Pure embedding similarity therefore
+ * rewards the test, and for a query like "retry with exponential backoff when
+ * the API returns a rate limit error" the whole result page came back as test
+ * call sites while the decorator that implements it never appeared at all.
+ *
+ * This demotes, never excludes: sometimes the test *is* the answer ("how do I
+ * call this?"), so it should still be reachable, just not ahead of the thing it
+ * tests. A query that asks for tests outright skips the penalty entirely, and
+ * CLAUDE_CONTEXT_TEST_RANK_PENALTY=1 disables it everywhere.
+ */
+export function rerankByCodeRole<T extends { relativePath: string; score: number }>(
+    results: T[],
+    query?: string
+): T[] {
+    const penalty = getTestRankPenalty();
+    if (penalty === 1) return results;
+    if (query !== undefined && isTestSeekingQuery(query)) return results;
+
+    return results
+        .map((result, position) => ({
+            result,
+            position,
+            adjusted: isTestPath(result.relativePath) ? result.score * penalty : result.score,
+        }))
+        // Ties keep the vector store's own ordering rather than reshuffling on
+        // float noise, so the ranking stays reproducible between identical runs.
+        .sort((a, b) => (b.adjusted - a.adjusted) || (a.position - b.position))
+        .map((entry) => entry.result);
+}
+
 /**
  * Markers of "the vector database is not reachable", as opposed to any other
  * failure. The Milvus gRPC client reports an unreachable backend as status 14

--- a/packages/vscode-extension/src/commands/indexCommand.ts
+++ b/packages/vscode-extension/src/commands/indexCommand.ts
@@ -81,10 +81,11 @@ export class IndexCommand {
                     this.context.getSupportedExtensions() || []
                 );
                 await synchronizer.initialize();
-                // Store synchronizer in the context's internal map using the collection name from context
+                // Store synchronizer in the context's internal map, keyed by codebase
+                // path (the collection is shared across worktrees, so a per-collection
+                // key would collide).
                 await this.context.getPreparedCollection(selectedFolder.uri.fsPath);
-                const collectionName = this.context.getCollectionName(selectedFolder.uri.fsPath);
-                this.context.setSynchronizer(collectionName, synchronizer);
+                this.context.setSynchronizer(selectedFolder.uri.fsPath, synchronizer);
 
                 // Start indexing with progress callback
                 indexStats = await this.context.indexCodebase(


### PR DESCRIPTION
## Problem

Collection names — and the merkle snapshots that drive incremental sync — are keyed by the **absolute codebase path** (`md5(path)`). So indexing the same repository at a second path re-embeds every file from scratch:

- git **worktrees** (same repo, different branch, different path),
- a **re-clone** at a different location,
- **CI** checkouts.

Embeddings are a pure function of `(model, text)`, so this is pure waste — and on a **CPU embedder** (e.g. Ollama `nomic-embed-text`) embedding dominates indexing time, turning "index my other worktree" into minutes/hours.

This is closely related to #271 (sharing across clones). Rather than collapse everyone onto one shared collection — which loses per-branch correctness and thrashes when multiple branches are indexed at once — this shares only the **embedding work**, keeping per-codebase collections independent.

## What this adds

An opt-out, content-addressed embedding cache mapping `(modelIdentifier, chunk text) -> vector`. Each unique chunk is embedded **once ever** and reused across every collection on the machine; different branches/worktrees stay independently searchable.

- **`FileSystemEmbeddingCache`** — zero-dependency, sharded, atomic-write (temp + rename, safe for concurrent worktree indexers) cache under `~/.context/embedding-cache` (configurable via `EMBEDDING_CACHE_DIR`), mirroring how `FileSynchronizer` persists under `~/.context`.
- **`CachedEmbedding`** — transparent decorator over any `Embedding` provider: splits each batch into cache hits/misses, only sends misses to the provider, preserves input order, and stays faithful to a misbehaving provider (never reshapes a mismatched/empty batch, so the caller's length validation still fires).
- **`Embedding.getModelIdentifier()`** — fully qualifies the model so two models can never share entries; overridden by each provider (`Ollama`, `OpenAI`, `Gemini`, `VoyageAI`) to include the model name.
- Wired into `Context`; **enabled by default**, opt out with `EMBEDDING_CACHE=false`.
- New env vars documented in the MCP `--help` and startup summary.

## Correctness

Caching never changes results — an embedding is deterministic for a given `(model, text)`, and the cache key mixes a fully-qualified model identifier with the exact text (NUL-separated). Two different models cannot return each other's vectors.

## Tests

- New `cached-embedding.test.ts`: unique-once, partial-batch misses, order preservation across hits/misses, model isolation, single-`embed()` round-trip.
- Existing `embedding-error` tests bypass the cache (they assert on embedder calls); a jest `setupFiles` redirects the cache to a temp dir so the suite never touches the developer's real `~/.context`.
- `pnpm --filter @zilliz/claude-context-core test` → 34 passed. `pnpm build` succeeds for core + mcp.

## Measured

Re-indexing an identical tree at a **new path** drops from **~69s to ~3s** (`nomic-embed-text` on CPU), search results unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)