### PR TITLE
feat(core): add git-remote collection keying and Bedrock embedding provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,25 @@ OPENAI_API_KEY=your-openai-api-key-here
 # OLLAMA_HOST=http://localhost:11434
 
 # =============================================================================
+# Bedrock Configuration
+# =============================================================================
+
+# AWS region for Bedrock Runtime (falls back to AWS_REGION)
+# BEDROCK_REGION=us-east-1
+
+# Optional static credentials. If omitted, the default AWS credential chain
+# is used (env vars, shared config/profile, IAM role, etc).
+# BEDROCK_ACCESS_KEY_ID=your-access-key-id
+# BEDROCK_SECRET_ACCESS_KEY=your-secret-access-key
+# BEDROCK_SESSION_TOKEN=your-session-token
+
+# Optional custom endpoint (e.g. a VPC interface endpoint for Bedrock Runtime)
+# BEDROCK_ENDPOINT=https://vpce-xxxx.bedrock-runtime.us-east-1.vpce.amazonaws.com
+
+# Optional dimension override (only honored by amazon.titan-embed-text-v2:0)
+# BEDROCK_EMBEDDING_DIMENSION=1024
+
+# =============================================================================
 # Vector Database Configuration (Milvus/Zilliz)
 # =============================================================================
 
@@ -90,3 +109,16 @@ SPLITTER_TYPE=ast
 
 # Whether to use hybrid search mode. If true, it will use both dense vector and BM25; if false, it will use only dense vector search.
 # HYBRID_MODE=true
+
+# =============================================================================
+# Collection Naming Configuration
+# =============================================================================
+
+# Optional custom prefix for collection names (code_chunks_<override>_<pathHash>).
+# CODE_CHUNKS_COLLECTION_NAME_OVERRIDE=my_project
+
+# Set to "git-remote" to key collections by the codebase's git "origin" remote
+# URL instead of its absolute path, so every checkout of the same repo (CI,
+# every teammate's laptop, ...) converges on the same collection. Falls back
+# to the path if the codebase isn't a git repo or has no origin remote.
+# CODE_CHUNKS_COLLECTION_KEY_SOURCE=git-remote

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Packages depend on `core` via `workspace:*`, so **rebuild core (`pnpm build:core
 ```bash
 pnpm --filter @zilliz/claude-context-mcp start        # tsx src/index.ts
 ```
-Configuration is entirely via environment variables (see `.env.example` and `packages/mcp/src/config.ts`). Key vars: `EMBEDDING_PROVIDER` (OpenAI | VoyageAI | Gemini | Ollama | OpenRouter), provider API key, `EMBEDDING_MODEL`, `MILVUS_ADDRESS` and/or `MILVUS_TOKEN` (address can be auto-resolved from a Zilliz token), `CODE_CHUNKS_COLLECTION_NAME_OVERRIDE`.
+Configuration is entirely via environment variables (see `.env.example` and `packages/mcp/src/config.ts`). Key vars: `EMBEDDING_PROVIDER` (OpenAI | VoyageAI | Gemini | Ollama | OpenRouter | Bedrock), provider API key, `EMBEDDING_MODEL`, `MILVUS_ADDRESS` and/or `MILVUS_TOKEN` (address can be auto-resolved from a Zilliz token), `CODE_CHUNKS_COLLECTION_NAME_OVERRIDE`, `CODE_CHUNKS_COLLECTION_KEY_SOURCE` (set to `git-remote` to key a codebase's collection off its git `origin` remote instead of its local path, so multiple checkouts of the same repo share one collection).
 
 ## Architecture
 
@@ -56,7 +56,7 @@ Configuration is entirely via environment variables (see `.env.example` and `pac
 
 `Context` ties together three pluggable interfaces injected through its constructor config:
 
-- **Embedding** (`src/embedding/`) — `base-embedding.ts` interface with `OpenAIEmbedding`, `VoyageAIEmbedding`, `GeminiEmbedding`, `OllamaEmbedding` implementations.
+- **Embedding** (`src/embedding/`) — `base-embedding.ts` interface with `OpenAIEmbedding`, `VoyageAIEmbedding`, `GeminiEmbedding`, `OllamaEmbedding`, `BedrockEmbedding` implementations.
 - **VectorDatabase** (`src/vectordb/`) — `MilvusVectorDatabase` (gRPC, Node-only) and `MilvusRestfulVectorDatabase` (HTTP, browser-safe). `zilliz-utils.ts` (`ClusterManager`) can provision a free Zilliz cluster and resolve an address from a token.
 - **Splitter** (`src/splitter/`) — `AstCodeSplitter` (tree-sitter, the default at 2500/300 chunk/overlap) which falls back to `LangChainCodeSplitter` for unsupported languages or parse failures.
 

--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -20,7 +20,7 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 ### Embedding Provider
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `EMBEDDING_PROVIDER` | Provider: `OpenAI`, `VoyageAI`, `Gemini`, `Ollama` | `OpenAI` |
+| `EMBEDDING_PROVIDER` | Provider: `OpenAI`, `VoyageAI`, `Gemini`, `Ollama`, `OpenRouter`, `Bedrock` | `OpenAI` |
 | `EMBEDDING_MODEL` | Embedding model name (works for all providers) | Provider-specific default |
 | `OPENAI_API_KEY` | OpenAI API key | Required for OpenAI |
 | `OPENAI_BASE_URL` | OpenAI API base URL (optional, for custom endpoints) | `https://api.openai.com/v1` |
@@ -39,6 +39,8 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 > - Gemini Models: See `getSupportedModels` in [`gemini-embedding.ts`](https://github.com/zilliztech/claude-context/blob/master/packages/core/src/embedding/gemini-embedding.ts) for the full list of supported models.
 > 
 > - Ollama Models: Depends on the model you install locally.
+> 
+> - Bedrock Models: See `getSupportedModels` in [`bedrock-embedding.ts`](https://github.com/zilliztech/claude-context/blob/master/packages/core/src/embedding/bedrock-embedding.ts) for the full list of supported models.
 
 > **📖 For detailed provider-specific configuration examples and setup instructions, see the [MCP Configuration Guide](../../packages/mcp/README.md#embedding-provider-configuration).**
 
@@ -55,6 +57,16 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 | `OLLAMA_HOST` | Ollama server URL | `http://127.0.0.1:11434` |
 | `OLLAMA_MODEL`(alternative to `EMBEDDING_MODEL`) | Model name |  |
 
+### Bedrock (Required when `EMBEDDING_PROVIDER=Bedrock`)
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `BEDROCK_REGION` | AWS region for Bedrock Runtime (falls back to `AWS_REGION`) | Required |
+| `BEDROCK_ACCESS_KEY_ID` | Optional static access key. Omit to use the default AWS credential chain (env vars, shared config, IAM role) | Default AWS credential chain |
+| `BEDROCK_SECRET_ACCESS_KEY` | Optional static secret key, required if `BEDROCK_ACCESS_KEY_ID` is set | — |
+| `BEDROCK_SESSION_TOKEN` | Optional session token for temporary credentials | — |
+| `BEDROCK_ENDPOINT` | Optional custom endpoint, e.g. a VPC interface endpoint | — |
+| `BEDROCK_EMBEDDING_DIMENSION` | Optional dimension override (only honored by `amazon.titan-embed-text-v2:0`, which supports 256/512/1024) | Model default |
+
 
 ### Advanced Configuration
 | Variable | Description | Default |
@@ -65,8 +77,11 @@ Claude Context supports a global configuration file at `~/.context/.env` to simp
 | `CUSTOM_EXTENSIONS` | Additional file extensions to include (comma-separated, e.g., `.vue,.svelte,.astro`) | None |
 | `CUSTOM_IGNORE_PATTERNS` | Additional ignore patterns (comma-separated, e.g., `temp/**,*.backup,private/**`) | None |
 | `CODE_CHUNKS_COLLECTION_NAME_OVERRIDE` | Optional custom prefix for collection names. Produces `code_chunks_<suffix>_<pathHash>` or `hybrid_code_chunks_<suffix>_<pathHash>` after sanitization. The path hash stays appended so collections remain unique per codebase even when the override is set | None |
+| `CODE_CHUNKS_COLLECTION_KEY_SOURCE` | Set to `git-remote` to derive the collection's hash from the codebase's git remote URL (`origin`) instead of its absolute path. Falls back to the path when the codebase isn't a git repo or has no `origin` remote | `path` |
 
 When `CODE_CHUNKS_COLLECTION_NAME_OVERRIDE` is set, Claude Context writes to an override-named collection instead of the default `code_chunks_<pathHash>`. The per-codebase `<pathHash>` suffix is preserved to keep multiple codebases distinct under the same override. If you later unset the variable, Claude Context returns to the plain hash-based naming for that path.
+
+`CODE_CHUNKS_COLLECTION_KEY_SOURCE=git-remote` is useful when several machines index the same repository from different checkout paths (for example, a CI job and every teammate's laptop) and should all converge on the same collection instead of each getting a private one. The remote URL is normalized so SSH and HTTPS forms of the same repo (e.g. `git@github.com:org/repo.git` and `https://github.com/org/repo.git`) hash identically.
 
 ## 🚀 Quick Setup
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
         "test": "jest --runInBand"
     },
     "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.700.0",
         "@google/genai": "^1.9.0",
         "@zilliz/milvus2-sdk-node": "^2.5.10",
         "faiss-node": "^0.5.1",

--- a/packages/core/src/context.collection-name.test.ts
+++ b/packages/core/src/context.collection-name.test.ts
@@ -1,0 +1,120 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { Context } from './context';
+import { VectorDatabase } from './vectordb';
+
+const createVectorDatabase = (): jest.Mocked<VectorDatabase> => ({
+    createCollection: jest.fn().mockResolvedValue(undefined),
+    createHybridCollection: jest.fn().mockResolvedValue(undefined),
+    dropCollection: jest.fn().mockResolvedValue(undefined),
+    hasCollection: jest.fn().mockResolvedValue(false),
+    listCollections: jest.fn().mockResolvedValue([]),
+    insert: jest.fn().mockResolvedValue(undefined),
+    insertHybrid: jest.fn().mockResolvedValue(undefined),
+    search: jest.fn().mockResolvedValue([]),
+    hybridSearch: jest.fn().mockResolvedValue([]),
+    delete: jest.fn().mockResolvedValue(undefined),
+    query: jest.fn().mockResolvedValue([]),
+    getCollectionDescription: jest.fn().mockResolvedValue(''),
+    checkCollectionLimit: jest.fn().mockResolvedValue(true),
+    getCollectionRowCount: jest.fn().mockResolvedValue(0),
+});
+
+async function writeGitOriginConfig(repoDir: string, url: string): Promise<void> {
+    const gitDir = path.join(repoDir, '.git');
+    await fs.mkdir(gitDir, { recursive: true });
+    const config = [
+        '[core]',
+        '\trepositoryformatversion = 0',
+        '[remote "origin"]',
+        `\turl = ${url}`,
+        '\tfetch = +refs/heads/*:refs/remotes/origin/*',
+        '[branch "main"]',
+        '\tremote = origin',
+        '\tmerge = refs/heads/main',
+        ''
+    ].join('\n');
+    await fs.writeFile(path.join(gitDir, 'config'), config, 'utf-8');
+}
+
+describe('Context.getCollectionName with CODE_CHUNKS_COLLECTION_KEY_SOURCE=git-remote', () => {
+    let tempRoot: string;
+    let originalKeySource: string | undefined;
+    let originalHybridMode: string | undefined;
+
+    beforeEach(async () => {
+        tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-context-git-remote-'));
+        originalKeySource = process.env.CODE_CHUNKS_COLLECTION_KEY_SOURCE;
+        originalHybridMode = process.env.HYBRID_MODE;
+        process.env.HYBRID_MODE = 'false';
+    });
+
+    afterEach(async () => {
+        if (originalKeySource === undefined) {
+            delete process.env.CODE_CHUNKS_COLLECTION_KEY_SOURCE;
+        } else {
+            process.env.CODE_CHUNKS_COLLECTION_KEY_SOURCE = originalKeySource;
+        }
+        if (originalHybridMode === undefined) {
+            delete process.env.HYBRID_MODE;
+        } else {
+            process.env.HYBRID_MODE = originalHybridMode;
+        }
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    });
+
+    test('defaults to path-based hashing when the env var is unset', async () => {
+        delete process.env.CODE_CHUNKS_COLLECTION_KEY_SOURCE;
+        const repoA = path.join(tempRoot, 'checkout-a');
+        const repoB = path.join(tempRoot, 'checkout-b');
+        await fs.mkdir(repoA, { recursive: true });
+        await fs.mkdir(repoB, { recursive: true });
+        await writeGitOriginConfig(repoA, 'git@github.com:acme/widgets.git');
+        await writeGitOriginConfig(repoB, 'git@github.com:acme/widgets.git');
+
+        const context = new Context({ vectorDatabase: createVectorDatabase() });
+
+        expect(context.getCollectionName(repoA)).not.toBe(context.getCollectionName(repoB));
+    });
+
+    test('SSH and HTTPS remotes for the same repo converge on the same collection name', async () => {
+        process.env.CODE_CHUNKS_COLLECTION_KEY_SOURCE = 'git-remote';
+        const repoSsh = path.join(tempRoot, 'checkout-ssh');
+        const repoHttps = path.join(tempRoot, 'checkout-https');
+        await fs.mkdir(repoSsh, { recursive: true });
+        await fs.mkdir(repoHttps, { recursive: true });
+        await writeGitOriginConfig(repoSsh, 'git@github.com:acme/widgets.git');
+        await writeGitOriginConfig(repoHttps, 'https://github.com/acme/widgets.git');
+
+        const context = new Context({ vectorDatabase: createVectorDatabase() });
+
+        expect(context.getCollectionName(repoSsh)).toBe(context.getCollectionName(repoHttps));
+    });
+
+    test('different repos still get different collection names', async () => {
+        process.env.CODE_CHUNKS_COLLECTION_KEY_SOURCE = 'git-remote';
+        const repoA = path.join(tempRoot, 'checkout-a');
+        const repoB = path.join(tempRoot, 'checkout-b');
+        await fs.mkdir(repoA, { recursive: true });
+        await fs.mkdir(repoB, { recursive: true });
+        await writeGitOriginConfig(repoA, 'git@github.com:acme/widgets.git');
+        await writeGitOriginConfig(repoB, 'git@github.com:acme/gizmos.git');
+
+        const context = new Context({ vectorDatabase: createVectorDatabase() });
+
+        expect(context.getCollectionName(repoA)).not.toBe(context.getCollectionName(repoB));
+    });
+
+    test('falls back to path-based hashing when there is no git repo', async () => {
+        process.env.CODE_CHUNKS_COLLECTION_KEY_SOURCE = 'git-remote';
+        const notARepo = path.join(tempRoot, 'plain-folder');
+        await fs.mkdir(notARepo, { recursive: true });
+
+        const context = new Context({ vectorDatabase: createVectorDatabase() });
+
+        const expectedHash = crypto.createHash('md5').update(path.resolve(notARepo)).digest('hex').substring(0, 8);
+        expect(context.getCollectionName(notARepo)).toBe(`code_chunks_${expectedHash}`);
+    });
+});

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -284,13 +284,25 @@ export class Context {
     }
 
     /**
-     * Generate collection name based on codebase path and hybrid mode
+     * Generate collection name based on codebase path (or git remote identity) and hybrid mode
      */
     public getCollectionName(codebasePath: string): string {
         const isHybrid = this.getIsHybrid();
         const prefix = isHybrid === true ? 'hybrid_code_chunks' : 'code_chunks';
-        const normalizedPath = path.resolve(codebasePath);
-        const pathHash = crypto.createHash('md5').update(normalizedPath).digest('hex').substring(0, 8);
+
+        // Default identity is the absolute path, so distinct checkouts of the same
+        // repo get distinct collections. Opting into CODE_CHUNKS_COLLECTION_KEY_SOURCE=git-remote
+        // switches to the repo's remote URL instead, so every checkout of the same
+        // repo (CI, every teammate's laptop, etc.) converges on the same collection.
+        let hashInput = path.resolve(codebasePath);
+        const keySource = envManager.get('CODE_CHUNKS_COLLECTION_KEY_SOURCE');
+        if (keySource?.trim().toLowerCase() === 'git-remote') {
+            const remoteIdentity = this.getGitRemoteIdentity(codebasePath);
+            if (remoteIdentity) {
+                hashInput = remoteIdentity;
+            }
+        }
+        const pathHash = crypto.createHash('md5').update(hashInput).digest('hex').substring(0, 8);
 
         // Overrides always keep the per-codebase `_<pathHash>` suffix so that multiple
         // codebases indexed by the same MCP server can't collapse into one collection.
@@ -307,6 +319,60 @@ export class Context {
         }
 
         return `${prefix}_${pathHash}`;
+    }
+
+    /**
+     * Resolve a repo-stable identity string (e.g. "github.com/org/repo") from the
+     * codebase's git remote "origin", or undefined if it can't be determined
+     * (not a git repo, no origin remote, unreadable config, etc).
+     */
+    private getGitRemoteIdentity(codebasePath: string): string | undefined {
+        try {
+            const gitConfigPath = path.join(path.resolve(codebasePath), '.git', 'config');
+            if (!fs.existsSync(gitConfigPath) || !fs.statSync(gitConfigPath).isFile()) {
+                return undefined;
+            }
+            const configContent = fs.readFileSync(gitConfigPath, 'utf-8');
+            const originMatch = configContent.match(/\[remote "origin"\][^[]*/);
+            if (!originMatch) {
+                return undefined;
+            }
+            const urlMatch = originMatch[0].match(/url\s*=\s*(.+)/);
+            if (!urlMatch) {
+                return undefined;
+            }
+            return this.normalizeGitRemoteUrl(urlMatch[1].trim());
+        } catch (error) {
+            console.warn(`[Context] ⚠️ Failed to read git remote for ${codebasePath}: ${error}`);
+            return undefined;
+        }
+    }
+
+    /**
+     * Normalize a git remote URL (SSH, HTTPS, or git protocol, with or without a
+     * trailing ".git") into a host-agnostic "<host>/<path>" identity string, so
+     * that different clone styles of the same repo hash to the same value.
+     */
+    private normalizeGitRemoteUrl(url: string): string | undefined {
+        let normalized = url.trim();
+        if (normalized.length === 0) {
+            return undefined;
+        }
+
+        // scp-like SSH syntax: git@host:org/repo(.git)
+        const scpMatch = normalized.match(/^(?:[^@]+@)?([^:/]+):(.+)$/);
+        if (!normalized.includes('://') && scpMatch) {
+            normalized = `${scpMatch[1]}/${scpMatch[2]}`;
+        } else {
+            // URL syntax: scheme://[user@]host/path(.git)
+            normalized = normalized.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, '');
+            normalized = normalized.replace(/^[^@/]+@/, '');
+        }
+
+        normalized = normalized.replace(/\.git\/?$/, '');
+        normalized = normalized.replace(/\/+$/, '');
+
+        return normalized.toLowerCase();
     }
 
     private getValidOverrideValue(value?: string): string | undefined {

--- a/packages/core/src/embedding/bedrock-embedding.test.ts
+++ b/packages/core/src/embedding/bedrock-embedding.test.ts
@@ -1,0 +1,152 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
+import { BedrockEmbedding } from './bedrock-embedding';
+
+const mockSend = jest.fn();
+
+jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
+    BedrockRuntimeClient: jest.fn().mockImplementation((config) => ({ send: mockSend, config })),
+    InvokeModelCommand: jest.fn().mockImplementation((input) => ({ input })),
+}));
+
+function jsonResponse(body: unknown) {
+    return {
+        body: {
+            transformToString: async () => JSON.stringify(body),
+        },
+    };
+}
+
+describe('BedrockEmbedding', () => {
+    beforeEach(() => {
+        mockSend.mockReset();
+        (BedrockRuntimeClient as unknown as jest.Mock).mockClear();
+        (InvokeModelCommand as unknown as jest.Mock).mockClear();
+    });
+
+    it('exposes known model metadata', () => {
+        const supportedModels = BedrockEmbedding.getSupportedModels();
+
+        expect(supportedModels['amazon.titan-embed-text-v2:0']).toMatchObject({
+            dimension: 1024,
+            family: 'titan',
+        });
+        expect(supportedModels['cohere.embed-english-v3']).toMatchObject({
+            dimension: 1024,
+            family: 'cohere',
+        });
+    });
+
+    it('embeds a single text with Titan v2, requesting the configured dimensions', async () => {
+        mockSend.mockResolvedValue(jsonResponse({ embedding: [1, 0, 0] }));
+
+        const embedding = new BedrockEmbedding({
+            model: 'amazon.titan-embed-text-v2:0',
+            region: 'us-east-1',
+        });
+
+        const result = await embedding.embed('hello world');
+
+        expect(result).toEqual({ vector: [1, 0, 0], dimension: 3 });
+        expect(mockSend).toHaveBeenCalledTimes(1);
+        expect(InvokeModelCommand).toHaveBeenCalledWith(
+            expect.objectContaining({
+                modelId: 'amazon.titan-embed-text-v2:0',
+                body: JSON.stringify({ inputText: 'hello world', dimensions: 1024, normalize: true }),
+            })
+        );
+    });
+
+    it('issues one InvokeModel call per text for Titan models (no native batching)', async () => {
+        mockSend
+            .mockResolvedValueOnce(jsonResponse({ embedding: [1, 0, 0] }))
+            .mockResolvedValueOnce(jsonResponse({ embedding: [0, 1, 0] }));
+
+        const embedding = new BedrockEmbedding({
+            model: 'amazon.titan-embed-text-v1',
+            region: 'us-east-1',
+        });
+
+        const results = await embedding.embedBatch(['first', 'second']);
+
+        expect(results).toEqual([
+            { vector: [1, 0, 0], dimension: 3 },
+            { vector: [0, 1, 0], dimension: 3 },
+        ]);
+        expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it('batches Cohere embeddings into a single InvokeModel call', async () => {
+        mockSend.mockResolvedValue(jsonResponse({ embeddings: [[1, 0], [0, 1]] }));
+
+        const embedding = new BedrockEmbedding({
+            model: 'cohere.embed-english-v3',
+            region: 'us-east-1',
+        });
+
+        const results = await embedding.embedBatch(['first', 'second']);
+
+        expect(results).toEqual([
+            { vector: [1, 0], dimension: 2 },
+            { vector: [0, 1], dimension: 2 },
+        ]);
+        expect(mockSend).toHaveBeenCalledTimes(1);
+        expect(InvokeModelCommand).toHaveBeenCalledWith(
+            expect.objectContaining({
+                modelId: 'cohere.embed-english-v3',
+                body: JSON.stringify({ texts: ['first', 'second'], input_type: 'search_document' }),
+            })
+        );
+    });
+
+    it('returns an empty batch without calling Bedrock', async () => {
+        const embedding = new BedrockEmbedding({
+            model: 'amazon.titan-embed-text-v2:0',
+            region: 'us-east-1',
+        });
+
+        await expect(embedding.embedBatch([])).resolves.toEqual([]);
+        expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('throws a clear error when the Titan response has no embedding field', async () => {
+        mockSend.mockResolvedValue(jsonResponse({ unexpected: true }));
+
+        const embedding = new BedrockEmbedding({
+            model: 'amazon.titan-embed-text-v2:0',
+            region: 'us-east-1',
+        });
+
+        await expect(embedding.embed('hello')).rejects.toThrow(/no "embedding" field/);
+    });
+
+    it('passes static credentials through to the Bedrock client when provided', () => {
+        new BedrockEmbedding({
+            model: 'amazon.titan-embed-text-v2:0',
+            region: 'us-east-1',
+            accessKeyId: 'AKIA_TEST',
+            secretAccessKey: 'secret',
+            sessionToken: 'session',
+        });
+
+        expect(BedrockRuntimeClient).toHaveBeenCalledWith(
+            expect.objectContaining({
+                region: 'us-east-1',
+                credentials: {
+                    accessKeyId: 'AKIA_TEST',
+                    secretAccessKey: 'secret',
+                    sessionToken: 'session',
+                },
+            })
+        );
+    });
+
+    it('omits credentials from the client config when not provided, relying on the default chain', () => {
+        new BedrockEmbedding({
+            model: 'amazon.titan-embed-text-v2:0',
+            region: 'us-east-1',
+        });
+
+        const callArgs = (BedrockRuntimeClient as unknown as jest.Mock).mock.calls[0][0];
+        expect(callArgs.credentials).toBeUndefined();
+    });
+});

--- a/packages/core/src/embedding/bedrock-embedding.ts
+++ b/packages/core/src/embedding/bedrock-embedding.ts
@@ -1,0 +1,209 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
+import { Embedding, EmbeddingVector } from './base-embedding';
+
+type BedrockModelFamily = 'titan' | 'cohere';
+
+type BedrockModelInfo = {
+    dimension: number;
+    maxTokens: number;
+    family: BedrockModelFamily;
+    description: string;
+    supportedDimensions?: number[];
+};
+
+export interface BedrockEmbeddingConfig {
+    model: string;
+    region: string;
+    // Optional static credentials. When omitted, the AWS SDK's default
+    // credential provider chain is used (env vars, shared config, IAM role, etc).
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+    // Optional custom endpoint, e.g. a VPC interface endpoint for Bedrock Runtime.
+    endpoint?: string;
+    // Optional dimension override (only honored by amazon.titan-embed-text-v2:0).
+    dimension?: number;
+}
+
+// Cohere Embed models on Bedrock accept at most 96 texts per InvokeModel call.
+const COHERE_BATCH_LIMIT = 96;
+
+export class BedrockEmbedding extends Embedding {
+    private client: BedrockRuntimeClient;
+    private config: BedrockEmbeddingConfig;
+    private dimension: number;
+    protected maxTokens: number;
+
+    constructor(config: BedrockEmbeddingConfig) {
+        super();
+        this.config = config;
+        this.client = new BedrockRuntimeClient({
+            region: config.region,
+            ...(config.endpoint && { endpoint: config.endpoint }),
+            ...(config.accessKeyId && config.secretAccessKey && {
+                credentials: {
+                    accessKeyId: config.accessKeyId,
+                    secretAccessKey: config.secretAccessKey,
+                    ...(config.sessionToken && { sessionToken: config.sessionToken })
+                }
+            })
+        });
+
+        const model = config.model || 'amazon.titan-embed-text-v2:0';
+        const modelInfo = BedrockEmbedding.getSupportedModels()[model];
+        this.dimension = config.dimension || modelInfo?.dimension || 1024;
+        this.maxTokens = modelInfo?.maxTokens || 8192;
+    }
+
+    async detectDimension(): Promise<number> {
+        // Bedrock embedding dimensions are known per-model, no dynamic detection needed.
+        return this.dimension;
+    }
+
+    async embed(text: string): Promise<EmbeddingVector> {
+        const [result] = await this.embedBatch([text]);
+        return result;
+    }
+
+    async embedBatch(texts: string[]): Promise<EmbeddingVector[]> {
+        if (texts.length === 0) {
+            return [];
+        }
+
+        const processedTexts = this.preprocessTexts(texts);
+        const model = this.config.model || 'amazon.titan-embed-text-v2:0';
+        const family = this.getModelFamily(model);
+
+        if (family === 'cohere') {
+            return this.embedCohereBatch(processedTexts, model);
+        }
+
+        // Titan embedding models only accept a single inputText per InvokeModel call.
+        const results: EmbeddingVector[] = [];
+        for (const text of processedTexts) {
+            results.push(await this.embedTitanSingle(text, model));
+        }
+        return results;
+    }
+
+    private getModelFamily(model: string): BedrockModelFamily {
+        return model.startsWith('cohere.') ? 'cohere' : 'titan';
+    }
+
+    private async embedTitanSingle(text: string, model: string): Promise<EmbeddingVector> {
+        const body: Record<string, unknown> = { inputText: text };
+        if (model.includes('titan-embed-text-v2')) {
+            body.dimensions = this.dimension;
+            body.normalize = true;
+        }
+
+        const response = await this.invoke(model, body);
+        if (!Array.isArray(response.embedding)) {
+            throw new Error(`Bedrock model ${model} returned a response with no "embedding" field`);
+        }
+
+        return {
+            vector: response.embedding,
+            dimension: response.embedding.length
+        };
+    }
+
+    private async embedCohereBatch(texts: string[], model: string): Promise<EmbeddingVector[]> {
+        const results: EmbeddingVector[] = [];
+        for (let i = 0; i < texts.length; i += COHERE_BATCH_LIMIT) {
+            const chunk = texts.slice(i, i + COHERE_BATCH_LIMIT);
+            const response = await this.invoke(model, {
+                texts: chunk,
+                input_type: 'search_document'
+            });
+
+            if (!Array.isArray(response.embeddings)) {
+                throw new Error(`Bedrock model ${model} returned a response with no "embeddings" field`);
+            }
+
+            for (const embedding of response.embeddings) {
+                results.push({ vector: embedding, dimension: embedding.length });
+            }
+        }
+        return results;
+    }
+
+    private async invoke(model: string, body: Record<string, unknown>): Promise<any> {
+        try {
+            const command = new InvokeModelCommand({
+                modelId: model,
+                contentType: 'application/json',
+                accept: 'application/json',
+                body: JSON.stringify(body)
+            });
+            const response = await this.client.send(command);
+            const raw = await response.body?.transformToString();
+            if (!raw) {
+                throw new Error('Bedrock returned an empty response body');
+            }
+            return JSON.parse(raw);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            throw new Error(`Bedrock embedding failed for model ${model}: ${errorMessage}`);
+        }
+    }
+
+    getDimension(): number {
+        return this.dimension;
+    }
+
+    getProvider(): string {
+        return 'Bedrock';
+    }
+
+    /**
+     * Set model type
+     * @param model Bedrock model ID
+     */
+    setModel(model: string): void {
+        this.config.model = model;
+        const modelInfo = BedrockEmbedding.getSupportedModels()[model];
+        this.dimension = this.config.dimension || modelInfo?.dimension || 1024;
+        this.maxTokens = modelInfo?.maxTokens || 8192;
+    }
+
+    /**
+     * Get client instance (for advanced usage)
+     */
+    getClient(): BedrockRuntimeClient {
+        return this.client;
+    }
+
+    /**
+     * Get list of supported models
+     */
+    static getSupportedModels(): Record<string, BedrockModelInfo> {
+        return {
+            'amazon.titan-embed-text-v2:0': {
+                dimension: 1024,
+                maxTokens: 8192,
+                family: 'titan',
+                description: 'Titan Text Embeddings V2 (recommended; supports 256/512/1024 dims)',
+                supportedDimensions: [256, 512, 1024]
+            },
+            'amazon.titan-embed-text-v1': {
+                dimension: 1536,
+                maxTokens: 8192,
+                family: 'titan',
+                description: 'Titan Text Embeddings V1 (legacy)'
+            },
+            'cohere.embed-english-v3': {
+                dimension: 1024,
+                maxTokens: 512,
+                family: 'cohere',
+                description: 'Cohere Embed English V3'
+            },
+            'cohere.embed-multilingual-v3': {
+                dimension: 1024,
+                maxTokens: 512,
+                family: 'cohere',
+                description: 'Cohere Embed Multilingual V3'
+            }
+        };
+    }
+}

--- a/packages/core/src/embedding/index.ts
+++ b/packages/core/src/embedding/index.ts
@@ -5,4 +5,5 @@ export * from './base-embedding';
 export * from './openai-embedding';
 export * from './voyageai-embedding';
 export * from './ollama-embedding';
-export * from './gemini-embedding'; 
+export * from './gemini-embedding';
+export * from './bedrock-embedding';

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -34,7 +34,7 @@ Claude Context MCP supports multiple embedding providers. Choose the one that be
 > 📋 **Quick Reference**: For a complete list of environment variables and their descriptions, see the [Environment Variables Guide](../../docs/getting-started/environment-variables.md).
 
 ```bash
-# Supported providers: OpenAI, VoyageAI, Gemini, Ollama
+# Supported providers: OpenAI, VoyageAI, Gemini, Ollama, OpenRouter, Bedrock
 EMBEDDING_PROVIDER=OpenAI
 ```
 
@@ -152,6 +152,45 @@ EMBEDDING_DIMENSION=768
 
 </details>
 
+<details>
+<summary><strong>5. Amazon Bedrock Configuration</strong></summary>
+
+Amazon Bedrock lets you use managed embedding models (Titan, Cohere) from your own AWS account, keeping traffic inside your AWS network/VPC.
+
+```bash
+EMBEDDING_PROVIDER=Bedrock
+
+# Required: AWS region for Bedrock Runtime (falls back to AWS_REGION)
+BEDROCK_REGION=us-east-1
+
+# Optional: Specify embedding model (default: amazon.titan-embed-text-v2:0)
+EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
+
+# Optional: static credentials. If omitted, the default AWS credential chain
+# is used (env vars, shared config/profile, IAM role, ECS/EC2 instance role, etc).
+BEDROCK_ACCESS_KEY_ID=your-access-key-id
+BEDROCK_SECRET_ACCESS_KEY=your-secret-access-key
+BEDROCK_SESSION_TOKEN=your-session-token
+
+# Optional: custom endpoint, e.g. a VPC interface endpoint for Bedrock Runtime
+BEDROCK_ENDPOINT=https://vpce-xxxx.bedrock-runtime.us-east-1.vpce.amazonaws.com
+
+# Optional: dimension override (only honored by amazon.titan-embed-text-v2:0,
+# which supports 256/512/1024)
+BEDROCK_EMBEDDING_DIMENSION=1024
+```
+
+**Available Models:**
+See `getSupportedModels` in [`bedrock-embedding.ts`](https://github.com/zilliztech/claude-context/blob/master/packages/core/src/embedding/bedrock-embedding.ts) for the full list of supported models (Titan and Cohere embedding models).
+
+**Prerequisites:**
+
+1. Request access to the embedding model(s) you want in the [Bedrock console model access page](https://console.aws.amazon.com/bedrock/home#/modelaccess) for your chosen region.
+2. Either configure AWS credentials locally (`aws configure`, an assumed role, or an EC2/ECS instance role) or set `BEDROCK_ACCESS_KEY_ID`/`BEDROCK_SECRET_ACCESS_KEY` explicitly.
+3. Grant the credentials the `bedrock:InvokeModel` IAM permission for the embedding model(s) you use.
+
+</details>
+
 #### Get a free vector database on Zilliz Cloud
 
 Claude Context needs a vector database. You can [sign up](https://cloud.zilliz.com/signup?utm_source=github&utm_medium=referral&utm_campaign=2507-codecontext-readme) on Zilliz Cloud to get an API key.
@@ -199,6 +238,17 @@ CODE_CHUNKS_COLLECTION_NAME_OVERRIDE=my_project
 ```
 
 The per-codebase `<pathHash>` suffix is preserved even when the override is set, so the same MCP server can still index multiple repos without collapsing them onto one collection. The override value is sanitized to letters, numbers, and underscores, and truncated to keep the full name within Milvus's 255-char limit. If you unset the variable later, Claude Context switches back to the plain `code_chunks_<pathHash>` naming.
+
+#### Collection Key Source (Optional)
+
+By default, the `<pathHash>` in a collection name is derived from the codebase's absolute local path, so two checkouts of the same repo (e.g. a CI runner and your laptop) get different collections. Use this to key it off the repo's git remote instead, so every checkout of the same repo converges on one shared collection:
+
+```bash
+# Hash the "origin" remote URL instead of the local path
+CODE_CHUNKS_COLLECTION_KEY_SOURCE=git-remote
+```
+
+SSH and HTTPS forms of the same remote (`git@github.com:org/repo.git` vs `https://github.com/org/repo.git`) normalize to the same identity and hash. Falls back to the path-based hash when the codebase isn't a git repo or has no `origin` remote.
 
 #### Trigger File Watcher (Optional)
 

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -5,7 +5,7 @@ export interface ContextMcpConfig {
     name: string;
     version: string;
     // Embedding provider configuration
-    embeddingProvider: 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama' | 'OpenRouter';
+    embeddingProvider: 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama' | 'OpenRouter' | 'Bedrock';
     embeddingModel: string;
     // Provider-specific API keys
     openaiApiKey?: string;
@@ -19,6 +19,13 @@ export interface ContextMcpConfig {
     ollamaModel?: string;
     ollamaHost?: string;
     ollamaDimension?: number;
+    // Bedrock configuration
+    bedrockRegion?: string;
+    bedrockAccessKeyId?: string;
+    bedrockSecretAccessKey?: string;
+    bedrockSessionToken?: string;
+    bedrockEndpoint?: string;
+    bedrockDimension?: number;
     // Vector database configuration
     milvusAddress?: string; // Optional, can be auto-resolved from token
     milvusToken?: string;
@@ -94,6 +101,8 @@ export function getDefaultModelForProvider(provider: string): string {
             return 'openai/text-embedding-3-small';
         case 'Ollama':
             return 'nomic-embed-text';
+        case 'Bedrock':
+            return 'amazon.titan-embed-text-v2:0';
         default:
             return 'text-embedding-3-small';
     }
@@ -159,15 +168,18 @@ export function createMcpConfig(): ContextMcpConfig {
     console.log(`[DEBUG]   OLLAMA_MODEL: ${envManager.get('OLLAMA_MODEL') || 'NOT SET'}`);
     console.log(`[DEBUG]   GEMINI_API_KEY: ${envManager.get('GEMINI_API_KEY') ? 'SET (length: ' + envManager.get('GEMINI_API_KEY')!.length + ')' : 'NOT SET'}`);
     console.log(`[DEBUG]   OPENAI_API_KEY: ${envManager.get('OPENAI_API_KEY') ? 'SET (length: ' + envManager.get('OPENAI_API_KEY')!.length + ')' : 'NOT SET'}`);
+    console.log(`[DEBUG]   BEDROCK_REGION: ${envManager.get('BEDROCK_REGION') || envManager.get('AWS_REGION') || 'NOT SET'}`);
+    console.log(`[DEBUG]   BEDROCK_ACCESS_KEY_ID: ${envManager.get('BEDROCK_ACCESS_KEY_ID') ? 'SET' : 'NOT SET (using default AWS credential chain)'}`);
     console.log(`[DEBUG]   MILVUS_ADDRESS: ${envManager.get('MILVUS_ADDRESS') || 'NOT SET'}`);
     console.log(`[DEBUG]   CODE_CHUNKS_COLLECTION_NAME_OVERRIDE: ${envManager.get('CODE_CHUNKS_COLLECTION_NAME_OVERRIDE') || 'NOT SET'}`);
+    console.log(`[DEBUG]   CODE_CHUNKS_COLLECTION_KEY_SOURCE: ${envManager.get('CODE_CHUNKS_COLLECTION_KEY_SOURCE') || 'NOT SET'}`);
     console.log(`[DEBUG]   NODE_ENV: ${envManager.get('NODE_ENV') || 'NOT SET'}`);
 
     const config: ContextMcpConfig = {
         name: envManager.get('MCP_SERVER_NAME') || "Context MCP Server",
         version: envManager.get('MCP_SERVER_VERSION') || defaultMcpServerVersion,
         // Embedding provider configuration
-        embeddingProvider: (envManager.get('EMBEDDING_PROVIDER') as 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama' | 'OpenRouter') || 'OpenAI',
+        embeddingProvider: (envManager.get('EMBEDDING_PROVIDER') as 'OpenAI' | 'VoyageAI' | 'Gemini' | 'Ollama' | 'OpenRouter' | 'Bedrock') || 'OpenAI',
         embeddingModel: getEmbeddingModelForProvider(envManager.get('EMBEDDING_PROVIDER') || 'OpenAI'),
         // Provider-specific API keys
         openaiApiKey: envManager.get('OPENAI_API_KEY'),
@@ -181,6 +193,13 @@ export function createMcpConfig(): ContextMcpConfig {
         ollamaModel: envManager.get('OLLAMA_MODEL'),
         ollamaHost: envManager.get('OLLAMA_HOST'),
         ollamaDimension: getPositiveIntegerFromEnv('EMBEDDING_DIMENSION'),
+        // Bedrock configuration
+        bedrockRegion: envManager.get('BEDROCK_REGION') || envManager.get('AWS_REGION'),
+        bedrockAccessKeyId: envManager.get('BEDROCK_ACCESS_KEY_ID'),
+        bedrockSecretAccessKey: envManager.get('BEDROCK_SECRET_ACCESS_KEY'),
+        bedrockSessionToken: envManager.get('BEDROCK_SESSION_TOKEN'),
+        bedrockEndpoint: envManager.get('BEDROCK_ENDPOINT'),
+        bedrockDimension: getPositiveIntegerFromEnv('BEDROCK_EMBEDDING_DIMENSION'),
         // Vector database configuration - address can be auto-resolved from token
         milvusAddress: envManager.get('MILVUS_ADDRESS'), // Optional, can be resolved from token
         milvusToken: envManager.get('MILVUS_TOKEN'),
@@ -229,6 +248,16 @@ export function logConfigurationSummary(config: ContextMcpConfig): void {
                 console.log(`[MCP]   Ollama Embedding Dimension: ${config.ollamaDimension}`);
             }
             break;
+        case 'Bedrock':
+            console.log(`[MCP]   Bedrock Region: ${config.bedrockRegion || '❌ Missing'}`);
+            console.log(`[MCP]   Bedrock Credentials: ${config.bedrockAccessKeyId ? '✅ Explicit keys configured' : 'Using default AWS credential chain'}`);
+            if (config.bedrockEndpoint) {
+                console.log(`[MCP]   Bedrock Endpoint: ${config.bedrockEndpoint}`);
+            }
+            if (config.bedrockDimension) {
+                console.log(`[MCP]   Bedrock Embedding Dimension: ${config.bedrockDimension}`);
+            }
+            break;
     }
 
     console.log(`[MCP] 🔧 Initializing server components...`);
@@ -248,10 +277,10 @@ Environment Variables:
   MCP_SERVER_VERSION      Server version
   
   Embedding Provider Configuration:
-  EMBEDDING_PROVIDER      Embedding provider: OpenAI, VoyageAI, Gemini, Ollama, OpenRouter (default: OpenAI)
+  EMBEDDING_PROVIDER      Embedding provider: OpenAI, VoyageAI, Gemini, Ollama, OpenRouter, Bedrock (default: OpenAI)
   EMBEDDING_MODEL         Embedding model name (works for all providers)
   EMBEDDING_DIMENSION     Optional embedding dimension override for Ollama
-  
+
   Provider-specific API Keys:
   OPENAI_API_KEY          OpenAI API key (required for OpenAI provider)
   OPENAI_BASE_URL         OpenAI API base URL (optional, for custom endpoints)
@@ -263,7 +292,19 @@ Environment Variables:
   Ollama Configuration:
   OLLAMA_HOST             Ollama server host (default: http://127.0.0.1:11434)
   OLLAMA_MODEL            Ollama model name (alternative to EMBEDDING_MODEL for Ollama)
-  
+
+  Bedrock Configuration (required for Bedrock provider):
+  BEDROCK_REGION          AWS region for Bedrock Runtime (falls back to AWS_REGION)
+  BEDROCK_ACCESS_KEY_ID   Optional static access key (falls back to the default
+                          AWS credential chain: env vars, shared config, IAM role, etc)
+  BEDROCK_SECRET_ACCESS_KEY
+                          Optional static secret key, required if BEDROCK_ACCESS_KEY_ID is set
+  BEDROCK_SESSION_TOKEN   Optional session token for temporary credentials
+  BEDROCK_ENDPOINT        Optional custom endpoint (e.g. a VPC interface endpoint)
+  BEDROCK_EMBEDDING_DIMENSION
+                          Optional dimension override (only honored by
+                          amazon.titan-embed-text-v2:0, which supports 256/512/1024)
+
   Vector Database Configuration:
   MILVUS_ADDRESS          Milvus address (optional, can be auto-resolved from token)
   MILVUS_TOKEN            Milvus token (optional, used for authentication and address resolution)
@@ -273,6 +314,13 @@ Environment Variables:
                           after sanitization (letters/digits/underscore, 255 chars max).
                           The per-codebase pathHash is preserved so multiple
                           codebases stay distinct under the same override.
+  CODE_CHUNKS_COLLECTION_KEY_SOURCE
+                          Set to "git-remote" to hash the codebase's git
+                          "origin" remote URL instead of its absolute path,
+                          so every checkout of the same repo (CI, laptops, ...)
+                          converges on the same collection. Falls back to the
+                          path if the codebase isn't a git repo or has no
+                          origin remote. Default: path.
 
   MCP Sync Configuration:
   CLAUDE_CONTEXT_BACKGROUND_SYNC
@@ -312,8 +360,18 @@ Examples:
   # Start MCP server with Ollama and specific model (using EMBEDDING_MODEL)
   EMBEDDING_PROVIDER=Ollama EMBEDDING_MODEL=nomic-embed-text MILVUS_TOKEN=your-token npx @zilliz/claude-context-mcp@latest
 
+  # Start MCP server with Bedrock, using the default AWS credential chain
+  EMBEDDING_PROVIDER=Bedrock BEDROCK_REGION=us-east-1 MILVUS_TOKEN=your-token npx @zilliz/claude-context-mcp@latest
+
+  # Start MCP server with Bedrock and explicit credentials/model
+  EMBEDDING_PROVIDER=Bedrock BEDROCK_REGION=us-east-1 BEDROCK_ACCESS_KEY_ID=AKIA... BEDROCK_SECRET_ACCESS_KEY=xxx EMBEDDING_MODEL=cohere.embed-english-v3 MILVUS_TOKEN=your-token npx @zilliz/claude-context-mcp@latest
+
   # Start MCP server with a human-readable collection name override
   OPENAI_API_KEY=sk-xxx MILVUS_TOKEN=your-token CODE_CHUNKS_COLLECTION_NAME_OVERRIDE=my_project npx @zilliz/claude-context-mcp@latest
+
+  # Start MCP server keyed by the repo's git remote instead of its local path
+  # (so a shared Milvus stays in sync across every checkout of the same repo)
+  OPENAI_API_KEY=sk-xxx MILVUS_TOKEN=your-token CODE_CHUNKS_COLLECTION_KEY_SOURCE=git-remote npx @zilliz/claude-context-mcp@latest
 
   # Start MCP server with background sync enabled every minute
   OPENAI_API_KEY=sk-xxx MILVUS_TOKEN=your-token CLAUDE_CONTEXT_BACKGROUND_SYNC=true CLAUDE_CONTEXT_SYNC_INTERVAL_MS=60000 npx @zilliz/claude-context-mcp@latest

--- a/packages/mcp/src/embedding.ts
+++ b/packages/mcp/src/embedding.ts
@@ -1,8 +1,8 @@
-import { OpenAIEmbedding, VoyageAIEmbedding, GeminiEmbedding, OllamaEmbedding } from "@zilliz/claude-context-core";
+import { OpenAIEmbedding, VoyageAIEmbedding, GeminiEmbedding, OllamaEmbedding, BedrockEmbedding } from "@zilliz/claude-context-core";
 import { ContextMcpConfig } from "./config.js";
 
 // Helper function to create embedding instance based on provider
-export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding  {
+export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding | BedrockEmbedding  {
     console.log(`[EMBEDDING] Creating ${config.embeddingProvider} embedding instance...`);
 
     switch (config.embeddingProvider) {
@@ -73,13 +73,35 @@ export function createEmbeddingInstance(config: ContextMcpConfig): OpenAIEmbeddi
             console.log(`[EMBEDDING] ✅ Ollama embedding instance created successfully`);
             return ollamaEmbedding;
 
+        case 'Bedrock':
+            if (!config.bedrockRegion) {
+                console.error(`[EMBEDDING] ❌ Bedrock region is required but not provided`);
+                throw new Error('BEDROCK_REGION (or AWS_REGION) is required for Bedrock embedding provider');
+            }
+            if (config.bedrockAccessKeyId && !config.bedrockSecretAccessKey) {
+                console.error(`[EMBEDDING] ❌ BEDROCK_ACCESS_KEY_ID was provided without BEDROCK_SECRET_ACCESS_KEY`);
+                throw new Error('BEDROCK_SECRET_ACCESS_KEY is required when BEDROCK_ACCESS_KEY_ID is set');
+            }
+            console.log(`[EMBEDDING] 🔧 Configuring Bedrock with model: ${config.embeddingModel}, region: ${config.bedrockRegion}`);
+            const bedrockEmbedding = new BedrockEmbedding({
+                model: config.embeddingModel,
+                region: config.bedrockRegion,
+                ...(config.bedrockAccessKeyId && { accessKeyId: config.bedrockAccessKeyId }),
+                ...(config.bedrockSecretAccessKey && { secretAccessKey: config.bedrockSecretAccessKey }),
+                ...(config.bedrockSessionToken && { sessionToken: config.bedrockSessionToken }),
+                ...(config.bedrockEndpoint && { endpoint: config.bedrockEndpoint }),
+                ...(config.bedrockDimension && { dimension: config.bedrockDimension })
+            });
+            console.log(`[EMBEDDING] ✅ Bedrock embedding instance created successfully`);
+            return bedrockEmbedding;
+
         default:
             console.error(`[EMBEDDING] ❌ Unsupported embedding provider: ${config.embeddingProvider}`);
             throw new Error(`Unsupported embedding provider: ${config.embeddingProvider}`);
     }
 }
 
-export function logEmbeddingProviderInfo(config: ContextMcpConfig, embedding: OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding): void {
+export function logEmbeddingProviderInfo(config: ContextMcpConfig, embedding: OpenAIEmbedding | VoyageAIEmbedding | GeminiEmbedding | OllamaEmbedding | BedrockEmbedding): void {
     console.log(`[EMBEDDING] ✅ Successfully initialized ${config.embeddingProvider} embedding provider`);
     console.log(`[EMBEDDING] Provider details - Model: ${config.embeddingModel}, Dimension: ${embedding.getDimension()}`);
 
@@ -99,6 +121,9 @@ export function logEmbeddingProviderInfo(config: ContextMcpConfig, embedding: Op
             break;
         case 'Ollama':
             console.log(`[EMBEDDING] Ollama configuration - Host: ${config.ollamaHost || 'http://127.0.0.1:11434'}, Model: ${config.embeddingModel}${config.ollamaDimension ? `, Dimension: ${config.ollamaDimension}` : ''}`);
+            break;
+        case 'Bedrock':
+            console.log(`[EMBEDDING] Bedrock configuration - Region: ${config.bedrockRegion}, Credentials: ${config.bedrockAccessKeyId ? 'Explicit keys' : 'Default AWS credential chain'}${config.bedrockEndpoint ? `, Endpoint: ${config.bedrockEndpoint}` : ''}`);
             break;
     }
 }

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -14,7 +14,7 @@ A code indexing and semantic search VSCode extension powered by [Claude Context]
 - 🔍 **Semantic Search**: Intelligent code search based on semantic understanding, not just keyword matching
 - 📁 **Codebase Indexing**: Automatically index entire codebase and build semantic vector database
 - 🎯 **Context Search**: Search related code by selecting code snippets
-- 🔧 **Multi-platform Support**: Support for OpenAI, VoyageAI, Gemini, and Ollama as embedding providers
+- 🔧 **Multi-platform Support**: Support for OpenAI, VoyageAI, Gemini, Ollama, and Bedrock as embedding providers
 - 💾 **Vector Storage**: Integrated with Milvus vector database for efficient storage and retrieval
 
 ## Requirements
@@ -50,6 +50,7 @@ Configure your embedding provider to convert code into semantic vectors.
 - **Gemini**: Google's state-of-the-art embedding model with Matryoshka representation learning
 - **VoyageAI**: Alternative embedding provider with competitive performance  
 - **Ollama**: For local embedding models
+- **Bedrock**: Amazon Bedrock (Titan, Cohere embedding models), using your own AWS account/VPC. Requires a `Region`, and optionally static AWS credentials (falls back to the default AWS credential chain if omitted)
 
 #### Code Splitter Configuration
 Configure how your code is split into chunks for indexing.
@@ -106,11 +107,17 @@ MILVUS_TOKEN=your-zilliz-cloud-api-key
 
 ## Configuration
 
-- `semanticCodeSearch.embeddingProvider.provider` - Embedding provider (OpenAI/VoyageAI/Gemini/Ollama)
+- `semanticCodeSearch.embeddingProvider.provider` - Embedding provider (OpenAI/VoyageAI/Gemini/Ollama/Bedrock)
 - `semanticCodeSearch.embeddingProvider.model` - Embedding model to use
 - `semanticCodeSearch.embeddingProvider.apiKey` - API key for embedding provider
 - `semanticCodeSearch.embeddingProvider.baseURL` - Custom API endpoint URL (optional, for OpenAI and Gemini)
 - `semanticCodeSearch.embeddingProvider.outputDimensionality` - Output dimension for Gemini (supports 3072, 1536, 768, 256)
+- `semanticCodeSearch.embeddingProvider.region` - AWS region for Bedrock
+- `semanticCodeSearch.embeddingProvider.accessKeyId` - AWS access key ID for Bedrock (optional; uses the default AWS credential chain if omitted)
+- `semanticCodeSearch.embeddingProvider.secretAccessKey` - AWS secret access key for Bedrock (required if access key ID is set)
+- `semanticCodeSearch.embeddingProvider.sessionToken` - AWS session token for Bedrock temporary credentials (optional)
+- `semanticCodeSearch.embeddingProvider.endpoint` - Custom Bedrock endpoint URL, e.g. a VPC interface endpoint (optional)
+- `semanticCodeSearch.embeddingProvider.dimension` - Embedding dimension override for Bedrock (only honored by amazon.titan-embed-text-v2:0: 256, 512, or 1024)
 - `semanticCodeSearch.milvus.address` - Milvus server address
 
 ## Contributing

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -83,7 +83,8 @@
                         "OpenAI",
                         "VoyageAI",
                         "Ollama",
-                        "Gemini"
+                        "Gemini",
+                        "Bedrock"
                     ],
                     "description": "Embedding service provider"
                 },
@@ -110,6 +111,30 @@
                 "semanticCodeSearch.embeddingProvider.outputDimensionality": {
                     "type": "number",
                     "description": "Output dimension for Gemini embedding (supports Matryoshka representation: 3072, 1536, 768, 256)"
+                },
+                "semanticCodeSearch.embeddingProvider.region": {
+                    "type": "string",
+                    "description": "AWS region for Bedrock Runtime (e.g., us-east-1)"
+                },
+                "semanticCodeSearch.embeddingProvider.accessKeyId": {
+                    "type": "string",
+                    "description": "AWS access key ID for Bedrock (optional; uses the default AWS credential chain if omitted)"
+                },
+                "semanticCodeSearch.embeddingProvider.secretAccessKey": {
+                    "type": "string",
+                    "description": "AWS secret access key for Bedrock (required if access key ID is set)"
+                },
+                "semanticCodeSearch.embeddingProvider.sessionToken": {
+                    "type": "string",
+                    "description": "AWS session token for Bedrock temporary credentials (optional)"
+                },
+                "semanticCodeSearch.embeddingProvider.endpoint": {
+                    "type": "string",
+                    "description": "Custom Bedrock endpoint URL, e.g. a VPC interface endpoint (optional)"
+                },
+                "semanticCodeSearch.embeddingProvider.dimension": {
+                    "type": "number",
+                    "description": "Embedding dimension override for Bedrock (only honored by amazon.titan-embed-text-v2:0: 256, 512, or 1024)"
                 },
                 "semanticCodeSearch.milvus.address": {
                     "type": "string",

--- a/packages/vscode-extension/src/config/configManager.ts
+++ b/packages/vscode-extension/src/config/configManager.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { OpenAIEmbedding, OpenAIEmbeddingConfig, VoyageAIEmbedding, VoyageAIEmbeddingConfig, OllamaEmbedding, OllamaEmbeddingConfig, GeminiEmbedding, GeminiEmbeddingConfig, MilvusConfig, SplitterType, SplitterConfig, AstCodeSplitter, LangChainCodeSplitter } from '@zilliz/claude-context-core';
+import { OpenAIEmbedding, OpenAIEmbeddingConfig, VoyageAIEmbedding, VoyageAIEmbeddingConfig, OllamaEmbedding, OllamaEmbeddingConfig, GeminiEmbedding, GeminiEmbeddingConfig, BedrockEmbedding, BedrockEmbeddingConfig, MilvusConfig, SplitterType, SplitterConfig, AstCodeSplitter, LangChainCodeSplitter } from '@zilliz/claude-context-core';
 
 // Simplified Milvus configuration interface for frontend
 export interface MilvusWebConfig {
@@ -19,6 +19,9 @@ export type EmbeddingProviderConfig = {
 } | {
     provider: 'Gemini';
     config: GeminiEmbeddingConfig;
+} | {
+    provider: 'Bedrock';
+    config: BedrockEmbeddingConfig;
 };
 
 export type SplitterProviderConfig = {
@@ -102,6 +105,25 @@ const EMBEDDING_PROVIDERS = {
         ] as FieldDefinition[],
         defaultConfig: {
             model: 'gemini-embedding-001'
+        }
+    },
+    'Bedrock': {
+        name: 'Bedrock',
+        class: BedrockEmbedding,
+        requiredFields: [
+            { name: 'model', type: 'string', description: 'Model name to use', inputType: 'select-with-custom', required: true },
+            { name: 'region', type: 'string', description: 'AWS region for Bedrock Runtime', inputType: 'text', required: true, placeholder: 'us-east-1' }
+        ] as FieldDefinition[],
+        optionalFields: [
+            { name: 'accessKeyId', type: 'string', description: 'AWS access key ID (optional; uses the default AWS credential chain if omitted)', inputType: 'text' },
+            { name: 'secretAccessKey', type: 'string', description: 'AWS secret access key (required if access key ID is set)', inputType: 'password' },
+            { name: 'sessionToken', type: 'string', description: 'AWS session token for temporary credentials (optional)', inputType: 'password' },
+            { name: 'endpoint', type: 'string', description: 'Custom endpoint URL, e.g. a VPC interface endpoint (optional)', inputType: 'url' },
+            { name: 'dimension', type: 'number', description: 'Embedding dimension override (only honored by amazon.titan-embed-text-v2:0: 256, 512, or 1024)', inputType: 'text', placeholder: '1024' }
+        ] as FieldDefinition[],
+        defaultConfig: {
+            model: 'amazon.titan-embed-text-v2:0',
+            region: 'us-east-1'
         }
     }
 } as const;
@@ -205,7 +227,7 @@ export class ConfigManager {
         if (!configObject) return undefined;
 
         return {
-            provider: provider as 'OpenAI' | 'VoyageAI' | 'Ollama' | 'Gemini',
+            provider: provider as 'OpenAI' | 'VoyageAI' | 'Ollama' | 'Gemini' | 'Bedrock',
             config: configObject
         };
     }

--- a/packages/vscode-extension/src/webview/scripts/semanticSearch.js
+++ b/packages/vscode-extension/src/webview/scripts/semanticSearch.js
@@ -184,7 +184,8 @@ class SemanticSearchController {
                 { value: 'OpenAI', text: 'OpenAI' },
                 { value: 'VoyageAI', text: 'VoyageAI' },
                 { value: 'Ollama', text: 'Ollama' },
-                { value: 'Gemini', text: 'Gemini' }
+                { value: 'Gemini', text: 'Gemini' },
+                { value: 'Bedrock', text: 'Bedrock' }
             ];
 
             defaultProviders.forEach(provider => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@aws-sdk/client-bedrock-runtime':
+        specifier: ^3.700.0
+        version: 3.1095.0
       '@google/genai':
         specifier: ^1.9.0
         version: 1.9.0(@modelcontextprotocol/sdk@1.12.1)
@@ -298,6 +301,82 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@aws-sdk/client-bedrock-runtime@3.1095.0':
+    resolution: {integrity: sha512-DWcwoQdQPrQJxnG3hz1sG88EjfzGv3SReRy4mtAO+pZXtLX+trriTa20o+qcTmVzwqS43JXtX26ythOzErev9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.1':
+    resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.61':
+    resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.63':
+    resolution: {integrity: sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.6':
+    resolution: {integrity: sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.68':
+    resolution: {integrity: sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.72':
+    resolution: {integrity: sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.61':
+    resolution: {integrity: sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.5':
+    resolution: {integrity: sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.67':
+    resolution: {integrity: sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.30':
+    resolution: {integrity: sha512-hJboPgIpq5+ADc++/B9TBqn65CXV21cZLGB8V5RBQbxkZ/rQ6qMfcxTnW/SvQlasX4jhaSG8B1wsVjhQyDrsnQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.25':
+    resolution: {integrity: sha512-9SFbPzJDHHR5k6Q6KvXVas/veUm/TzNcNTFM2UhdXHZHpyIvI2lS+s4cxljw1BihGpVhsAkQDo/2nW7dHxpf4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.43':
+    resolution: {integrity: sha512-n29++15Vma64Kd0enp9Bo8a6LTm8TvUoMbJEwqXtIksv0oEs+SUCRMm3gozDfPD1Ly0k/sSBughxarlLlRF6Xw==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.35':
+    resolution: {integrity: sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.42':
+    resolution: {integrity: sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1095.0':
+    resolution: {integrity: sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@azu/format-text@1.0.2':
     resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
@@ -1023,6 +1102,30 @@ packages:
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
+  '@smithy/core@3.30.0':
+    resolution: {integrity: sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.14':
+    resolution: {integrity: sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.11':
+    resolution: {integrity: sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.11':
+    resolution: {integrity: sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.10':
+    resolution: {integrity: sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
   '@textlint/ast-node-types@14.8.4':
     resolution: {integrity: sha512-+fI7miec/r9VeniFV9ppL4jRCmHNsTxieulTUf/4tvGII3db5hGriKHC4p/diq1SkQ9Sgs7kg6UyydxZtpTz1Q==}
 
@@ -1600,6 +1703,9 @@ packages:
 
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -4392,6 +4498,179 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@aws-sdk/client-bedrock-runtime@3.1095.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-node': 3.972.72
+      '@aws-sdk/eventstream-handler-node': 3.972.30
+      '@aws-sdk/middleware-eventstream': 3.972.25
+      '@aws-sdk/middleware-websocket': 3.972.43
+      '@aws-sdk/token-providers': 3.1095.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.1':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.30.0
+      '@smithy/signature-v4': 5.6.10
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.6':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-env': 3.972.61
+      '@aws-sdk/credential-provider-http': 3.972.63
+      '@aws-sdk/credential-provider-login': 3.972.68
+      '@aws-sdk/credential-provider-process': 3.972.61
+      '@aws-sdk/credential-provider-sso': 3.973.5
+      '@aws-sdk/credential-provider-web-identity': 3.972.67
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/credential-provider-imds': 4.4.14
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.68':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.72':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.61
+      '@aws-sdk/credential-provider-http': 3.972.63
+      '@aws-sdk/credential-provider-ini': 3.973.6
+      '@aws-sdk/credential-provider-process': 3.972.61
+      '@aws-sdk/credential-provider-sso': 3.973.5
+      '@aws-sdk/credential-provider-web-identity': 3.972.67
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/credential-provider-imds': 4.4.14
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.5':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/token-providers': 3.1095.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.30':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.25':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/signature-v4': 5.6.10
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.35':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.42
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.42':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.10
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1095.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@azu/format-text@1.0.2': {}
 
   '@azu/style-format@1.0.1':
@@ -5266,6 +5545,39 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@smithy/core@3.30.0':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.14':
+    dependencies:
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.11':
+    dependencies:
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.11':
+    dependencies:
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.10':
+    dependencies:
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@textlint/ast-node-types@14.8.4': {}
 
   '@textlint/linter-formatter@14.8.4':
@@ -5952,6 +6264,8 @@ snapshots:
   boolbase@1.0.0: {}
 
   boundary@2.0.0: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.11:
     dependencies:


### PR DESCRIPTION
## Use case

We're rolling out Claude Context company-wide so that Claude Code understands **other teams'** code while working in any repo, not just the one currently checked out. The design: a single shared Milvus cluster, populated by CI (one writer per repo, on every push to the default branch), with every engineer's laptop running Claude Context **read-only** against that same cluster.

Two gaps blocked that design:

1. **Collection names were keyed off the absolute local checkout path** (`code_chunks_<md5(path)>`). CI checks out a repo at a different path than any given laptop, so CI and laptops silently ended up talking to *different* collections for the same repo — CI would build an index nobody's laptop could ever find.
2. **No first-party AWS Bedrock embedding provider.** Some orgs standardize on Bedrock for embeddings (existing AWS spend/commitments, keeping embedding traffic inside their own AWS account/VPC instead of sending code to a third-party API, IAM-based access control instead of managing separate provider API keys).

This PR fixes both, as two independent, additive features:

### 1. `CODE_CHUNKS_COLLECTION_KEY_SOURCE=git-remote`

Opt-in env var. When set, `Context.getCollectionName()` hashes the codebase's git `origin` remote URL instead of its absolute path. SSH and HTTPS forms of the same remote (`git@github.com:org/repo.git` vs `https://github.com/org/repo.git`) are normalized to the same identity string before hashing, so they converge on the same hash. Falls back to the existing path-based hash if the codebase isn't a git repo or has no `origin` remote — fully backward compatible, default behavior unchanged.

### 2. `BedrockEmbedding` provider

New `Embedding` implementation (`packages/core/src/embedding/bedrock-embedding.ts`) using `@aws-sdk/client-bedrock-runtime`. Supports:
- Titan Text Embeddings (`amazon.titan-embed-text-v2:0`, `amazon.titan-embed-text-v1`) — Bedrock's `InvokeModel` API for Titan only accepts one `inputText` per call (no batch field in the request schema), so `embedBatch()` loops one `InvokeModel` call per chunk for these models. This is an AWS API limitation, not a design choice.
- Cohere Embed (`cohere.embed-english-v3`, `cohere.embed-multilingual-v3`) — these *do* accept a `texts` array, so we batch up to 96 texts per call.

Credentials default to the AWS SDK's standard provider chain (env vars, shared config/profile, IAM/ECS/EC2 role, SSO) or explicit static keys via env vars. Wired through as a new `EMBEDDING_PROVIDER=Bedrock` option in:
- `packages/core` — the embedding class itself
- `packages/mcp` — `BEDROCK_REGION`, `BEDROCK_ACCESS_KEY_ID`/`SECRET_ACCESS_KEY`/`SESSION_TOKEN`, `BEDROCK_ENDPOINT`, `BEDROCK_EMBEDDING_DIMENSION`
- `packages/vscode-extension` — new provider entry in the settings UI (dynamically generated form, model dropdown, "Test Connection" support) — no VS Code-extension-specific code was needed beyond registering the provider, since the settings UI is entirely data-driven off the same provider definition used by `packages/core`.

Both features are independently opt-in (unset `CODE_CHUNKS_COLLECTION_KEY_SOURCE` → old path-based naming; `EMBEDDING_PROVIDER` unset → defaults to `OpenAI` as before), so there is no behavior change for existing users.

## What was tested

**Automated:**
- `packages/core`: 41/41 Jest tests pass, including 12 new tests — 4 for git-remote collection naming (`context.collection-name.test.ts`: default path-based hashing unaffected, SSH/HTTPS convergence, distinct repos stay distinct, non-git-repo fallback) and 8 for `BedrockEmbedding` (`bedrock-embedding.test.ts`: model metadata, Titan single-call request shape, Titan per-text looping, Cohere batching into one call, empty-batch short-circuit, missing-field error handling, static-credential wiring, default-credential-chain fallback), all with the AWS SDK client mocked.
- `packages/mcp`: 6/6 Node test-runner tests pass (unaffected by this change, re-run to confirm no regression).
- `tsc --noEmit` and full builds pass clean for `core`, `mcp`, and `vscode-extension` (including the production webpack bundle for the VS Code extension — confirmed `@aws-sdk/client-bedrock-runtime` bundles fine under its `node` target; the only build warnings are pre-existing and unrelated, from `@google/genai`'s optional `ws` native deps).

**Manual, end-to-end, against real infrastructure** (a live AWS account + a live Zilliz Cloud serverless cluster):
1. Confirmed Bedrock model access by invoking `amazon.titan-embed-text-v2:0` directly via the AWS CLI — real 1024-dim embedding returned.
2. Built two simulated "checkouts" of the same GitHub repo at different local paths, one with an `https://` origin and one with a `git@` origin. With `CODE_CHUNKS_COLLECTION_KEY_SOURCE=git-remote`, both resolved to the identical collection name.
3. Indexed real source files from the first ("CI") checkout into the live Zilliz cluster using live Bedrock Titan v2 embeddings.
4. Ran semantic search from the *second* ("laptop") checkout path, which was never itself indexed, and it found the content indexed from the first checkout's path — end-to-end proof that CI and a laptop checkout of the same repo now share one collection.
5. Installed the locally-built MCP server into a real Claude Code CLI (`claude mcp add ... -s user`), confirmed it connects, indexed this actual repo through it for real (100 files / 100 chunks against live Bedrock + Zilliz), and ran real `search_code` queries against the result.
6. Cleaned up all test collections/data from the live Zilliz cluster afterward.

## Files changed

- `packages/core/src/context.ts` — collection naming logic + git remote URL normalization
- `packages/core/src/context.collection-name.test.ts` (new)
- `packages/core/src/embedding/bedrock-embedding.ts` (new), `bedrock-embedding.test.ts` (new), `embedding/index.ts`, `package.json` (new `@aws-sdk/client-bedrock-runtime` dependency)
- `packages/mcp/src/config.ts`, `src/embedding.ts`, `README.md`
- `packages/vscode-extension/src/config/configManager.ts`, `package.json`, `src/webview/scripts/semanticSearch.js`, `README.md`
- `.env.example`, `docs/getting-started/environment-variables.md`, `CLAUDE.md`

## Out of scope

- `packages/chrome-extension` was not touched — it has its own separate provider/config surface and wasn't part of this request.
- No change to the Merkle sync snapshot path (`getSnapshotPath`) — intentionally left path-based; it's local cache only and doesn't affect collection identity.
